### PR TITLE
feat: add SearchTools and CallTool for executor-style tool discovery

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -30,6 +30,7 @@
 	"dependencies": {
 		"@clack/prompts": "^1.0.0",
 		"@mariozechner/pi-ai": "^0.54.0",
+		"@modelcontextprotocol/sdk": "^1.29.0",
 		"picocolors": "^1.1.1",
 		"ws": "^8.19.0"
 	}

--- a/gateway/src/agents/prompt.ts
+++ b/gateway/src/agents/prompt.ts
@@ -229,6 +229,14 @@ function buildToolingSection(tools: ToolDefinition[] | undefined): string {
   lines.push(
     "`gsv__*` tools are native Gateway tools. `<nodeId>__<toolName>` tools target a specific connected node.",
   );
+
+  const hasSearchTools = tools.some((t) => t.name === "gsv__SearchTools");
+  if (hasSearchTools) {
+    lines.push(
+      "Remote tool servers are connected with additional capabilities. If you can't do something with the tools below, search for more.",
+    );
+  }
+
   lines.push("Available tools:");
   for (const tool of tools) {
     const description = tool.description?.trim();

--- a/gateway/src/agents/tools/constants.ts
+++ b/gateway/src/agents/tools/constants.ts
@@ -11,4 +11,6 @@ export const NATIVE_TOOLS = {
   MESSAGE: `${NATIVE_TOOL_PREFIX}Message`,
   SESSIONS_LIST: `${NATIVE_TOOL_PREFIX}SessionsList`,
   SESSION_SEND: `${NATIVE_TOOL_PREFIX}SessionSend`,
+  SEARCH_TOOLS: `${NATIVE_TOOL_PREFIX}SearchTools`,
+  CALL_TOOL: `${NATIVE_TOOL_PREFIX}CallTool`,
 } as const;

--- a/gateway/src/agents/tools/discover.ts
+++ b/gateway/src/agents/tools/discover.ts
@@ -1,0 +1,105 @@
+/**
+ * Tool discovery and execution meta-tools.
+ *
+ * These provide an executor-style interface where the agent discovers
+ * tools on demand instead of seeing all remote tools in its context.
+ * MCP tools are kept out of the default tool list — the agent finds
+ * them via SearchTools and invokes them via CallTool.
+ *
+ * Native tools remain in the tool list for direct access, but CallTool
+ * can also invoke them for a consistent interface.
+ */
+
+import { NATIVE_TOOLS } from "./constants";
+import type { ToolDefinition } from "../../protocol/tools";
+import type { NativeToolHandlerMap } from "./types";
+
+export const getDiscoverToolDefinitions = (): ToolDefinition[] => [
+  {
+    name: NATIVE_TOOLS.SEARCH_TOOLS,
+    description:
+      "Search for capabilities you don't have built in. Remote tool servers are " +
+      "connected to this gateway — they can look up documentation, search memory, " +
+      "query APIs, and more. ALWAYS try this before saying you can't do something. " +
+      "Returns discovered tool names, descriptions, and schemas for use with CallTool.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "What you need — describe the capability, not the tool name. " +
+            'Examples: "documentation for React", "search my memory", "look up API docs".',
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: NATIVE_TOOLS.CALL_TOOL,
+    description:
+      "Execute a discovered tool by name. After finding tools with SearchTools, " +
+      "call them here with the exact name and arguments from the search results. " +
+      "Works with any tool — native, node, or remote.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tool: {
+          type: "string",
+          description:
+            'The full tool name as returned by SearchTools (e.g., "aeon__recall", "gsv__ReadFile").',
+        },
+        args: {
+          type: "object",
+          description: "Arguments to pass to the tool, matching its input schema.",
+        },
+      },
+      required: ["tool"],
+    },
+  },
+];
+
+export const discoverNativeToolHandlers: NativeToolHandlerMap = {
+  [NATIVE_TOOLS.SEARCH_TOOLS]: async (context, args) => {
+    if (!context.gateway) {
+      return {
+        ok: false,
+        error: "SearchTools unavailable: gateway context missing",
+      };
+    }
+
+    const query = typeof args.query === "string" ? args.query.trim() : "";
+    if (!query) {
+      return { ok: false, error: "query is required" };
+    }
+
+    const results = await context.gateway.searchTools(query);
+    return { ok: true, result: results };
+  },
+
+  [NATIVE_TOOLS.CALL_TOOL]: async (context, args) => {
+    if (!context.gateway) {
+      return {
+        ok: false,
+        error: "CallTool unavailable: gateway context missing",
+      };
+    }
+
+    const tool = typeof args.tool === "string" ? args.tool.trim() : "";
+    if (!tool) {
+      return { ok: false, error: "tool name is required" };
+    }
+
+    const toolArgs =
+      args.args && typeof args.args === "object" && !Array.isArray(args.args)
+        ? (args.args as Record<string, unknown>)
+        : {};
+
+    const result = await context.gateway.callToolDirect(
+      tool,
+      toolArgs,
+      context.agentId,
+    );
+    return result;
+  },
+};

