### PR TITLE
fix: add debug logging to CLI deployment wizard

### DIFF
--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -2914,17 +2914,21 @@ pub async fn bootstrap_gateway_config(
 
     if let Some(auth_token) = config.auth_token.as_deref() {
         gateway_config_set(&conn, "auth.token", json!(auth_token)).await?;
-        println!("Configured gateway auth token.");
+        println!("✓ Configured gateway auth token.");
     }
 
     if let Some(provider) = config.llm_provider.as_deref() {
         gateway_config_set(&conn, "model.provider", json!(provider)).await?;
-        println!("Configured LLM provider: {}", provider);
+        println!("✓ Configured LLM provider: {}", provider);
+    } else {
+        println!("⊘ Skipping model.provider (not provided)");
     }
 
     if let Some(model) = config.llm_model.as_deref() {
         gateway_config_set(&conn, "model.id", json!(model)).await?;
-        println!("Configured LLM model: {}", model);
+        println!("✓ Configured LLM model: {}", model);
+    } else {
+        println!("⊘ Skipping model.id (not provided)");
     }
 
     if let Some(api_key) = config.llm_api_key.as_deref() {
@@ -2933,7 +2937,9 @@ pub async fn bootstrap_gateway_config(
             .as_deref()
             .ok_or("LLM provider is required when setting llm_api_key")?;
         gateway_config_set(&conn, &format!("apiKeys.{}", provider), json!(api_key)).await?;
-        println!("Configured API key for provider: {}", provider);
+        println!("✓ Configured API key for provider: {} ({}...)", provider, &api_key[..api_key.len().min(8)]);
+    } else {
+        println!("⊘ Skipping API key (not provided)");
     }
 
     if config.set_whatsapp_pairing {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1424,6 +1424,7 @@ async fn run_deploy(
                 && prompt_yes_no("Configure gateway auth + LLM settings now?", true)?
             {
                 resolved_provider = Some(prompt_llm_provider(Some("anthropic"))?);
+                println!("Selected provider: {:?}", resolved_provider);
             }
 
             if let Some(provider) = resolved_provider.as_deref() {
@@ -1434,6 +1435,7 @@ async fn run_deploy(
                         } else {
                             resolved_llm_model = Some(default_model.to_string());
                         }
+                        println!("Using model: {:?}", resolved_llm_model);
                     } else if interactive && wizard_mode {
                         resolved_llm_model = prompt_line("LLM model", None)?;
                     } else {
@@ -1457,6 +1459,9 @@ async fn run_deploy(
                 }
                 if resolved_llm_api_key.is_none() && interactive && wizard_mode {
                     resolved_llm_api_key = prompt_secret(&format!("{} API key", provider))?;
+                    if let Some(ref key) = resolved_llm_api_key {
+                        println!("Got API key: {}...", &key[..key.len().min(8)]);
+                    }
                 }
                 if resolved_llm_api_key.is_none() {
                     return Err(format!(
@@ -1566,6 +1571,13 @@ async fn run_deploy(
                         llm_api_key: resolved_llm_api_key.clone(),
                         set_whatsapp_pairing,
                     };
+
+                    println!("Gateway bootstrap config:");
+                    println!("  auth_token: {:?}", gateway_bootstrap.auth_token.as_ref().map(|t| format!("{}...", &t[..t.len().min(8)])));
+                    println!("  llm_provider: {:?}", gateway_bootstrap.llm_provider);
+                    println!("  llm_model: {:?}", gateway_bootstrap.llm_model);
+                    println!("  llm_api_key: {:?}", gateway_bootstrap.llm_api_key.as_ref().map(|k| format!("{}...", &k[..k.len().min(8)])));
+                    println!("  set_whatsapp_pairing: {:?}", gateway_bootstrap.set_whatsapp_pairing);
 
                     let should_bootstrap = gateway_bootstrap.auth_token.is_some()
                         || gateway_bootstrap.llm_provider.is_some()


### PR DESCRIPTION
## Issue

#30 - Wizard: OpenRouter provider setup doesn't save model or API key

When using the CLI deployment wizard with OpenRouter, only the provider is saved to gateway config. Model and API key are not persisted.

## Changes

Added extensive debug logging to the CLI deployment wizard:

**cli/src/main.rs:**
- Log selected provider after prompt_llm_provider
- Log model value after prompt_line or default assignment  
- Log API key value after prompt_secret (truncated for security)
- Log all gateway_bootstrap config values before calling bootstrap_gateway_config

**cli/src/deploy.rs:**
- Add ✓ symbols for successful config.set calls
- Add ⊘ symbols for skipped config.set calls (when value not provided)
- Shows exactly which values are being sent to the gateway

## What this will show

When reproducing the issue, you'll see:

1. Whether the provider, model, and API key prompts are being called
2. What values are captured from user input
3. Whether all three values are present in gateway_bootstrap
4. Which config.set calls are being made to the gateway

This will help identify where the values are being lost - during prompting, during transmission, or somewhere else.

## Note

This is a diagnostic PR to help identify the root cause. Once we have the debug output, we can implement the actual fix.