### PR TITLE
improve cli release/versioning with channel-aware upgrades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,21 +25,38 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.channel.outputs.channel }}
+      short_sha: ${{ steps.channel.outputs.short_sha }}
+      release_tag: ${{ steps.channel.outputs.release_tag }}
+      built_at: ${{ steps.channel.outputs.built_at }}
     steps:
       - name: Resolve channel
         id: channel
         run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "channel=${{ inputs.channel }}" >> "$GITHUB_OUTPUT"
+            CHANNEL="${{ inputs.channel }}"
           elif [ "${{ github.ref }}" = "refs/heads/stable" ]; then
-            echo "channel=stable" >> "$GITHUB_OUTPUT"
+            CHANNEL="stable"
           else
-            echo "channel=dev" >> "$GITHUB_OUTPUT"
+            CHANNEL="dev"
           fi
+
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=gsv-${CHANNEL}-${GITHUB_RUN_NUMBER}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "built_at=${BUILT_AT}" >> "$GITHUB_OUTPUT"
 
   # Build CLI binaries for multiple platforms
   build-cli:
     needs: [resolve]
+    env:
+      GSV_BUILD_CHANNEL: ${{ needs.resolve.outputs.channel }}
+      GSV_BUILD_SHA: ${{ github.sha }}
+      GSV_BUILD_RUN_NUMBER: ${{ github.run_number }}
+      GSV_BUILD_TAG: ${{ needs.resolve.outputs.release_tag }}
+      GSV_BUILD_TIMESTAMP: ${{ needs.resolve.outputs.built_at }}
     strategy:
       matrix:
         include:
@@ -77,11 +94,22 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --no-default-features --features rustls
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          GSV_BUILD_CHANNEL: ${{ needs.resolve.outputs.channel }}
+          GSV_BUILD_SHA: ${{ github.sha }}
+          GSV_BUILD_RUN_NUMBER: ${{ github.run_number }}
+          GSV_BUILD_TAG: ${{ needs.resolve.outputs.release_tag }}
+          GSV_BUILD_TIMESTAMP: ${{ needs.resolve.outputs.built_at }}
 
       - name: Build CLI (macOS - use native-tls for system certs)
         if: runner.os == 'macOS'
         working-directory: cli
         run: cargo build --release --target ${{ matrix.target }}
+        env:
+          GSV_BUILD_CHANNEL: ${{ needs.resolve.outputs.channel }}
+          GSV_BUILD_SHA: ${{ github.sha }}
+          GSV_BUILD_RUN_NUMBER: ${{ github.run_number }}
+          GSV_BUILD_TAG: ${{ needs.resolve.outputs.release_tag }}
+          GSV_BUILD_TIMESTAMP: ${{ needs.resolve.outputs.built_at }}
 
       - name: Rename binary
         run: |
@@ -222,6 +250,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHANNEL: ${{ needs.resolve.outputs.channel }}
+      RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+      SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
+      BUILT_AT: ${{ needs.resolve.outputs.built_at }}
     steps:
       - uses: actions/checkout@v4
 
@@ -258,9 +289,6 @@ jobs:
       - name: Build release body
         id: body
         run: |
-          SHORT_SHA="${GITHUB_SHA:0:7}"
-          TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
           if [ "$CHANNEL" = "stable" ]; then
             TITLE="GSV (stable)"
             INSTALL_CMD='curl -sSL https://install.gsv.space | bash'
@@ -272,12 +300,18 @@ jobs:
           cat > body.md <<BODY
           ## ${TITLE}
 