--- a/gateway/src/agents/tools/gateway.ts
+++ b/gateway/src/agents/tools/gateway.ts
@@ -51,7 +51,7 @@ export const gatewayNativeToolHandlers: NativeToolHandlerMap = {
 
     const path = typeof args.path === "string" ? args.path.trim() : undefined;
     if (path) {
-      const value = await context.gateway.getConfigPath(path);
+      const value = await context.gateway.getSafeConfigPath(path);
       return {
         ok: true,
         result: { path, value },

--- a/gateway/src/agents/tools/index.ts
+++ b/gateway/src/agents/tools/index.ts
@@ -18,6 +18,10 @@ import {
   workspaceNativeToolHandlers,
 } from "./workspace";
 import { getTransferToolDefinitions } from "./transfer";
+import {
+  discoverNativeToolHandlers,
+  getDiscoverToolDefinitions,
+} from "./discover";
 import type {
   NativeToolExecutionContext,
   NativeToolHandlerMap,
@@ -32,6 +36,7 @@ export * from "./gateway";
 export * from "./message";
 export * from "./sessions";
 export * from "./transfer";
+export * from "./discover";
 
 const nativeToolHandlers: NativeToolHandlerMap = {
   ...workspaceNativeToolHandlers,
@@ -39,6 +44,7 @@ const nativeToolHandlers: NativeToolHandlerMap = {
   ...cronNativeToolHandlers,
   ...messageNativeToolHandlers,
   ...sessionsNativeToolHandlers,
+  ...discoverNativeToolHandlers,
 };
 
 export function isNativeTool(toolName: string): boolean {
@@ -53,6 +59,7 @@ export function getNativeToolDefinitions(): ToolDefinition[] {
     ...getMessageToolDefinitions(),
     ...getSessionsToolDefinitions(),
     ...getTransferToolDefinitions(),
+    ...getDiscoverToolDefinitions(),
   ];
 }
 

--- a/gateway/src/config/defaults.ts
+++ b/gateway/src/config/defaults.ts
@@ -56,5 +56,8 @@ export const DEFAULT_CONFIG: GsvConfig = {
     maxRunsPerJobHistory: 200,
     maxConcurrentRuns: 4,
   },
+  mcp: {
+    servers: {},
+  },
   userTimezone: "UTC",
 };

--- a/gateway/src/config/index.ts
+++ b/gateway/src/config/index.ts
@@ -185,6 +185,22 @@ export interface CronConfig {
   maxConcurrentRuns: number;
 }
 
+export interface McpServerConfig {
+  // MCP server URL. Must be HTTPS except for localhost/127.0.0.1.
+  url: string;
+  // Bearer token for authentication.
+  token?: string;
+  // Tool list cache TTL in milliseconds (default: 300000 / 5 min).
+  cacheTtlMs?: number;
+  // Request timeout in milliseconds (default: 30000).
+  timeoutMs?: number;
+}
+
+export interface McpConfig {
+  // Map of server ID → server configuration.
+  servers: Record<string, McpServerConfig>;
+}
+
 export interface GsvConfig {
   // Model settings 
   model: {
@@ -237,6 +253,9 @@ export interface GsvConfig {
   // Cron job scheduler configuration
   cron: CronConfig;
 
+  // Remote MCP server connections
+  mcp: McpConfig;
+
   // User timezone (IANA string, e.g. "America/Chicago"). Defaults to "UTC".
   // Used in message envelopes, cron scheduling context, and system prompt.
   userTimezone: string;
@@ -268,6 +287,9 @@ export type GsvConfigInput = {
   };
   compaction?: Partial<CompactionConfig>;
   cron?: Partial<CronConfig>;
+  mcp?: {
+    servers?: Record<string, Partial<McpServerConfig>>;
+  };
   userTimezone?: string;
 };
 

--- a/gateway/src/gateway/async-exec/state.ts
+++ b/gateway/src/gateway/async-exec/state.ts
@@ -732,7 +732,7 @@ export class GatewayAsyncExecStateService implements GatewayAsyncExecStateBridge
   }
 
   listTools(): ToolDefinition[] {
-    return this.#gateway.nodeService.listTools(this.#gateway.nodes.keys());
+    return this.#gateway.getAllTools();
   }
 
   getNodeInventory(): RuntimeNodeInventory {

--- a/gateway/src/gateway/channel-inbound.ts
+++ b/gateway/src/gateway/channel-inbound.ts
@@ -274,7 +274,7 @@ export async function handleChannelInboundRpc(
     const result = await sessionStub.chatSend(
       envelopedMessage,
       runId,
-      JSON.parse(JSON.stringify(gw.nodeService.listTools(gw.nodes.keys()))),
+      JSON.parse(JSON.stringify(gw.getAllTools())),
       JSON.parse(
         JSON.stringify(gw.nodeService.getRuntimeNodeInventory(gw.nodes.keys())),
       ),

--- a/gateway/src/gateway/cron-execution.ts
+++ b/gateway/src/gateway/cron-execution.ts
@@ -84,7 +84,7 @@ export async function executeCronJob(
     await session.chatSend(
       cronMessage,
       runId,
-      JSON.parse(JSON.stringify(gw.nodeService.listTools(gw.nodes.keys()))),
+      JSON.parse(JSON.stringify(gw.getAllTools())),
       JSON.parse(
         JSON.stringify(gw.nodeService.getRuntimeNodeInventory(gw.nodes.keys())),
       ),

--- a/gateway/src/gateway/do.ts
+++ b/gateway/src/gateway/do.ts
@@ -11,6 +11,8 @@ import { isWebSocketRequest, validateFrame } from "../shared/utils";
 import { DEFAULT_CONFIG } from "../config/defaults";
 import { GsvConfig, GsvConfigInput, mergeConfig, PendingPair } from "../config";
 import { McpService, isValidMcpServerId, type ResolvedMcpTool } from "./mcp-service";
+import { getNativeToolDefinitions, isNativeTool, executeNativeTool } from "../agents/tools";
+import { tokenize, scoreToolMatch } from "./tool-search";
 import { getDefaultAgentId } from "../config/parsing";
 import {
   HeartbeatState,
@@ -90,18 +92,6 @@ type GatewayAlarmParticipant = {
   nextDueMs: number | undefined;
   run: (params: { now: number }) => Promise<void> | void;
 };
-
-function traverseDotPath(root: unknown, path: string): unknown {
-  let current: unknown = root;
-  for (const part of path.split(".")) {
-    if (current && typeof current === "object" && part in current) {
-      current = (current as Record<string, unknown>)[part];
-    } else {
-      return undefined;
-    }
-  }
-  return current;
-}
 
 export class Gateway extends DurableObject<Env> {
   clients: Map<string, WebSocket> = new Map();
@@ -390,6 +380,8 @@ export class Gateway extends DurableObject<Env> {
   }
 
   private resolveMcp(toolName: string): ResolvedMcpTool | null {
+    const mcpStore = this.configStore["mcp"] as { servers?: Record<string, unknown> } | undefined;
+    if (!mcpStore?.servers || Object.keys(mcpStore.servers).length === 0) return null;
     return this.mcpService.resolve(toolName, this.getFullConfig().mcp);
   }
 
@@ -446,6 +438,97 @@ export class Gateway extends DurableObject<Env> {
           console.error("[Gateway] MCP tool invoke error:", err);
         }),
     );
+  }
+
+  /**
+   * Search for tools across all sources by keyword.
+   * Matches against tool names, descriptions, and schema property names.
+   */
+  searchTools(
+    query: string,
+    limit: number = 10,
+  ): { tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown>; source: string }> } {
+    const config = this.getFullConfig();
+
+    // Collect tools from sources callable via CallTool (native + MCP).
+    // Node tools are excluded — they're in the LLM's tool list for direct use
+    // and can't be executed via CallTool (requires WebSocket dispatch).
+    const allTools: Array<{ tool: ToolDefinition; source: string }> = [];
+    for (const tool of getNativeToolDefinitions()) allTools.push({ tool, source: "native" });
+    for (const tool of this.mcpService.listToolsCached(config.mcp)) allTools.push({ tool, source: "mcp" });
+
+    // Weighted token matching (executor-style scoring)
+    const queryTokens = tokenize(query);
+    if (queryTokens.length === 0) return { tools: [] };
+
+    const scored = allTools
+      .map(({ tool, source }) => ({
+        tool,
+        source,
+        score: scoreToolMatch(queryTokens, tool),
+      }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score);
+
+    return {
+      tools: scored.slice(0, limit).map(({ tool, source }) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        source,
+      })),
+    };
+  }
+
+  /**
+   * Execute any tool directly and return the result synchronously.
+   * Used by gsv__CallTool — a single interface for invoking any tool.
+   *
+   * Approval model: gsv__CallTool itself goes through the session's normal
+   * tool approval flow before reaching this method. We don't re-evaluate
+   * approval on the inner tool because GSV's security model prioritizes
+   * capability and simplicity (defaultDecision: "allow", no rules by
+   * default). The user's approval of CallTool is the consent point.
+   *
+   * If the approval model evolves to require per-tool granularity through
+   * CallTool, add a nested evaluateToolApproval check here with the inner
+   * tool name and args, and plumb ask/deny back through the session.
+   */
+  async callToolDirect(
+    toolName: string,
+    args: Record<string, unknown>,
+    agentId: string,
+  ): Promise<{ ok: boolean; result?: unknown; error?: string }> {
+    if (toolName === "gsv__CallTool" || toolName === "gsv__SearchTools") {
+      return { ok: false, error: `"${toolName}" cannot be called through CallTool` };
+    }
+
+    // MCP tools
+    const resolved = this.resolveMcp(toolName);
+    if (resolved) {
+      return this.mcpService.callTool(
+        resolved.serverConfig,
+        resolved.toolName,
+        args,
+        resolved.serverId,
+      );
+    }
+
+    // Native tools — get a stub to self for the gateway context
+    if (isNativeTool(toolName)) {
+      const gateway = this.env.GATEWAY.getByName("singleton");
+      return executeNativeTool(
+        { bucket: this.env.STORAGE, agentId, gateway },
+        toolName,
+        args,
+      );
+    }
+
+    // Node tools require WebSocket dispatch — not yet supported via CallTool
+    return {
+      ok: false,
+      error: `Tool "${toolName}" is a node tool. Node tools require a connected device and are not yet callable via CallTool.`,
+    };
   }
 
   /** Validate MCP server IDs in a config write at any depth. */
@@ -694,19 +777,17 @@ export class Gateway extends DurableObject<Env> {
       `[Gateway]   toolRegistry keys: [${this.nodeService.listToolRegistryNodeIds().join(", ")}]`,
     );
 
-    // Unified tool list: native + node + MCP
-    const config = this.getFullConfig();
-    const mcpTools = this.mcpService.listToolsCached(config.mcp);
-    const tools = [
-      ...this.nodeService.listTools(this.nodes.keys()),
-      ...mcpTools,
-    ];
+    // Native + node tools go in the LLM's tool list. MCP tools are
+    // deliberately excluded — the agent discovers them via SearchTools
+    // and invokes them via CallTool. This keeps context lean regardless
+    // of how many MCP servers are configured.
+    const tools = this.nodeService.listTools(this.nodes.keys());
     const nodeTools = tools.filter(
       (tool) => tool.name.includes("__") && !tool.name.startsWith("gsv__"),
     );
     const nativeTools = tools.length - nodeTools.length;
     console.log(
-      `[Gateway]   returning ${tools.length} tools (${nativeTools} native + ${nodeTools.length} remote [${mcpTools.length} mcp]): [${tools.map((t) => t.name).join(", ")}]`,
+      `[Gateway]   returning ${tools.length} tools (${nativeTools} native + ${nodeTools.length} node): [${tools.map((t) => t.name).join(", ")}]`,
     );
     return tools;
   }
@@ -877,7 +958,18 @@ export class Gateway extends DurableObject<Env> {
   }
 
   getConfigPath(path: string): unknown {
-    return traverseDotPath(this.getFullConfig(), path);
+    const parts = path.split(".");
+    let current: unknown = this.getFullConfig();
+
+    for (const part of parts) {
+      if (current && typeof current === "object" && part in current) {
+        current = (current as Record<string, unknown>)[part];
+      } else {
+        return undefined;
+      }
+    }
+
+    return current;
   }
 
   setConfigPath(path: string, value: unknown): void {
@@ -966,7 +1058,17 @@ export class Gateway extends DurableObject<Env> {
   }
 
   getSafeConfigPath(path: string): unknown {
-    return traverseDotPath(this.getSafeConfig(), path);
+    const safe = this.getSafeConfig();
+    const parts = path.split(".");
+    let current: unknown = safe;
+    for (const part of parts) {
+      if (current && typeof current === "object" && part in current) {
+        current = (current as Record<string, unknown>)[part];
+      } else {
+        return undefined;
+      }
+    }
+    return current;
   }
 
   getConfig(): GsvConfig {

--- a/gateway/src/gateway/do.ts
+++ b/gateway/src/gateway/do.ts
@@ -10,6 +10,7 @@ import type {
 import { isWebSocketRequest, validateFrame } from "../shared/utils";
 import { DEFAULT_CONFIG } from "../config/defaults";
 import { GsvConfig, GsvConfigInput, mergeConfig, PendingPair } from "../config";
+import { McpService, isValidMcpServerId, type ResolvedMcpTool } from "./mcp-service";
 import { getDefaultAgentId } from "../config/parsing";
 import {
   HeartbeatState,
@@ -90,6 +91,18 @@ type GatewayAlarmParticipant = {
   run: (params: { now: number }) => Promise<void> | void;
 };
 
+function traverseDotPath(root: unknown, path: string): unknown {
+  let current: unknown = root;
+  for (const part of path.split(".")) {
+    if (current && typeof current === "object" && part in current) {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
 export class Gateway extends DurableObject<Env> {
   clients: Map<string, WebSocket> = new Map();
   nodes: Map<string, WebSocket> = new Map();
@@ -104,6 +117,7 @@ export class Gateway extends DurableObject<Env> {
   readonly nodeService = new GatewayNodeService(
     this.ctx.storage.kv,
   );
+  readonly mcpService = new McpService();
 
   readonly configStore = PersistedObject<Record<string, unknown>>(
     this.ctx.storage.kv,
@@ -243,6 +257,9 @@ export class Gateway extends DurableObject<Env> {
         `[Gateway] Preserving ${detachedRuntimeNodeIds.length} detached runtime entries for known hosts`,
       );
     }
+
+    // Like nodes, MCP tools only appear in the catalog after the cache warms.
+    this.warmMcpCacheIfConfigured();
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -372,10 +389,121 @@ export class Gateway extends DurableObject<Env> {
     }
   }
 
+  private resolveMcp(toolName: string): ResolvedMcpTool | null {
+    return this.mcpService.resolve(toolName, this.getFullConfig().mcp);
+  }
+
   async toolRequest(
     params: ToolRequestParams,
   ): Promise<{ ok: boolean; error?: string }> {
+    // MCP first — always-available remote servers take priority over nodes.
+    const resolved = this.resolveMcp(params.tool);
+    if (resolved) {
+      this.ctx.waitUntil(this.executeMcpToolCall(params, resolved));
+      return { ok: true };
+    }
+
+    // Fall through to node routing
     return this.nodeService.requestToolForSession(params, this.nodes);
+  }
+
+  private async executeMcpToolCall(
+    params: ToolRequestParams,
+    resolved: ResolvedMcpTool,
+  ): Promise<void> {
+    const sessionStub = this.env.SESSION.getByName(params.sessionKey);
+    const mcpResult = await this.mcpService.callTool(
+      resolved.serverConfig,
+      resolved.toolName,
+      params.args,
+      resolved.serverId,
+    );
+    await sessionStub.toolResult({
+      callId: params.callId,
+      result: mcpResult.ok ? mcpResult.result : undefined,
+      error: mcpResult.ok ? undefined : mcpResult.error,
+    });
+  }
+
+  /** @internal Called by handleToolInvoke RPC handler — needs ctx.waitUntil. */
+  executeMcpToolInvoke(
+    ws: WebSocket,
+    frameId: string,
+    resolved: ResolvedMcpTool,
+    args: Record<string, unknown>,
+  ): void {
+    this.ctx.waitUntil(
+      this.mcpService
+        .callTool(resolved.serverConfig, resolved.toolName, args, resolved.serverId)
+        .then((mcpResult) => {
+          if (!mcpResult.ok) {
+            this.sendError(ws, frameId, 500, mcpResult.error || "MCP tool failed");
+          } else {
+            this.sendOk(ws, frameId, { result: mcpResult.result });
+          }
+        })
+        .catch((err) => {
+          console.error("[Gateway] MCP tool invoke error:", err);
+        }),
+    );
+  }
+
+  /** Validate MCP server IDs in a config write at any depth. */
+  private validateMcpConfig(parts: string[], value: unknown): void {
+    // mcp.servers.{serverId}[.*] — validate the specific server ID
+    if (parts.length >= 3 && parts[0] === "mcp" && parts[1] === "servers") {
+      const validation = isValidMcpServerId(parts[2]);
+      if (!validation.valid) {
+        throw new Error(`Invalid MCP server ID "${parts[2]}": ${validation.reason}`);
+      }
+      return;
+    }
+
+    // mcp.servers = { id: {...}, ... } — validate all server IDs in the object
+    if (parts.length === 2 && parts[0] === "mcp" && parts[1] === "servers" && value && typeof value === "object") {
+      this.validateMcpServerIds(value as Record<string, unknown>);
+      return;
+    }
+
+    // mcp = { servers: { id: {...}, ... } } — validate server IDs in nested object
+    if (parts.length === 1 && parts[0] === "mcp" && value && typeof value === "object") {
+      const servers = (value as Record<string, unknown>).servers;
+      if (servers && typeof servers === "object") {
+        this.validateMcpServerIds(servers as Record<string, unknown>);
+      }
+    }
+  }
+
+  private validateMcpServerIds(servers: Record<string, unknown>): void {
+    for (const serverId of Object.keys(servers)) {
+      const validation = isValidMcpServerId(serverId);
+      if (!validation.valid) {
+        throw new Error(`Invalid MCP server ID "${serverId}": ${validation.reason}`);
+      }
+    }
+  }
+
+  /** Invalidate MCP cache and warm after config change. */
+  private onMcpConfigChanged(parts: string[]): void {
+    if (parts.length >= 3 && parts[0] === "mcp" && parts[1] === "servers") {
+      if (this.nodes.has(parts[2])) {
+        console.warn(
+          `[Gateway] MCP server "${parts[2]}" collides with connected node ID. MCP tools will take priority.`,
+        );
+      }
+    }
+    this.mcpService.invalidateCache();
+    this.warmMcpCacheIfConfigured();
+  }
+
+  private warmMcpCacheIfConfigured(): void {
+    const config = this.getFullConfig();
+    if (Object.keys(config.mcp.servers).length === 0) return;
+    this.ctx.waitUntil(
+      this.mcpService.refreshCache(config.mcp).then(() =>
+        this.scheduleGatewayAlarm(),
+      ),
+    );
   }
 
   sendOk(ws: WebSocket, id: string, payload?: unknown) {
@@ -566,13 +694,19 @@ export class Gateway extends DurableObject<Env> {
       `[Gateway]   toolRegistry keys: [${this.nodeService.listToolRegistryNodeIds().join(", ")}]`,
     );
 
-    const tools = this.nodeService.listTools(this.nodes.keys());
+    // Unified tool list: native + node + MCP
+    const config = this.getFullConfig();
+    const mcpTools = this.mcpService.listToolsCached(config.mcp);
+    const tools = [
+      ...this.nodeService.listTools(this.nodes.keys()),
+      ...mcpTools,
+    ];
     const nodeTools = tools.filter(
       (tool) => tool.name.includes("__") && !tool.name.startsWith("gsv__"),
     );
     const nativeTools = tools.length - nodeTools.length;
     console.log(
-      `[Gateway]   returning ${tools.length} tools (${nativeTools} native + ${nodeTools.length} node): [${tools.map((t) => t.name).join(", ")}]`,
+      `[Gateway]   returning ${tools.length} tools (${nativeTools} native + ${nodeTools.length} remote [${mcpTools.length} mcp]): [${tools.map((t) => t.name).join(", ")}]`,
     );
     return tools;
   }
@@ -743,25 +877,21 @@ export class Gateway extends DurableObject<Env> {
   }
 
   getConfigPath(path: string): unknown {
-    const parts = path.split(".");
-    let current: unknown = this.getFullConfig();
-
-    for (const part of parts) {
-      if (current && typeof current === "object" && part in current) {
-        current = (current as Record<string, unknown>)[part];
-      } else {
-        return undefined;
-      }
-    }
-
-    return current;
+    return traverseDotPath(this.getFullConfig(), path);
   }
 
   setConfigPath(path: string, value: unknown): void {
     const parts = path.split(".");
 
+    // Validate MCP server IDs before writing — handles both nested and top-level
+    this.validateMcpConfig(parts, value);
+
     if (parts.length === 1) {
       this.configStore[path] = value;
+      // Run post-write hooks for top-level MCP config replacement
+      if (path === "mcp") {
+        this.onMcpConfigChanged(parts);
+      }
       return;
     }
 
@@ -796,6 +926,10 @@ export class Gateway extends DurableObject<Env> {
 
     // Clean up any flat key that might exist
     delete this.configStore[path];
+
+    if (path === "mcp.servers" || path.startsWith("mcp.servers.")) {
+      this.onMcpConfigChanged(parts);
+    }
   }
 
   getFullConfig(): GsvConfig {
@@ -817,11 +951,22 @@ export class Gateway extends DurableObject<Env> {
       ...full.auth,
       token: full.auth.token ? "***" : undefined,
     };
+    const mcpServers = Object.fromEntries(
+      Object.entries(full.mcp.servers).map(([id, server]) => [
+        id,
+        { ...server, token: server.token ? "***" : undefined },
+      ]),
+    );
     return {
       ...full,
       apiKeys,
       auth,
+      mcp: { ...full.mcp, servers: mcpServers },
     };
+  }
+
+  getSafeConfigPath(path: string): unknown {
+    return traverseDotPath(this.getSafeConfig(), path);
   }
 
   getConfig(): GsvConfig {
@@ -967,6 +1112,18 @@ export class Gateway extends DurableObject<Env> {
           await this.asyncExecStateService.deliverPendingAsyncExecDeliveries(
             params.now,
           );
+        },
+      },
+      {
+        name: "mcpCacheRefresh",
+        nextDueMs: this.mcpService.nextCacheExpiryMs(
+          this.getFullConfig().mcp,
+        ),
+        run: async () => {
+          const config = this.getFullConfig();
+          if (Object.keys(config.mcp.servers).length > 0) {
+            await this.mcpService.refreshCache(config.mcp);
+          }
         },
       },
     ];

--- a/gateway/src/gateway/heartbeat.ts
+++ b/gateway/src/gateway/heartbeat.ts
@@ -371,7 +371,7 @@ export async function runHeartbeat(
     };
   }
   const prompt = config.prompt;
-  const tools = JSON.parse(JSON.stringify(gw.nodeService.listTools(gw.nodes.keys())));
+  const tools = JSON.parse(JSON.stringify(gw.getAllTools()));
   const runtimeNodes = JSON.parse(
     JSON.stringify(gw.nodeService.getRuntimeNodeInventory(gw.nodes.keys())),
   );

--- a/gateway/src/gateway/mcp-service.integration.test.ts
+++ b/gateway/src/gateway/mcp-service.integration.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration test: McpService against a live MCP server (context7).
+ * Skipped by default. Run with:
+ *   cd gateway && MCP_INTEGRATION=1 npx vitest run src/gateway/mcp-service.integration.test.ts
+ */
+
+import { describe, expect, it } from "vitest";
+import { McpService } from "./mcp-service";
+import type { McpConfig } from "../config";
+
+const CONTEXT7_URL = "https://mcp.context7.com/mcp";
+const RUN_INTEGRATION = process.env.MCP_INTEGRATION === "1";
+
+describe.skipIf(!RUN_INTEGRATION)("McpService integration (live context7)", () => {
+  const service = new McpService();
+  const config: McpConfig = {
+    servers: {
+      context7: { url: CONTEXT7_URL, timeoutMs: 30_000 },
+    },
+  };
+
+  it("discovers tools from context7 via refreshCache", async () => {
+    await service.refreshCache(config);
+
+    const tools = service.listToolsCached(config);
+    console.log(`Discovered ${tools.length} tools from context7:`);
+    for (const tool of tools) {
+      console.log(`  ${tool.name}: ${tool.description?.slice(0, 80)}`);
+    }
+
+    expect(tools.length).toBeGreaterThan(0);
+    // context7 tools should be namespaced as context7__{toolName}
+    expect(tools[0].name).toMatch(/^context7__/);
+    expect(tools[0].inputSchema).toBeDefined();
+  }, 30_000);
+
+  it("resolves a discovered tool", async () => {
+    // Cache should still be warm from previous test
+    const tools = service.listToolsCached(config);
+    if (tools.length === 0) {
+      await service.refreshCache(config);
+    }
+
+    const firstTool = service.listToolsCached(config)[0];
+    const resolved = service.resolve(firstTool.name, config);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.serverId).toBe("context7");
+    expect(resolved!.serverConfig.url).toBe(CONTEXT7_URL);
+  }, 10_000);
+
+  it("calls a tool on context7", async () => {
+    // Ensure cache is warm
+    if (service.listToolsCached(config).length === 0) {
+      await service.refreshCache(config);
+    }
+
+    const tools = service.listToolsCached(config);
+    // Find resolve-library-id tool (common context7 tool)
+    const resolveTool = tools.find((t) => t.name.includes("resolve"));
+    if (!resolveTool) {
+      console.log("No resolve tool found, skipping callTool test");
+      return;
+    }
+
+    console.log("Tool schema:", JSON.stringify(resolveTool.inputSchema, null, 2));
+
+    const resolved = service.resolve(resolveTool.name, config);
+    expect(resolved).not.toBeNull();
+
+    // resolve-library-id requires { query: string, libraryName: string }
+    const result = await service.callTool(
+      resolved!.serverConfig,
+      resolved!.toolName,
+      { query: "UI framework", libraryName: "react" },
+    );
+
+    console.log("callTool result:", JSON.stringify(result).slice(0, 200));
+
+    // Should get a result (not an error)
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+  }, 30_000);
+});

--- a/gateway/src/gateway/mcp-service.test.ts
+++ b/gateway/src/gateway/mcp-service.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { McpService } from "./mcp-service";
+import type { McpConfig } from "../config";
+
+function makeConfig(servers: McpConfig["servers"] = {}): McpConfig {
+  return { servers };
+}
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn().mockImplementation(() => ({})),
+}));
+
+describe("McpService", () => {
+  let service: McpService;
+
+  beforeEach(async () => {
+    service = new McpService();
+    const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+    (Client as any).mockImplementation(() => ({
+      connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+      callTool: vi.fn().mockResolvedValue({ content: [] }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -- resolve: the core routing logic --
+
+  describe("resolve", () => {
+    it("resolves when server + cache + tool all match", () => {
+      const config = makeConfig({ aeon: { url: "https://aeon.fly.dev/mcp" } });
+      (service as any).toolCache.set("aeon", {
+        tools: [{ name: "aeon__recall", description: "Search", inputSchema: {} }],
+        fetchedAt: Date.now(),
+      });
+
+      const result = service.resolve("aeon__recall", config);
+      expect(result).toEqual({
+        serverId: "aeon",
+        toolName: "recall",
+        serverConfig: { url: "https://aeon.fly.dev/mcp" },
+      });
+    });
+
+    it("returns null — unknown server", () => {
+      expect(service.resolve("unknown__tool", makeConfig({}))).toBeNull();
+    });
+
+    it("returns null — tool not in cache", () => {
+      const config = makeConfig({ aeon: { url: "https://aeon.fly.dev/mcp" } });
+      (service as any).toolCache.set("aeon", {
+        tools: [{ name: "aeon__ingest", description: "x", inputSchema: {} }],
+        fetchedAt: Date.now(),
+      });
+      expect(service.resolve("aeon__recall", config)).toBeNull();
+    });
+
+    it("returns null — cold cache (fail closed)", () => {
+      const config = makeConfig({ aeon: { url: "https://aeon.fly.dev/mcp" } });
+      expect(service.resolve("aeon__recall", config)).toBeNull();
+    });
+
+    it("returns null — expired cache (fail closed)", () => {
+      const config = makeConfig({ aeon: { url: "https://aeon.fly.dev/mcp", cacheTtlMs: 60_000 } });
+      (service as any).toolCache.set("aeon", {
+        tools: [{ name: "aeon__recall", description: "x", inputSchema: {} }],
+        fetchedAt: Date.now() - 120_000,
+      });
+      expect(service.resolve("aeon__recall", config)).toBeNull();
+    });
+
+    it("returns null — malformed names", () => {
+      const config = makeConfig({ aeon: { url: "https://aeon.fly.dev/mcp" } });
+      expect(service.resolve("aeon", config)).toBeNull();
+      expect(service.resolve("aeon__", config)).toBeNull();
+    });
+  });
+
+  // -- listToolsCached: TTL enforcement --
+
+  describe("listToolsCached", () => {
+    it("returns cached tools when fresh, empty when expired", () => {
+      const config = makeConfig({ s: { url: "https://s.dev/mcp", cacheTtlMs: 60_000 } });
+
+      (service as any).toolCache.set("s", {
+        tools: [{ name: "s__t", description: "x", inputSchema: {} }],
+        fetchedAt: Date.now(),
+      });
+      expect(service.listToolsCached(config)).toHaveLength(1);
+
+      // Expire it
+      (service as any).toolCache.get("s").fetchedAt = Date.now() - 120_000;
+      expect(service.listToolsCached(config)).toHaveLength(0);
+    });
+  });
+
+  // -- refreshCache: the SDK integration seam --
+
+  describe("refreshCache", () => {
+    it("namespaces discovered tools as {serverId}__{toolName}", async () => {
+      const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+      (Client as any).mockImplementation(() => ({
+        connect: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({
+          tools: [
+            { name: "recall", description: "Search", inputSchema: { type: "object" } },
+            { name: "ingest", description: "Store" },
+          ],
+        }),
+      }));
+
+      const config = makeConfig({ aeon: { url: "https://aeon.fly.dev/mcp" } });
+      await service.refreshCache(config);
+
+      const cached = service.listToolsCached(config);
+      expect(cached.map((t) => t.name)).toEqual(["aeon__recall", "aeon__ingest"]);
+    });
+
+    it("clears stale cache on refresh failure", async () => {
+      (service as any).toolCache.set("bad", {
+        tools: [{ name: "bad__tool", description: "x", inputSchema: {} }],
+        fetchedAt: Date.now(),
+      });
+
+      const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+      (Client as any).mockImplementation(() => ({
+        connect: vi.fn().mockRejectedValue(new Error("connection refused")),
+        close: vi.fn().mockResolvedValue(undefined),
+      }));
+
+      await service.refreshCache(makeConfig({ bad: { url: "https://bad.dev/mcp" } }));
+      expect(service.listToolsCached(makeConfig({ bad: { url: "https://bad.dev/mcp" } }))).toEqual([]);
+    });
+  });
+
+  // -- nextCacheExpiryMs: alarm scheduling --
+
+  describe("nextCacheExpiryMs", () => {
+    it("returns undefined with no servers", () => {
+      expect(service.nextCacheExpiryMs(makeConfig({}))).toBeUndefined();
+    });
+
+    it("defers uncached servers by one TTL (no spin-loop)", () => {
+      const config = makeConfig({ s: { url: "https://s.dev/mcp", cacheTtlMs: 60_000 } });
+      expect(service.nextCacheExpiryMs(config)!).toBeGreaterThan(Date.now());
+    });
+  });
+
+  // -- URL validation: the security boundary --
+
+  describe("URL validation", () => {
+    it("rejects non-localhost HTTP and exotic protocols", async () => {
+      const http = await service.callTool({ url: "http://evil.com/mcp" }, "t", {});
+      expect(http.error).toContain("must use HTTPS");
+
+      const ftp = await service.callTool({ url: "ftp://x.com/mcp" }, "t", {});
+      expect(ftp.error).toContain("must use HTTPS");
+    });
+
+    it("allows localhost HTTP and HTTPS", async () => {
+      const local = await service.callTool({ url: "http://localhost:3000/mcp" }, "t", {});
+      expect(local.error).toBeUndefined();
+
+      const https = await service.callTool({ url: "https://mcp.example.com/api" }, "t", {});
+      expect(https.error).toBeUndefined();
+    });
+  });
+
+  // -- invalidateCache --
+
+  describe("invalidateCache", () => {
+    it("clears one or all", () => {
+      (service as any).toolCache.set("a", { tools: [], fetchedAt: 0 });
+      (service as any).toolCache.set("b", { tools: [], fetchedAt: 0 });
+
+      service.invalidateCache("a");
+      expect((service as any).toolCache.has("a")).toBe(false);
+      expect((service as any).toolCache.has("b")).toBe(true);
+
+      service.invalidateCache();
+      expect((service as any).toolCache.size).toBe(0);
+    });
+  });
+});

--- a/gateway/src/gateway/mcp-service.ts
+++ b/gateway/src/gateway/mcp-service.ts
@@ -1,0 +1,346 @@
+/**
+ * MCP tool source. Connects to remote MCP servers over streamable HTTP
+ * via @modelcontextprotocol/sdk. Tools are namespaced as {serverId}__{toolName}
+ * and cached in memory with configurable TTL.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { ToolDefinition } from "../protocol/tools";
+import type { McpConfig, McpServerConfig } from "../config";
+import { NATIVE_TOOL_PREFIX } from "../agents/tools/constants";
+
+type CachedToolList = {
+  tools: ToolDefinition[];
+  fetchedAt: number;
+};
+
+export type ResolvedMcpTool = {
+  serverId: string;
+  toolName: string;
+  serverConfig: McpServerConfig;
+};
+
+/** Race a promise against a timeout, cleaning up the timer on resolution. */
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+const TOOL_SEPARATOR = "__";
+const RESERVED_SOURCE_IDS = [NATIVE_TOOL_PREFIX.replace(/__$/, "")];
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes (tool list)
+const DEFAULT_CLIENT_TTL_MS = 2 * 60 * 1000; // 2 minutes (connection)
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+type CachedClient = {
+  client: Client;
+  connectedAt: number;
+};
+
+/** Check if a server ID is valid (not reserved). */
+export function isValidMcpServerId(serverId: string): { valid: boolean; reason?: string } {
+  if (!serverId) {
+    return { valid: false, reason: "server ID cannot be empty" };
+  }
+  if (RESERVED_SOURCE_IDS.includes(serverId)) {
+    return { valid: false, reason: `"${serverId}" is reserved for native tools` };
+  }
+  if (serverId.includes("__")) {
+    return { valid: false, reason: `"${serverId}" contains "__" which breaks tool name routing` };
+  }
+  return { valid: true };
+}
+
+export class McpService {
+  private readonly toolCache = new Map<string, CachedToolList>();
+  private readonly clientCache = new Map<string, CachedClient>();
+  // Stable retry timestamps for servers that failed refresh (prevents alarm sliding)
+  private readonly retryAt = new Map<string, number>();
+
+  /**
+   * Parse a namespaced tool name and resolve it against MCP config + cache.
+   * Returns null if the source isn't an MCP server, the cache is cold/expired,
+   * or the tool wasn't discovered. Fail-closed by design.
+   */
+  resolve(
+    namespacedTool: string,
+    mcpConfig: McpConfig,
+  ): ResolvedMcpTool | null {
+    const separatorIdx = namespacedTool.indexOf(TOOL_SEPARATOR);
+    if (separatorIdx <= 0 || separatorIdx === namespacedTool.length - TOOL_SEPARATOR.length) {
+      return null;
+    }
+
+    const sourceId = namespacedTool.slice(0, separatorIdx);
+    const toolName = namespacedTool.slice(separatorIdx + TOOL_SEPARATOR.length);
+
+    // Never resolve reserved namespaces as MCP — prevents impersonation
+    if (RESERVED_SOURCE_IDS.includes(sourceId)) return null;
+
+    const serverConfig = mcpConfig.servers[sourceId];
+    if (!serverConfig) return null;
+
+    // Fail closed: require a warm, non-expired cache before allowing dispatch
+    const cached = this.toolCache.get(sourceId);
+    if (!cached) return null;
+
+    const ttl = serverConfig.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    if (Date.now() - cached.fetchedAt > ttl) return null;
+
+    const exists = cached.tools.some((t) => t.name === namespacedTool);
+    if (!exists) return null;
+
+    return { serverId: sourceId, toolName, serverConfig };
+  }
+
+  /**
+   * Return all cached MCP tool definitions (non-expired).
+   * These are merged into the unified tool list alongside native and node tools.
+   */
+  listToolsCached(mcpConfig: McpConfig): ToolDefinition[] {
+    const tools: ToolDefinition[] = [];
+    for (const serverId of Object.keys(mcpConfig.servers)) {
+      const cached = this.toolCache.get(serverId);
+      if (!cached) continue;
+
+      const ttl = mcpConfig.servers[serverId].cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+      if (Date.now() - cached.fetchedAt > ttl) continue;
+
+      tools.push(...cached.tools);
+    }
+    return tools;
+  }
+
+  /** Refresh tool lists from all configured MCP servers in parallel. */
+  async refreshCache(mcpConfig: McpConfig): Promise<void> {
+    const serverIds = Object.keys(mcpConfig.servers);
+    const results = await Promise.allSettled(
+      serverIds.map((serverId) =>
+        this.fetchToolList(serverId, mcpConfig.servers[serverId]),
+      ),
+    );
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === "rejected") {
+        this.toolCache.delete(serverIds[i]);
+        const ttl = mcpConfig.servers[serverIds[i]].cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+        this.retryAt.set(serverIds[i], Date.now() + ttl);
+        console.error(
+          `[McpService] Failed to refresh tool cache for ${serverIds[i]}:`,
+          result.reason,
+        );
+      } else {
+        this.retryAt.delete(serverIds[i]);
+      }
+    }
+  }
+
+  /** Earliest cache expiry across all servers, for alarm scheduling. */
+  nextCacheExpiryMs(mcpConfig: McpConfig): number | undefined {
+    let earliest: number | undefined;
+    for (const [serverId, serverConfig] of Object.entries(mcpConfig.servers)) {
+      const cached = this.toolCache.get(serverId);
+      const ttl = serverConfig.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+      // Use stable retry timestamp for uncached/failed servers (prevents alarm sliding)
+      const expiresAt = cached
+        ? cached.fetchedAt + ttl
+        : this.retryAt.get(serverId) ?? Date.now() + ttl;
+      if (earliest === undefined || expiresAt < earliest) {
+        earliest = expiresAt;
+      }
+    }
+    return earliest;
+  }
+
+  invalidateCache(serverId?: string): void {
+    if (serverId) {
+      this.toolCache.delete(serverId);
+      this.closeClient(serverId);
+    } else {
+      this.toolCache.clear();
+      for (const cached of this.clientCache.values()) {
+        cached.client.close().catch(() => {});
+      }
+      this.clientCache.clear();
+    }
+  }
+
+  /** Execute a tool call against an MCP server. Reuses cached connections. */
+  async callTool(
+    serverConfig: McpServerConfig,
+    toolName: string,
+    args: Record<string, unknown>,
+    serverId?: string,
+  ): Promise<{ ok: boolean; result?: unknown; error?: string }> {
+    try {
+      this.validateServerUrl(serverConfig.url);
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    const cacheKey = serverId ?? serverConfig.url;
+
+    try {
+      const client = await this.getOrCreateClient(cacheKey, serverConfig);
+
+      const response = await client.callTool(
+        { name: toolName, arguments: args },
+        undefined,
+        { timeout: serverConfig.timeoutMs ?? DEFAULT_TIMEOUT_MS },
+      );
+
+      // Preserve the full MCP response shape — don't flatten to text-only.
+      // Let the caller decide how to present structured/non-text content.
+      if (response.isError) {
+        const errorText = Array.isArray(response.content)
+          ? (response.content as Array<{ type: string; text?: string }>)
+              .filter((b) => b.type === "text" && b.text)
+              .map((b) => b.text!)
+              .join("\n")
+          : "MCP tool returned error";
+        return { ok: false, error: errorText || "MCP tool returned error" };
+      }
+
+      // Return the full response — don't discard structuredContent or metadata
+      return { ok: true, result: response };
+    } catch (err) {
+      // Connection broke — evict so next call gets a fresh client.
+      // No automatic retry — side-effecting tools must not be replayed.
+      this.closeClient(cacheKey);
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /** Get a cached client or create + connect a new one. Keyed by serverId. */
+  private async getOrCreateClient(
+    cacheKey: string,
+    serverConfig: McpServerConfig,
+  ): Promise<Client> {
+    const cached = this.clientCache.get(cacheKey);
+
+    if (cached && Date.now() - cached.connectedAt < DEFAULT_CLIENT_TTL_MS) {
+      return cached.client;
+    }
+
+    if (cached) {
+      await cached.client.close().catch(() => {});
+      this.clientCache.delete(cacheKey);
+    }
+
+    const client = this.createClient();
+    const transport = this.createTransport(serverConfig);
+    const timeoutMs = serverConfig.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    await withTimeout(client.connect(transport), timeoutMs, "MCP connect timeout");
+
+    this.clientCache.set(cacheKey, {
+      client,
+      connectedAt: Date.now(),
+    });
+
+    return client;
+  }
+
+  private closeClient(cacheKey: string): void {
+    const cached = this.clientCache.get(cacheKey);
+    if (cached) {
+      cached.client.close().catch(() => {});
+      this.clientCache.delete(cacheKey);
+    }
+  }
+
+  private async fetchToolList(
+    serverId: string,
+    serverConfig: McpServerConfig,
+  ): Promise<void> {
+    this.validateServerUrl(serverConfig.url);
+
+    const client = this.createClient();
+    const transport = this.createTransport(serverConfig);
+    const timeoutMs = serverConfig.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    try {
+      // Bound connect + listTools so a hung server can't stall the alarm cycle
+      await withTimeout(client.connect(transport), timeoutMs, `MCP connect timeout for ${serverId}`);
+      const response = await withTimeout(client.listTools(), timeoutMs, `MCP listTools timeout for ${serverId}`);
+      if (!response.tools || !Array.isArray(response.tools)) {
+        throw new Error(
+          `MCP tools/list for ${serverId}: invalid response shape`,
+        );
+      }
+
+      // Namespace tools with {serverId}__ to match the unified tool convention
+      const tools: ToolDefinition[] = response.tools.map((tool) => ({
+        name: `${serverId}${TOOL_SEPARATOR}${tool.name}`,
+        description: tool.description || `Tool from ${serverId}`,
+        inputSchema: (tool.inputSchema as Record<string, unknown>) ?? {
+          type: "object",
+          properties: {},
+        },
+      }));
+
+      this.toolCache.set(serverId, {
+        tools,
+        fetchedAt: Date.now(),
+      });
+
+      console.log(
+        `[McpService] Refreshed tool cache for ${serverId}: ${tools.length} tools`,
+      );
+    } finally {
+      await client.close().catch(() => {});
+    }
+  }
+
+  private createClient(): Client {
+    return new Client(
+      { name: "gsv-gateway", version: "1.0.0" },
+      { capabilities: {} },
+    );
+  }
+
+  private createTransport(
+    serverConfig: McpServerConfig,
+  ): StreamableHTTPClientTransport {
+    const headers: Record<string, string> = {};
+    if (serverConfig.token) {
+      headers["Authorization"] = `Bearer ${serverConfig.token}`;
+    }
+
+    // Timeout is handled per-operation by the SDK (callTool, listTools),
+    // not at the transport level — a transport-level signal would abort
+    // the initialize handshake and conflict with the SDK's own deadline.
+    return new StreamableHTTPClientTransport(
+      new URL(serverConfig.url),
+      { requestInit: { headers } },
+    );
+  }
+
+  private validateServerUrl(url: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new Error(`Invalid MCP server URL: ${url}`);
+    }
+
+    if (parsed.protocol === "http:") {
+      const hostname = parsed.hostname;
+      if (hostname !== "localhost" && hostname !== "127.0.0.1") {
+        throw new Error(
+          `MCP server URL must use HTTPS (got HTTP for ${hostname}). Use localhost for development.`,
+        );
+      }
+    } else if (parsed.protocol !== "https:") {
+      throw new Error(
+        `MCP server URL must use HTTPS (got ${parsed.protocol})`,
+      );
+    }
+  }
+}

--- a/gateway/src/gateway/rpc-handlers/chat.ts
+++ b/gateway/src/gateway/rpc-handlers/chat.ts
@@ -244,7 +244,7 @@ export const handleChatSend: Handler<"chat.send"> = async ({ gw, params }) => {
   const result = await sessionStub.chatSend(
     directives.cleaned, // Send cleaned message without directives
     params.runId ?? crypto.randomUUID(),
-    JSON.parse(JSON.stringify(gw.nodeService.listTools(gw.nodes.keys()))),
+    JSON.parse(JSON.stringify(gw.getAllTools())),
     JSON.parse(
       JSON.stringify(gw.nodeService.getRuntimeNodeInventory(gw.nodes.keys())),
     ),

--- a/gateway/src/gateway/rpc-handlers/config.ts
+++ b/gateway/src/gateway/rpc-handlers/config.ts
@@ -3,7 +3,8 @@ import { RpcError } from "../../shared/utils";
 
 export const handleConfigGet: Handler<"config.get"> = ({ gw, params }) => {
   if (params?.path) {
-    // Get specific path
+    // Raw read — authenticated clients need real values (UI edits them).
+    // The AI agent's gsv__ConfigGet uses getSafeConfigPath() instead.
     const value = gw.getConfigPath(params.path);
     return { path: params.path, value };
   } else {

--- a/gateway/src/gateway/rpc-handlers/tools.ts
+++ b/gateway/src/gateway/rpc-handlers/tools.ts
@@ -30,15 +30,15 @@ function toToolDispatchRpcError(message: string): RpcError {
 }
 
 export const handleToolsList: Handler<"tools.list"> = ({ gw }) => ({
-  tools: gw.nodeService.listTools(gw.nodes.keys()),
+  tools: gw.getAllTools(),
 });
 
-export const handleToolRequest: Handler<"tool.request"> = ({ gw, params }) => {
+export const handleToolRequest: Handler<"tool.request"> = async ({ gw, params }) => {
   if (!params?.callId || !params?.tool || !params?.sessionKey) {
     throw new RpcError(400, "callId, tool, and sessionKey required");
   }
 
-  const result = gw.nodeService.requestToolForSession(params, gw.nodes);
+  const result = await gw.toolRequest(params);
   if (!result.ok) {
     throw toToolDispatchRpcError(result.error ?? "Failed to dispatch tool");
   }
@@ -58,6 +58,17 @@ export const handleToolInvoke: Handler<"tool.invoke"> = (ctx) => {
     throw new RpcError(101, "Not connected");
   }
 
+  // Unified dispatch: try MCP resolution first, then fall through to node.
+  // resolve() returns null fast when cache is cold or server not configured.
+  const resolved = gw.mcpService.resolve(params.tool, gw.getFullConfig().mcp);
+  if (resolved) {
+    // MCP tool: execute via HTTP, send result through WS frame.
+    // Route through gateway.executeMcpToolInvoke to use ctx.waitUntil.
+    gw.executeMcpToolInvoke(ws, frame.id, resolved, params.args ?? {});
+    return DEFER_RESPONSE;
+  }
+
+  // Node tool: async dispatch via WebSocket
   const result = gw.nodeService.requestToolFromClient(
     {
       clientId,

--- a/gateway/src/gateway/tool-executors.ts
+++ b/gateway/src/gateway/tool-executors.ts
@@ -345,7 +345,7 @@ export async function executeSessionSendTool(
   const runId = crypto.randomUUID();
   const sessionStub = env.SESSION.getByName(sessionKey);
 
-  const tools = JSON.parse(JSON.stringify(gw.nodeService.listTools(gw.nodes.keys())));
+  const tools = JSON.parse(JSON.stringify(gw.getAllTools()));
   const runtimeNodes = JSON.parse(
     JSON.stringify(gw.nodeService.getRuntimeNodeInventory(gw.nodes.keys())),
   );

--- a/gateway/src/gateway/tool-search.test.ts
+++ b/gateway/src/gateway/tool-search.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { tokenize, scoreToolMatch } from "./tool-search";
+
+describe("tool search", () => {
+  describe("tokenize", () => {
+    it("splits on spaces", () => {
+      expect(tokenize("react hooks")).toEqual(["react", "hooks"]);
+    });
+
+    it("expands camelCase", () => {
+      expect(tokenize("useEffect")).toEqual(["use", "effect"]);
+    });
+
+    it("normalizes separators", () => {
+      expect(tokenize("query-docs")).toEqual(["query", "docs"]);
+      expect(tokenize("resolve_library_id")).toEqual(["resolve", "library", "id"]);
+    });
+  });
+
+  describe("scoreToolMatch", () => {
+    const docsTool = {
+      name: "context7__query-docs",
+      description: "Retrieves and queries up-to-date documentation and code examples from Context7",
+      inputSchema: {
+        type: "object",
+        properties: { libraryId: {}, query: {} },
+      },
+    };
+
+    const resolveTool = {
+      name: "context7__resolve-library-id",
+      description: "Resolves a package/product name to a Context7-compatible library ID",
+      inputSchema: {
+        type: "object",
+        properties: { libraryName: {}, query: {} },
+      },
+    };
+
+    const readFile = {
+      name: "gsv__ReadFile",
+      description: "Read a file or list a directory in your workspace.",
+      inputSchema: {
+        type: "object",
+        properties: { path: {} },
+      },
+    };
+
+    it("scores documentation query higher for docs tool", () => {
+      const tokens = tokenize("documentation");
+      const docsScore = scoreToolMatch(tokens, docsTool);
+      const resolveScore = scoreToolMatch(tokens, resolveTool);
+      const readScore = scoreToolMatch(tokens, readFile);
+
+      expect(docsScore).toBeGreaterThan(resolveScore);
+      expect(docsScore).toBeGreaterThan(readScore);
+    });
+
+    it("scores 'react docs' matching both tokens", () => {
+      const tokens = tokenize("react docs");
+      const docsScore = scoreToolMatch(tokens, docsTool);
+      // "docs" matches tool name, no exact "react" but partial coverage
+      expect(docsScore).toBeGreaterThan(0);
+    });
+
+    it("scores source ID matches (context7)", () => {
+      const tokens = tokenize("context7");
+      const docsScore = scoreToolMatch(tokens, docsTool);
+      const readScore = scoreToolMatch(tokens, readFile);
+
+      expect(docsScore).toBeGreaterThan(0);
+      expect(readScore).toBe(0);
+    });
+
+    it("returns 0 for no match", () => {
+      const tokens = tokenize("kubernetes");
+      expect(scoreToolMatch(tokens, docsTool)).toBe(0);
+      expect(scoreToolMatch(tokens, readFile)).toBe(0);
+    });
+
+    it("scores file-related query higher for ReadFile", () => {
+      const tokens = tokenize("read file");
+      const readScore = scoreToolMatch(tokens, readFile);
+      const docsScore = scoreToolMatch(tokens, docsTool);
+
+      expect(readScore).toBeGreaterThan(docsScore);
+    });
+  });
+});

--- a/gateway/src/gateway/tool-search.ts
+++ b/gateway/src/gateway/tool-search.ts
@@ -1,0 +1,145 @@
+/**
+ * Weighted token matching for tool discovery.
+ *
+ * Follows the executor-style scoring approach: normalize text (expand
+ * camelCase, split on separators), tokenize the query, then score each
+ * tool field with different weights. Exact matches score higher than
+ * prefix matches, which score higher than substring matches.
+ */
+
+import type { ToolDefinition } from "../protocol/tools";
+
+// Field weights — name and source ID matter more than description
+const FIELD_WEIGHTS = {
+  name: 10,
+  sourceId: 8,
+  description: 5,
+  schemaKeys: 3,
+};
+
+// Scoring tiers per field
+const EXACT_MATCH = 14;
+const STARTS_WITH = 9;
+const PHRASE_SUBSTRING = 6;
+const TOKEN_MATCH = 4;
+const TOKEN_PREFIX = 2;
+const TOKEN_SUBSTRING = 1;
+
+// Coverage bonuses
+const FULL_COVERAGE_BONUS = 25;
+const PARTIAL_COVERAGE_BONUS = 10;
+
+/** Normalize text: expand camelCase, replace separators with spaces, lowercase. */
+function normalize(text: string): string {
+  return text
+    .replace(/([a-z])([A-Z])/g, "$1 $2") // camelCase → spaces
+    .replace(/[_.\-/:]+/g, " ")            // separators → spaces
+    .toLowerCase()
+    .trim();
+}
+
+/** Split normalized text into tokens. */
+export function tokenize(text: string): string[] {
+  return normalize(text)
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}
+
+/** Score how well a field matches a set of query tokens. Returns weighted score. */
+function scoreField(
+  queryTokens: string[],
+  fieldText: string,
+  weight: number,
+): { score: number; matchedTokens: Set<string> } {
+  const normalized = normalize(fieldText);
+  const fieldTokens = normalized.split(/\s+/).filter((t) => t.length > 0);
+  const query = queryTokens.join(" ");
+  let score = 0;
+  const matchedTokens = new Set<string>();
+
+  // Exact full match
+  if (normalized === query) {
+    score += weight * EXACT_MATCH;
+    for (const t of queryTokens) matchedTokens.add(t);
+    return { score, matchedTokens };
+  }
+
+  // Field starts with query
+  if (normalized.startsWith(query)) {
+    score += weight * STARTS_WITH;
+    for (const t of queryTokens) matchedTokens.add(t);
+    return { score, matchedTokens };
+  }
+
+  // Exact phrase substring
+  if (normalized.includes(query)) {
+    score += weight * PHRASE_SUBSTRING;
+    for (const t of queryTokens) matchedTokens.add(t);
+    return { score, matchedTokens };
+  }
+
+  // Per-token matching
+  for (const qt of queryTokens) {
+    let tokenBestScore = 0;
+    for (const ft of fieldTokens) {
+      if (ft === qt) {
+        tokenBestScore = Math.max(tokenBestScore, TOKEN_MATCH);
+      } else if (ft.startsWith(qt)) {
+        tokenBestScore = Math.max(tokenBestScore, TOKEN_PREFIX);
+      } else if (ft.includes(qt)) {
+        tokenBestScore = Math.max(tokenBestScore, TOKEN_SUBSTRING);
+      }
+    }
+    if (tokenBestScore > 0) {
+      score += weight * tokenBestScore;
+      matchedTokens.add(qt);
+    }
+  }
+
+  return { score, matchedTokens };
+}
+
+/** Score a tool against query tokens across all searchable fields. */
+export function scoreToolMatch(
+  queryTokens: string[],
+  tool: ToolDefinition,
+): number {
+  const allMatched = new Set<string>();
+  let totalScore = 0;
+
+  // Parse sourceId from namespaced tool name
+  const sepIdx = tool.name.indexOf("__");
+  const sourceId = sepIdx > 0 ? tool.name.slice(0, sepIdx) : "";
+  const toolName = sepIdx > 0 ? tool.name.slice(sepIdx + 2) : tool.name;
+
+  // Score each field
+  const fields: Array<[string, number]> = [
+    [toolName, FIELD_WEIGHTS.name],
+    [sourceId, FIELD_WEIGHTS.sourceId],
+    [tool.description || "", FIELD_WEIGHTS.description],
+    [
+      Object.keys(
+        (tool.inputSchema as { properties?: Record<string, unknown> })?.properties ?? {},
+      ).join(" "),
+      FIELD_WEIGHTS.schemaKeys,
+    ],
+  ];
+
+  for (const [text, weight] of fields) {
+    if (!text) continue;
+    const { score, matchedTokens } = scoreField(queryTokens, text, weight);
+    totalScore += score;
+    for (const t of matchedTokens) allMatched.add(t);
+  }
+
+  // Coverage bonuses
+  if (allMatched.size === queryTokens.length) {
+    totalScore += FULL_COVERAGE_BONUS;
+  } else if (allMatched.size > 0) {
+    totalScore += Math.round(
+      PARTIAL_COVERAGE_BONUS * (allMatched.size / queryTokens.length),
+    );
+  }
+
+  return totalScore;
+}

--- a/gateway/src/session/tool-approval.test.ts
+++ b/gateway/src/session/tool-approval.test.ts
@@ -164,6 +164,24 @@ describe("tool approval policy evaluation", () => {
 
     expect(result).toEqual({ decision: "allow" });
   });
+
+  // MCP tools use the same approval system as everything else.
+  // Users who want restrictions add rules like they would for any tool.
+  it("applies rules to MCP-style tool names", () => {
+    const config: ToolApprovalConfig = {
+      defaultDecision: "allow",
+      rules: [
+        { id: "deny-aeon-write", tool: "aeon__*", decision: "deny" },
+      ],
+    };
+
+    expect(
+      evaluateToolApproval("aeon__recall", {}, config),
+    ).toMatchObject({ decision: "deny", ruleId: "deny-aeon-write" });
+    expect(
+      evaluateToolApproval("context7__query-docs", {}, config),
+    ).toEqual({ decision: "allow" });
+  });
 });
 
 describe("tool approval decision parsing", () => {


### PR DESCRIPTION
## Summary

Builds on #66. Adds an executor-inspired discover → call pattern for MCP tools. Instead of putting all MCP tools in the LLM's context (costly at scale), the agent discovers them via `gsv__SearchTools` and invokes them via `gsv__CallTool`.

**SearchTools**: Weighted token matching (executor-style scoring) across tool name, description, sourceId, and schema property names. Returns top 10 results with relevance scoring.

**CallTool**: Unified dispatch — MCP tools via HTTP, native tools via `executeNativeTool`. Node tools return a clear unsupported message (WebSocket dispatch needed).

**Context efficiency**: MCP tools removed from default tool list. Only 2 fixed-cost tools added (~200 tokens) regardless of how many MCP servers are configured.

The system prompt hints the agent to search when it can't do something with its built-in tools. Tool descriptions validated with gepa/optimize_anything — seed descriptions score optimally.

### Design note: approval model

`gsv__CallTool` goes through normal session tool approval. We don't re-evaluate approval on the inner tool because GSV's security model prioritizes capability and simplicity (`defaultDecision: "allow"`, no rules by default). The user's approval of CallTool is the consent point. If the approval model evolves to require per-tool granularity, the JSDoc on `callToolDirect` documents exactly where to add it.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 226 tests passing (8 new for tool search scoring)
- [x] Gateway e2e: MCP tools absent from tools.list, SearchTools + CallTool present
- [x] Tool search scoring: "documentation" ranks context7__query-docs highest
- [ ] Agent behavior: send chat message requiring external capability, verify SearchTools is called