### PR TITLE
fix: inject HEARTBEAT.md content into heartbeat prompt

### DIFF
--- a/gateway/src/config/defaults.ts
+++ b/gateway/src/config/defaults.ts
@@ -36,7 +36,7 @@ export const DEFAULT_CONFIG: GsvConfig = {
     bindings: [],
     defaultHeartbeat: {
       every: "30m",
-      prompt: "Read HEARTBEAT.md if it exists in your workspace. Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
+      prompt: "Follow the HEARTBEAT.md instructions below. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
       target: "last",
       activeHours: { start: "08:00", end: "23:00" },
     },


### PR DESCRIPTION
The heartbeat session is persistent, so the agent only read HEARTBEAT.md on the first run via tool call. Subsequent runs saw the stale context from the session history and never re-read the file.

Now the gateway loads HEARTBEAT.md content and injects it directly into the heartbeat prompt message, ensuring the agent always sees the latest version regardless of session state.