-          **Commit:** \`${SHORT_SHA}\` · **Built:** ${TIMESTAMP}
+          **Commit:** \`${SHORT_SHA}\` · **Built:** ${BUILT_AT} · **Release tag:** \`${RELEASE_TAG}\`
 
           ### Installation
 
           \`\`\`bash
           ${INSTALL_CMD}
+          \`\`\`
+
+          Pin a specific release tag:
+
+          \`\`\`bash
+          GSV_VERSION=${RELEASE_TAG} curl -sSL https://install.gsv.space | bash
           \`\`\`
 
           ### Cloudflare Bundles
@@ -296,7 +330,28 @@ jobs:
           - **Linux (ARM64)**: \`gsv-linux-arm64\`
           BODY
 
-      - name: Create or update release
+      - name: Create immutable release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: GSV (${{ env.CHANNEL }}) ${{ env.RELEASE_TAG }}
+          draft: false
+          prerelease: ${{ env.CHANNEL == 'dev' }}
+          make_latest: false
+          body_path: body.md
+          files: |
+            release/gsv-linux-x64
+            release/gsv-linux-arm64
+            release/gsv-darwin-x64
+            release/gsv-darwin-arm64
+            release/gsv-cloudflare-gateway.tar.gz
+            release/gsv-cloudflare-channel-whatsapp.tar.gz
+            release/gsv-cloudflare-channel-discord.tar.gz
+            release/cloudflare-checksums.txt
+            release/install.sh
+            release/checksums.txt
+
+      - name: Create or update channel release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.CHANNEL }}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@
 curl -sSL https://install.gsv.space | bash
 
 # https://dash.cloudflare.com/profile/api-tokens Use "Edit Cloudflare Workers" template
-# First-time guided deploy
-gsv deploy up --wizard
+# First-time guided setup (deploy + local node daemon)
+gsv setup
+
+# Cloud-only setup (skip local node daemon)
+gsv setup --skip-node
+
+# Pin exact CLI release tag (immutable build)
+GSV_VERSION=gsv-stable-1234-abcdef0 curl -sSL https://install.gsv.space | bash
 ```
 
 If you want to configure a different machine after deployment:
@@ -39,7 +45,8 @@ gsv client "Hello, what can you help me with?"
 Nodes give GSV tools to interact with your machines:
 
 ```bash
-# Recommended: install node as a background service
+# Already handled by `gsv setup` unless you used --skip-node.
+# Manual install/start as a background service:
 gsv node install --id macbook --workspace ~/projects
 
 # Check status/logs
@@ -154,6 +161,12 @@ agents/{agentId}/
 
 ```bash
 # Core
+gsv setup [--id ID --workspace DIR]            # First-time setup (deploy + node)
+gsv upgrade [--version TAG] [--all]            # Upgrade deployed components
+GSV_CHANNEL=dev gsv upgrade --all              # Upgrade from moving dev channel release
+gsv local-config set release.channel stable    # Persist default release track for setup/upgrade
+gsv uninstall [--delete-bucket]                # Teardown deployment (+ local node by default)
+gsv version                                    # Show build/version metadata
 gsv client [MESSAGE]                  # Chat (interactive if no message)
 gsv node install --id ID --workspace DIR      # Install/start node daemon
 gsv node start|stop|status                    # Manage node daemon

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,82 @@
+use std::env;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn sanitize_segment(raw: &str) -> String {
+    raw.trim()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+        .collect()
+}
+
+fn optional_env(key: &str) -> Option<String> {
+    env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=GSV_BUILD_CHANNEL");
+    println!("cargo:rerun-if-env-changed=GSV_BUILD_SHA");
+    println!("cargo:rerun-if-env-changed=GSV_BUILD_RUN_NUMBER");
+    println!("cargo:rerun-if-env-changed=GSV_BUILD_TAG");
+    println!("cargo:rerun-if-env-changed=GSV_BUILD_TIMESTAMP");
+
+    let pkg_version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
+    let channel = optional_env("GSV_BUILD_CHANNEL")
+        .map(|value| sanitize_segment(&value))
+        .filter(|value| !value.is_empty());
+    let run_number = optional_env("GSV_BUILD_RUN_NUMBER")
+        .map(|value| sanitize_segment(&value))
+        .filter(|value| !value.is_empty());
+    let release_tag = optional_env("GSV_BUILD_TAG")
+        .map(|value| sanitize_segment(&value))
+        .filter(|value| !value.is_empty());
+    let commit_sha = optional_env("GSV_BUILD_SHA")
+        .map(|value| sanitize_segment(&value))
+        .filter(|value| !value.is_empty())
+        .map(|value| value.chars().take(12).collect::<String>());
+    let timestamp = optional_env("GSV_BUILD_TIMESTAMP").unwrap_or_else(|| {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        now.to_string()
+    });
+
+    let mut metadata_segments = Vec::new();
+    if let Some(value) = channel.as_ref() {
+        metadata_segments.push(value.clone());
+    }
+    if let Some(value) = run_number.as_ref() {
+        metadata_segments.push(value.clone());
+    }
+    if let Some(value) = commit_sha.as_ref() {
+        metadata_segments.push(value.clone());
+    }
+
+    let build_version = if metadata_segments.is_empty() {
+        pkg_version.clone()
+    } else {
+        format!("{}+{}", pkg_version, metadata_segments.join("."))
+    };
+
+    println!("cargo:rustc-env=GSV_BUILD_VERSION={}", build_version);
+    println!(
+        "cargo:rustc-env=GSV_BUILD_CHANNEL={}",
+        channel.unwrap_or_default()
+    );
+    println!(
+        "cargo:rustc-env=GSV_BUILD_SHA={}",
+        commit_sha.unwrap_or_default()
+    );
+    println!(
+        "cargo:rustc-env=GSV_BUILD_RUN_NUMBER={}",
+        run_number.unwrap_or_default()
+    );
+    println!(
+        "cargo:rustc-env=GSV_BUILD_TAG={}",
+        release_tag.unwrap_or_default()
+    );
+    println!("cargo:rustc-env=GSV_BUILD_TIMESTAMP={}", timestamp);
+}

--- a/cli/src/build_info.rs
+++ b/cli/src/build_info.rs
@@ -1,0 +1,15 @@
+pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const BUILD_VERSION: &str = env!("GSV_BUILD_VERSION");
+pub const BUILD_CHANNEL: &str = env!("GSV_BUILD_CHANNEL");
+pub const BUILD_SHA: &str = env!("GSV_BUILD_SHA");
+pub const BUILD_RUN_NUMBER: &str = env!("GSV_BUILD_RUN_NUMBER");
+pub const BUILD_TAG: &str = env!("GSV_BUILD_TAG");
+pub const BUILD_TIMESTAMP: &str = env!("GSV_BUILD_TIMESTAMP");
+
+pub fn is_ci_build() -> bool {
+    !BUILD_CHANNEL.is_empty() || !BUILD_SHA.is_empty() || !BUILD_RUN_NUMBER.is_empty()
+}
+
+pub fn version_display() -> &'static str {
+    BUILD_VERSION
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -25,6 +25,10 @@ pub struct CliConfig {
     #[serde(default)]
     pub cloudflare: CloudflareConfig,
 
+    /// Release defaults (install/upgrade channel preference)
+    #[serde(default)]
+    pub release: ReleaseConfig,
+
     /// R2 storage settings (for mount command)
     #[serde(default)]
     pub r2: R2Config,
@@ -83,6 +87,12 @@ pub struct CloudflareConfig {
 
     /// Cloudflare API token
     pub api_token: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ReleaseConfig {
+    /// Preferred release channel for setup/upgrade defaults (`stable` or `dev`)
+    pub channel: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -180,6 +190,16 @@ impl CliConfig {
         self.gateway.token.clone()
     }
 
+    /// Get normalized release channel from config (`stable` or `dev`)
+    pub fn release_channel(&self) -> Option<String> {
+        self.release
+            .channel
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .filter(|value| matches!(value.as_str(), "stable" | "dev"))
+    }
+
     /// Get default session key
     pub fn default_session(&self) -> String {
         let raw = self
@@ -247,6 +267,10 @@ token = "your-token-here"
 # Used by 'gsv deploy' commands
 # account_id = "your-cloudflare-account-id"
 # api_token = "your-cloudflare-api-token"
+
+[release]
+# Preferred release channel for installer/setup/upgrade defaults (`stable` or `dev`)
+# channel = "stable"
 
 [r2]
 # Cloudflare R2 credentials (for 'gsv mount' command)

--- a/cli/src/connection.rs
+++ b/cli/src/connection.rs
@@ -1,3 +1,4 @@
+use crate::build_info;
 use crate::protocol::{
     AuthParams, ClientInfo, ConnectParams, ErrorShape, Frame, NodeRuntimeInfo, RequestFrame,
     ResponseFrame, ToolDefinition,
@@ -184,7 +185,7 @@ impl Connection {
             max_protocol: 1,
             client: ClientInfo {
                 id,
-                version: env!("CARGO_PKG_VERSION").to_string(),
+                version: build_info::BUILD_VERSION.to_string(),
                 platform: std::env::consts::OS.to_string(),
                 mode: mode.to_string(),
             },

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod build_info;
 pub mod config;
 pub mod connection;
 pub mod deploy;


### PR DESCRIPTION
## Summary
- add compile-time CLI build metadata (`channel`, `sha`, `run`, `release tag`, timestamp) via `cli/build.rs`
- use build metadata for `gsv --version`, add `gsv version`, and send build version in websocket handshake
- add `release.channel` to local config and use it as the default track for `setup`/`upgrade` when `--version latest`
- keep upgrades fresh on mutable refs (`dev`, `stable`, `latest`)
- update installer with `GSV_VERSION` for immutable pinned installs and persist release channel on channel installs
- update release workflow to publish immutable per-run tags plus moving channel releases
- refresh README examples for setup/upgrade/version flows

## Validation
- cargo fmt
- cargo build
- cargo test -q
- bash -n install.sh
- manual checks of `gsv --version` and `gsv version` with CI metadata env vars
