### PR TITLE
add prefix for multiple gsv deployments in same account

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Named after the planet-scale sentient ships from Iain M. Banks' Culture series, 
 curl -sSL https://install.gsv.space | bash
 # Deploys all components to your Cloudflare account
 gsv infra deploy --api-token <CLOUDFLARE-API-TOKEN>
+# For a second install in the same account, add a unique instance prefix:
+gsv infra deploy --instance gsv-personal --api-token <CLOUDFLARE-API-TOKEN>
 ```
 
 Once the deployment finishes open the URL to finish your onboarding through the Web UI.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -154,6 +154,10 @@ pub(crate) enum InfraAction {
         #[arg(long)]
         all: bool,
 
+        /// Deployment instance prefix for Worker and bucket names
+        #[arg(long, env = "GSV_INSTANCE", default_value = "gsv")]
+        instance: String,
+
         /// Overwrite existing extracted bundle directories
         #[arg(long)]
         force_fetch: bool,
@@ -193,6 +197,10 @@ pub(crate) enum InfraAction {
         #[arg(long)]
         all: bool,
 
+        /// Deployment instance prefix for Worker and bucket names
+        #[arg(long, env = "GSV_INSTANCE", default_value = "gsv")]
+        instance: String,
+
         /// Overwrite existing extracted bundle directories (auto-enabled for mutable refs like dev/stable/latest)
         #[arg(long)]
         force_fetch: bool,
@@ -227,6 +235,10 @@ pub(crate) enum InfraAction {
         /// Remove all components
         #[arg(long)]
         all: bool,
+
+        /// Deployment instance prefix for Worker and bucket names
+        #[arg(long, env = "GSV_INSTANCE", default_value = "gsv")]
+        instance: String,
 
         /// Also delete the shared R2 storage bucket
         #[arg(long)]

--- a/cli/src/commands/infra.rs
+++ b/cli/src/commands/infra.rs
@@ -13,6 +13,7 @@ struct DeployCommandOptions {
     version: String,
     component: Vec<String>,
     all: bool,
+    instance: String,
     force_fetch: bool,
     bundle_dir: Option<PathBuf>,
     api_token: Option<String>,
@@ -24,6 +25,7 @@ struct DeployCommandOptions {
 struct DestroyCommandOptions {
     component: Vec<String>,
     all: bool,
+    instance: String,
     delete_bucket: bool,
     purge_bucket: bool,
     wizard: bool,
@@ -35,6 +37,7 @@ struct DestroyCommandOptions {
 struct DestroyDeployOptions {
     component: Vec<String>,
     all: bool,
+    instance: String,
     delete_bucket: bool,
     purge_bucket: bool,
     wizard: bool,
@@ -51,6 +54,7 @@ pub(crate) async fn run_infra(
             version,
             component,
             all,
+            instance,
             force_fetch,
             bundle_dir,
             api_token,
@@ -64,6 +68,7 @@ pub(crate) async fn run_infra(
                     version,
                     component,
                     all,
+                    instance,
                     force_fetch,
                     bundle_dir,
                     api_token,
@@ -78,6 +83,7 @@ pub(crate) async fn run_infra(
             version,
             component,
             all,
+            instance,
             force_fetch,
             bundle_dir,
             api_token,
@@ -91,6 +97,7 @@ pub(crate) async fn run_infra(
                     version,
                     component,
                     all,
+                    instance,
                     force_fetch,
                     bundle_dir,
                     api_token,
@@ -104,6 +111,7 @@ pub(crate) async fn run_infra(
         InfraAction::Destroy {
             component,
             all,
+            instance,
             delete_bucket,
             purge_bucket,
             wizard,
@@ -116,6 +124,7 @@ pub(crate) async fn run_infra(
                 DestroyCommandOptions {
                     component,
                     all,
+                    instance,
                     delete_bucket,
                     purge_bucket,
                     wizard,
@@ -317,6 +326,7 @@ async fn run_destroy_command(
     let DestroyCommandOptions {
         component,
         all,
+        instance,
         delete_bucket,
         purge_bucket,
         wizard,
@@ -335,6 +345,7 @@ async fn run_destroy_command(
         DestroyDeployOptions {
             component,
             all,
+            instance,
             delete_bucket,
             purge_bucket,
             wizard,
@@ -374,6 +385,7 @@ async fn apply_deploy(
         version,
         component,
         all,
+        instance,
         force_fetch,
         bundle_dir,
         api_token,
@@ -382,6 +394,7 @@ async fn apply_deploy(
         telegram_bot_token,
     } = options;
     deploy::set_notification_output(false);
+    let instance = deploy::DeployInstance::parse(&instance)?;
 
     if all && !component.is_empty() {
         return Err("Use either --all or one/more --component values, not both".into());
@@ -396,6 +409,7 @@ async fn apply_deploy(
         resolve_cloudflare_account_id_for_deploy(&token, configured_account_id, false, false)
             .await?;
     println!("Cloudflare account ID: {}", resolved_account_id);
+    println!("GSV instance: {}", instance.name());
 
     let components = if all {
         deploy::available_components()
@@ -434,13 +448,20 @@ async fn apply_deploy(
         &token,
         &bundle_version,
         &components,
+        &instance,
     )
     .await?;
 
     if deploying_discord {
         if let Some(bot_token) = discord_bot_token.as_deref() {
             println!("Setting DISCORD_BOT_TOKEN secret on Discord channel worker...");
-            deploy::set_discord_bot_token_secret(&resolved_account_id, &token, bot_token).await?;
+            deploy::set_discord_bot_token_secret(
+                &resolved_account_id,
+                &token,
+                bot_token,
+                &instance,
+            )
+            .await?;
             println!("Configured DISCORD_BOT_TOKEN.");
         } else {
             println!("Note: Discord bot token not configured.");
@@ -453,7 +474,13 @@ async fn apply_deploy(
     if deploying_telegram {
         if let Some(bot_token) = telegram_bot_token.as_deref() {
             println!("Setting TELEGRAM_BOT_TOKEN secret on Telegram channel worker...");
-            deploy::set_telegram_bot_token_secret(&resolved_account_id, &token, bot_token).await?;
+            deploy::set_telegram_bot_token_secret(
+                &resolved_account_id,
+                &token,
+                bot_token,
+                &instance,
+            )
+            .await?;
             println!("Configured TELEGRAM_BOT_TOKEN.");
         } else {
             println!("Note: Telegram bot token not configured.");
@@ -486,6 +513,7 @@ async fn destroy_deploy(
     let DestroyDeployOptions {
         component,
         all,
+        instance,
         delete_bucket,
         purge_bucket,
         wizard,
@@ -493,6 +521,7 @@ async fn destroy_deploy(
         account_id,
     } = options;
     deploy::set_notification_output(false);
+    let instance = deploy::DeployInstance::parse(&instance)?;
 
     if all && !component.is_empty() {
         return Err("Use either --all or one/more --component values, not both".into());
@@ -530,6 +559,7 @@ async fn destroy_deploy(
     )
     .await?;
     println!("Cloudflare account ID: {}", resolved_account_id);
+    println!("GSV instance: {}", instance.name());
 
     let mut components = if all {
         deploy::available_components()
@@ -558,8 +588,11 @@ async fn destroy_deploy(
     let mut purge_bucket_resource = purge_bucket;
 
     if wizard_mode && interactive {
-        delete_bucket_resource =
-            prompt_yes_no("Also delete R2 bucket gsv-storage?", delete_bucket_resource)?;
+        let bucket_name = instance.storage_bucket_name();
+        delete_bucket_resource = prompt_yes_no(
+            &format!("Also delete R2 bucket {}?", bucket_name),
+            delete_bucket_resource,
+        )?;
         if delete_bucket_resource {
             purge_bucket_resource = prompt_yes_no(
                 "Purge bucket objects before deletion?",
@@ -593,6 +626,7 @@ async fn destroy_deploy(
         &components,
         delete_bucket_resource,
         purge_bucket_resource,
+        &instance,
     )
     .await
 }

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -32,6 +32,7 @@ const BUNDLE_CHANNEL_WHATSAPP: &str = "gsv-cloudflare-channel-whatsapp.tar.gz";
 const BUNDLE_CHANNEL_DISCORD: &str = "gsv-cloudflare-channel-discord.tar.gz";
 const BUNDLE_CHANNEL_TELEGRAM: &str = "gsv-cloudflare-channel-telegram.tar.gz";
 const BUNDLE_CHECKSUMS: &str = "cloudflare-checksums.txt";
+pub const DEFAULT_DEPLOY_INSTANCE: &str = "gsv";
 const DEFAULT_STORAGE_BUCKET_NAME: &str = "gsv-storage";
 const SCRIPT_ASSEMBLER: &str = "gsv-assembler";
 const SCRIPT_GATEWAY: &str = "gsv";
@@ -45,6 +46,94 @@ const CLOUDFLARE_MAX_ATTEMPTS: usize = 5;
 const CLOUDFLARE_RETRY_BASE_MS: u64 = 400;
 const MAX_SOURCE_MAP_UPLOAD_BYTES: usize = 2 * 1024 * 1024;
 static DEPLOY_NOTIFICATION_MODE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DeployInstance {
+    name: String,
+}
+
+impl DeployInstance {
+    pub fn parse(raw: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let name = normalize_instance_name(raw)?;
+        Ok(Self { name })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn is_default(&self) -> bool {
+        self.name == DEFAULT_DEPLOY_INSTANCE
+    }
+
+    pub fn storage_bucket_name(&self) -> String {
+        format!("{}-storage", self.name)
+    }
+
+    pub fn script_name(&self, component: &str) -> Option<String> {
+        match component {
+            COMPONENT_GATEWAY => Some(self.name.clone()),
+            COMPONENT_ASSEMBLER => Some(format!("{}-assembler", self.name)),
+            COMPONENT_RIPGIT if self.is_default() => Some(SCRIPT_RIPGIT.to_string()),
+            COMPONENT_RIPGIT => Some(format!("{}-ripgit", self.name)),
+            COMPONENT_CHANNEL_WHATSAPP => Some(format!("{}-channel-whatsapp", self.name)),
+            COMPONENT_CHANNEL_DISCORD => Some(format!("{}-channel-discord", self.name)),
+            COMPONENT_CHANNEL_TELEGRAM => Some(format!("{}-channel-telegram", self.name)),
+            _ => None,
+        }
+    }
+
+    fn script_name_for_config_service(&self, service: &str) -> String {
+        match service {
+            SCRIPT_GATEWAY => self
+                .script_name(COMPONENT_GATEWAY)
+                .unwrap_or_else(|| service.to_string()),
+            SCRIPT_ASSEMBLER => self
+                .script_name(COMPONENT_ASSEMBLER)
+                .unwrap_or_else(|| service.to_string()),
+            SCRIPT_RIPGIT => self
+                .script_name(COMPONENT_RIPGIT)
+                .unwrap_or_else(|| service.to_string()),
+            SCRIPT_CHANNEL_WHATSAPP => self
+                .script_name(COMPONENT_CHANNEL_WHATSAPP)
+                .unwrap_or_else(|| service.to_string()),
+            SCRIPT_CHANNEL_DISCORD => self
+                .script_name(COMPONENT_CHANNEL_DISCORD)
+                .unwrap_or_else(|| service.to_string()),
+            SCRIPT_CHANNEL_TELEGRAM => self
+                .script_name(COMPONENT_CHANNEL_TELEGRAM)
+                .unwrap_or_else(|| service.to_string()),
+            _ => service.to_string(),
+        }
+    }
+}
+
+impl Default for DeployInstance {
+    fn default() -> Self {
+        Self {
+            name: DEFAULT_DEPLOY_INSTANCE.to_string(),
+        }
+    }
+}
+
+fn normalize_instance_name(raw: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Err("GSV instance name cannot be empty".into());
+    }
+    if normalized.starts_with('-') || normalized.ends_with('-') {
+        return Err("GSV instance name cannot start or end with '-'".into());
+    }
+    if !normalized
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        return Err(
+            "GSV instance name must contain only lowercase letters, numbers, and '-'".into(),
+        );
+    }
+    Ok(normalized)
+}
 
 pub fn set_notification_output(enabled: bool) {
     DEPLOY_NOTIFICATION_MODE.store(enabled, Ordering::Relaxed);
@@ -397,6 +486,7 @@ struct WorkerScriptUpload<'a> {
 }
 
 struct UploadMetadataOptions<'a> {
+    instance: &'a DeployInstance,
     selected_components: &'a HashSet<String>,
     available_scripts: &'a HashSet<String>,
     account_subdomain: Option<&'a str>,
@@ -483,18 +573,6 @@ fn component_to_bundle(component: &str) -> Option<&'static str> {
         COMPONENT_CHANNEL_WHATSAPP => Some(BUNDLE_CHANNEL_WHATSAPP),
         COMPONENT_CHANNEL_DISCORD => Some(BUNDLE_CHANNEL_DISCORD),
         COMPONENT_CHANNEL_TELEGRAM => Some(BUNDLE_CHANNEL_TELEGRAM),
-        _ => None,
-    }
-}
-
-fn component_to_script_name(component: &str) -> Option<&'static str> {
-    match component {
-        COMPONENT_ASSEMBLER => Some(SCRIPT_ASSEMBLER),
-        COMPONENT_GATEWAY => Some(SCRIPT_GATEWAY),
-        COMPONENT_RIPGIT => Some(SCRIPT_RIPGIT),
-        COMPONENT_CHANNEL_WHATSAPP => Some(SCRIPT_CHANNEL_WHATSAPP),
-        COMPONENT_CHANNEL_DISCORD => Some(SCRIPT_CHANNEL_DISCORD),
-        COMPONENT_CHANNEL_TELEGRAM => Some(SCRIPT_CHANNEL_TELEGRAM),
         _ => None,
     }
 }
@@ -2005,21 +2083,48 @@ fn load_prepared_bundle(
     })
 }
 
+fn apply_instance_names_to_bundle(
+    bundle: &mut PreparedBundle,
+    instance: &DeployInstance,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let script_name = instance
+        .script_name(&bundle.component)
+        .ok_or_else(|| format!("Unsupported component '{}'", bundle.component))?;
+    bundle.wrangler.name = script_name.clone();
+    bundle.script_name = script_name;
+
+    let storage_bucket_name = instance.storage_bucket_name();
+    for bucket in &mut bundle.wrangler.r2_buckets {
+        if bucket.bucket_name.as_deref() == Some(DEFAULT_STORAGE_BUCKET_NAME) {
+            bucket.bucket_name = Some(storage_bucket_name.clone());
+        }
+    }
+
+    Ok(())
+}
+
 fn service_bindings_for_bundle(
     bundle: &PreparedBundle,
+    instance: &DeployInstance,
     selected_components: &HashSet<String>,
     available_scripts: &HashSet<String>,
 ) -> Vec<WranglerServiceBinding> {
     let mut bindings = bundle.wrangler.services.clone();
+    let gateway_script_name = instance
+        .script_name(COMPONENT_GATEWAY)
+        .unwrap_or_else(|| SCRIPT_GATEWAY.to_string());
+    let telegram_script_name = instance
+        .script_name(COMPONENT_CHANNEL_TELEGRAM)
+        .unwrap_or_else(|| SCRIPT_CHANNEL_TELEGRAM.to_string());
 
     if bundle.component == COMPONENT_CHANNEL_WHATSAPP
         && !bindings.iter().any(|binding| binding.binding == "GATEWAY")
         && (selected_components.contains(COMPONENT_GATEWAY)
-            || available_scripts.contains(SCRIPT_GATEWAY))
+            || available_scripts.contains(&gateway_script_name))
     {
         bindings.push(WranglerServiceBinding {
             binding: "GATEWAY".to_string(),
-            service: SCRIPT_GATEWAY.to_string(),
+            service: gateway_script_name.clone(),
             environment: None,
             entrypoint: Some("GatewayEntrypoint".to_string()),
         });
@@ -2030,11 +2135,11 @@ fn service_bindings_for_bundle(
             .iter()
             .any(|binding| binding.binding == "CHANNEL_TELEGRAM")
         && (selected_components.contains(COMPONENT_CHANNEL_TELEGRAM)
-            || available_scripts.contains(SCRIPT_CHANNEL_TELEGRAM))
+            || available_scripts.contains(&telegram_script_name))
     {
         bindings.push(WranglerServiceBinding {
             binding: "CHANNEL_TELEGRAM".to_string(),
-            service: SCRIPT_CHANNEL_TELEGRAM.to_string(),
+            service: telegram_script_name.clone(),
             environment: None,
             entrypoint: Some("TelegramChannel".to_string()),
         });
@@ -2049,6 +2154,7 @@ fn service_bindings_for_bundle(
             binding.entrypoint = Some("WhatsAppChannelEntrypoint".to_string());
         }
 
+        binding.service = instance.script_name_for_config_service(&binding.service);
         let keep = available_scripts.contains(&binding.service);
         if keep {
             filtered.push(binding);
@@ -2499,6 +2605,7 @@ fn build_upload_metadata(
 
     for service in service_bindings_for_bundle(
         bundle,
+        options.instance,
         options.selected_components,
         options.available_scripts,
     ) {
@@ -2603,6 +2710,7 @@ pub async fn apply_deploy(
     api_token: &str,
     version: &str,
     components: &[String],
+    instance: &DeployInstance,
 ) -> Result<DeployApplyResult, Box<dyn std::error::Error>> {
     if components.is_empty() {
         return Err("No components requested for deployment".into());
@@ -2612,20 +2720,32 @@ pub async fn apply_deploy(
         .iter()
         .map(|component| load_prepared_bundle(cfg, version, component))
         .collect::<Result<Vec<_>, _>>()?;
+    for bundle in &mut prepared {
+        apply_instance_names_to_bundle(bundle, instance)?;
+    }
     prepared.sort_by_key(|bundle| deploy_order(&bundle.component));
 
     let selected_components: HashSet<String> = components.iter().cloned().collect();
+    let gateway_script_name = instance
+        .script_name(COMPONENT_GATEWAY)
+        .ok_or("Unsupported gateway component")?;
+    let ripgit_script_name = instance
+        .script_name(COMPONENT_RIPGIT)
+        .ok_or("Unsupported ripgit component")?;
+    let assembler_script_name = instance
+        .script_name(COMPONENT_ASSEMBLER)
+        .ok_or("Unsupported assembler component")?;
 
     let client = reqwest::Client::new();
     let existing_scripts_with_migrations =
         list_worker_scripts(&client, account_id, api_token).await?;
     let existing_scripts: HashSet<String> =
         existing_scripts_with_migrations.keys().cloned().collect();
-    let gateway_existed_before_deploy = existing_scripts.contains(SCRIPT_GATEWAY);
-    let ripgit_available =
-        selected_components.contains(COMPONENT_RIPGIT) || existing_scripts.contains(SCRIPT_RIPGIT);
+    let gateway_existed_before_deploy = existing_scripts.contains(&gateway_script_name);
+    let ripgit_available = selected_components.contains(COMPONENT_RIPGIT)
+        || existing_scripts.contains(&ripgit_script_name);
     let assembler_available = selected_components.contains(COMPONENT_ASSEMBLER)
-        || existing_scripts.contains(SCRIPT_ASSEMBLER);
+        || existing_scripts.contains(&assembler_script_name);
     if selected_components.contains(COMPONENT_GATEWAY) && !ripgit_available {
         return Err(
             "Deploying `gateway` requires the `ripgit` worker. Include `--component ripgit` or deploy ripgit first."
@@ -2706,6 +2826,7 @@ pub async fn apply_deploy(
         let metadata = build_upload_metadata(
             bundle,
             UploadMetadataOptions {
+                instance,
                 selected_components: &selected_components,
                 available_scripts: &available_scripts,
                 account_subdomain: account_subdomain.as_deref(),
@@ -2784,6 +2905,7 @@ pub async fn apply_deploy(
         let metadata = build_upload_metadata(
             bundle,
             UploadMetadataOptions {
+                instance,
                 selected_components: &selected_components,
                 available_scripts: &available_scripts,
                 account_subdomain: account_subdomain.as_deref(),
@@ -2846,6 +2968,7 @@ pub async fn destroy_deploy(
     components: &[String],
     delete_bucket_resource: bool,
     purge_bucket_resource: bool,
+    instance: &DeployInstance,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if components.is_empty() {
         return Err("No components requested for teardown".into());
@@ -2856,13 +2979,15 @@ pub async fn destroy_deploy(
 
     let mut scripts_to_delete = Vec::new();
     for component in &component_order {
-        let script_name = component_to_script_name(component)
+        let script_name = instance
+            .script_name(component)
             .ok_or_else(|| format!("Unsupported component '{}'", component))?;
-        scripts_to_delete.push((component.clone(), script_name.to_string()));
+        scripts_to_delete.push((component.clone(), script_name));
     }
 
     let selected_components: HashSet<String> = components.iter().cloned().collect();
     let client = reqwest::Client::new();
+    let storage_bucket_name = instance.storage_bucket_name();
 
     println!("\nDeleting workers:");
     for (component, script_name) in scripts_to_delete {
@@ -2879,48 +3004,34 @@ pub async fn destroy_deploy(
         if purge_bucket_resource {
             println!(
                 "Purging objects from R2 bucket {} before deletion...",
-                DEFAULT_STORAGE_BUCKET_NAME
+                storage_bucket_name
             );
-            let deleted_objects = purge_r2_bucket_objects(
-                &client,
-                account_id,
-                api_token,
-                DEFAULT_STORAGE_BUCKET_NAME,
-                None,
-            )
-            .await?;
+            let deleted_objects =
+                purge_r2_bucket_objects(&client, account_id, api_token, &storage_bucket_name, None)
+                    .await?;
             if deleted_objects > 0 {
                 println!(
                     "Purged {} object(s) from R2 bucket {}",
-                    deleted_objects, DEFAULT_STORAGE_BUCKET_NAME
+                    deleted_objects, storage_bucket_name
                 );
             } else {
-                println!("R2 bucket {} is already empty", DEFAULT_STORAGE_BUCKET_NAME);
+                println!("R2 bucket {} is already empty", storage_bucket_name);
             }
         }
 
-        let delete_result = delete_r2_bucket(
-            &client,
-            account_id,
-            api_token,
-            DEFAULT_STORAGE_BUCKET_NAME,
-            None,
-        )
-        .await?;
+        let delete_result =
+            delete_r2_bucket(&client, account_id, api_token, &storage_bucket_name, None).await?;
         match delete_result {
             DeleteBucketResult::Deleted => {
-                println!("Deleted R2 bucket {}", DEFAULT_STORAGE_BUCKET_NAME);
+                println!("Deleted R2 bucket {}", storage_bucket_name);
             }
             DeleteBucketResult::NotFound => {
-                println!(
-                    "R2 bucket {} was already absent",
-                    DEFAULT_STORAGE_BUCKET_NAME
-                );
+                println!("R2 bucket {} was already absent", storage_bucket_name);
             }
             DeleteBucketResult::NotEmpty => {
                 println!(
                     "R2 bucket {} was not deleted because it is not empty.",
-                    DEFAULT_STORAGE_BUCKET_NAME
+                    storage_bucket_name
                 );
                 if purge_bucket_resource {
                     println!(
@@ -2936,7 +3047,7 @@ pub async fn destroy_deploy(
     } else if selected_components.contains(COMPONENT_GATEWAY) {
         println!(
             "R2 bucket {} retained (use --delete-bucket to remove)",
-            DEFAULT_STORAGE_BUCKET_NAME
+            storage_bucket_name
         );
     }
 
@@ -2948,6 +3059,7 @@ pub async fn print_deploy_status(
     account_id: &str,
     api_token: &str,
     components: &[String],
+    instance: &DeployInstance,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if components.is_empty() {
         return Err("No components requested for status".into());
@@ -2958,24 +3070,29 @@ pub async fn print_deploy_status(
 
     let client = reqwest::Client::new();
     let scripts = list_worker_scripts(&client, account_id, api_token).await?;
-    let gateway_script_name = if scripts.contains_key(SCRIPT_GATEWAY) {
-        Some(SCRIPT_GATEWAY.to_string())
-    } else if scripts.contains_key("gateway") {
-        Some("gateway".to_string())
+    let configured_gateway_script_name = instance
+        .script_name(COMPONENT_GATEWAY)
+        .ok_or("Unsupported gateway component")?;
+    let gateway_script_name = if instance.is_default()
+        && !scripts.contains_key(&configured_gateway_script_name)
+        && scripts.contains_key("gateway")
+    {
+        "gateway".to_string()
     } else {
-        None
+        configured_gateway_script_name
     };
 
     println!("\nWorkers:");
     for component in &component_order {
         let script_name = if component == COMPONENT_GATEWAY {
-            gateway_script_name.as_deref().unwrap_or(SCRIPT_GATEWAY)
+            gateway_script_name.clone()
         } else {
-            component_to_script_name(component)
+            instance
+                .script_name(component)
                 .ok_or_else(|| format!("Unsupported component '{}'", component))?
         };
 
-        if let Some(migration_tag) = scripts.get(script_name) {
+        if let Some(migration_tag) = scripts.get(&script_name) {
             if let Some(tag) = migration_tag.as_deref() {
                 println!(
                     "  {:<18} {:<24} deployed (migration: {})",
@@ -2991,17 +3108,12 @@ pub async fn print_deploy_status(
 
     if component_order.iter().any(|c| c == COMPONENT_GATEWAY) {
         println!("\nShared infrastructure:");
-        let bucket_exists = r2_bucket_exists(
-            &client,
-            account_id,
-            api_token,
-            DEFAULT_STORAGE_BUCKET_NAME,
-            None,
-        )
-        .await?;
+        let storage_bucket_name = instance.storage_bucket_name();
+        let bucket_exists =
+            r2_bucket_exists(&client, account_id, api_token, &storage_bucket_name, None).await?;
         println!(
             "  r2 bucket {:<26} {}",
-            DEFAULT_STORAGE_BUCKET_NAME,
+            storage_bucket_name,
             if bucket_exists { "exists" } else { "missing" }
         );
     }
@@ -3189,13 +3301,17 @@ pub async fn set_discord_bot_token_secret(
     account_id: &str,
     api_token: &str,
     bot_token: &str,
+    instance: &DeployInstance,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
+    let script_name = instance
+        .script_name(COMPONENT_CHANNEL_DISCORD)
+        .ok_or("Unsupported Discord channel component")?;
     set_worker_secret(
         &client,
         account_id,
         api_token,
-        SCRIPT_CHANNEL_DISCORD,
+        &script_name,
         "DISCORD_BOT_TOKEN",
         bot_token,
     )
@@ -3206,13 +3322,17 @@ pub async fn set_telegram_bot_token_secret(
     account_id: &str,
     api_token: &str,
     bot_token: &str,
+    instance: &DeployInstance,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
+    let script_name = instance
+        .script_name(COMPONENT_CHANNEL_TELEGRAM)
+        .ok_or("Unsupported Telegram channel component")?;
     set_worker_secret(
         &client,
         account_id,
         api_token,
-        SCRIPT_CHANNEL_TELEGRAM,
+        &script_name,
         "TELEGRAM_BOT_TOKEN",
         bot_token,
     )
@@ -3383,6 +3503,55 @@ mod tests {
     }
 
     #[test]
+    fn deploy_instance_default_preserves_legacy_names() {
+        let instance = DeployInstance::parse("gsv").unwrap();
+
+        assert_eq!(instance.name(), "gsv");
+        assert_eq!(
+            instance.script_name(COMPONENT_GATEWAY).as_deref(),
+            Some("gsv")
+        );
+        assert_eq!(
+            instance.script_name(COMPONENT_RIPGIT).as_deref(),
+            Some("ripgit")
+        );
+        assert_eq!(
+            instance.script_name(COMPONENT_CHANNEL_WHATSAPP).as_deref(),
+            Some("gsv-channel-whatsapp")
+        );
+        assert_eq!(instance.storage_bucket_name(), "gsv-storage");
+    }
+
+    #[test]
+    fn deploy_instance_named_scopes_worker_and_bucket_names() {
+        let instance = DeployInstance::parse("gsv-personal").unwrap();
+
+        assert_eq!(
+            instance.script_name(COMPONENT_GATEWAY).as_deref(),
+            Some("gsv-personal")
+        );
+        assert_eq!(
+            instance.script_name(COMPONENT_RIPGIT).as_deref(),
+            Some("gsv-personal-ripgit")
+        );
+        assert_eq!(
+            instance.script_name(COMPONENT_CHANNEL_TELEGRAM).as_deref(),
+            Some("gsv-personal-channel-telegram")
+        );
+        assert_eq!(instance.storage_bucket_name(), "gsv-personal-storage");
+    }
+
+    #[test]
+    fn deploy_instance_rejects_invalid_names() {
+        for value in ["", "-gsv", "gsv-", "gsv_test", "GSV!"] {
+            assert!(
+                DeployInstance::parse(value).is_err(),
+                "expected invalid instance name: {value}"
+            );
+        }
+    }
+
+    #[test]
     fn parse_wrangler_config_supports_toml() {
         let config = parse_wrangler_config(
             Path::new("wrangler.toml"),
@@ -3429,6 +3598,7 @@ bindings = [{ name = "REPOSITORY", class_name = "Repository" }]
 
     #[test]
     fn build_upload_metadata_includes_worker_loader_bindings() {
+        let instance = DeployInstance::default();
         let bundle = PreparedBundle {
             bundle_dir: PathBuf::from("/tmp/gsv-test-bundle"),
             component: COMPONENT_GATEWAY.to_string(),
@@ -3459,6 +3629,7 @@ bindings = [{ name = "REPOSITORY", class_name = "Repository" }]
         let metadata = build_upload_metadata(
             &bundle,
             UploadMetadataOptions {
+                instance: &instance,
                 selected_components: &HashSet::new(),
                 available_scripts: &HashSet::new(),
                 account_subdomain: None,
@@ -3479,6 +3650,7 @@ bindings = [{ name = "REPOSITORY", class_name = "Repository" }]
 
     #[test]
     fn service_bindings_inject_telegram_gateway_binding_when_worker_available() {
+        let instance = DeployInstance::default();
         let bundle = PreparedBundle {
             bundle_dir: PathBuf::from("/tmp/gsv-test-bundle"),
             component: COMPONENT_GATEWAY.to_string(),
@@ -3504,7 +3676,8 @@ bindings = [{ name = "REPOSITORY", class_name = "Repository" }]
         };
 
         let available_scripts = HashSet::from([SCRIPT_CHANNEL_TELEGRAM.to_string()]);
-        let bindings = service_bindings_for_bundle(&bundle, &HashSet::new(), &available_scripts);
+        let bindings =
+            service_bindings_for_bundle(&bundle, &instance, &HashSet::new(), &available_scripts);
 
         assert!(bindings.iter().any(|binding| {
             binding.binding == "CHANNEL_TELEGRAM"
@@ -3514,7 +3687,108 @@ bindings = [{ name = "REPOSITORY", class_name = "Repository" }]
     }
 
     #[test]
+    fn service_bindings_use_instance_scoped_targets() {
+        let instance = DeployInstance::parse("gsv-personal").unwrap();
+        let bundle = PreparedBundle {
+            bundle_dir: PathBuf::from("/tmp/gsv-test-bundle"),
+            component: COMPONENT_GATEWAY.to_string(),
+            manifest: BundleManifest {
+                component: COMPONENT_GATEWAY.to_string(),
+                worker: WorkerManifest {
+                    entrypoint: "worker/index.js".to_string(),
+                    source_map: None,
+                    wrangler_config: None,
+                },
+                assets_dir: None,
+            },
+            wrangler: WranglerConfig {
+                name: SCRIPT_GATEWAY.to_string(),
+                compatibility_date: Some("2026-01-28".to_string()),
+                services: vec![
+                    WranglerServiceBinding {
+                        binding: "RIPGIT".to_string(),
+                        service: SCRIPT_RIPGIT.to_string(),
+                        environment: None,
+                        entrypoint: None,
+                    },
+                    WranglerServiceBinding {
+                        binding: "ASSEMBLER".to_string(),
+                        service: SCRIPT_ASSEMBLER.to_string(),
+                        environment: None,
+                        entrypoint: None,
+                    },
+                ],
+                ..WranglerConfig::default()
+            },
+            script_name: SCRIPT_GATEWAY.to_string(),
+            entrypoint_part_name: "worker/index.js".to_string(),
+            entrypoint_bytes: Vec::new(),
+            additional_modules: Vec::new(),
+            source_map: None,
+        };
+
+        let available_scripts = HashSet::from([
+            "gsv-personal-ripgit".to_string(),
+            "gsv-personal-assembler".to_string(),
+        ]);
+        let bindings =
+            service_bindings_for_bundle(&bundle, &instance, &HashSet::new(), &available_scripts);
+
+        assert!(
+            bindings
+                .iter()
+                .any(|binding| binding.binding == "RIPGIT"
+                    && binding.service == "gsv-personal-ripgit")
+        );
+        assert!(bindings.iter().any(|binding| {
+            binding.binding == "ASSEMBLER" && binding.service == "gsv-personal-assembler"
+        }));
+    }
+
+    #[test]
+    fn apply_instance_names_scopes_bundle_script_and_r2_bucket() {
+        let instance = DeployInstance::parse("gsv-work").unwrap();
+        let mut bundle = PreparedBundle {
+            bundle_dir: PathBuf::from("/tmp/gsv-test-bundle"),
+            component: COMPONENT_GATEWAY.to_string(),
+            manifest: BundleManifest {
+                component: COMPONENT_GATEWAY.to_string(),
+                worker: WorkerManifest {
+                    entrypoint: "worker/index.js".to_string(),
+                    source_map: None,
+                    wrangler_config: None,
+                },
+                assets_dir: None,
+            },
+            wrangler: WranglerConfig {
+                name: SCRIPT_GATEWAY.to_string(),
+                compatibility_date: Some("2026-01-28".to_string()),
+                r2_buckets: vec![WranglerR2BucketBinding {
+                    binding: "STORAGE".to_string(),
+                    bucket_name: Some(DEFAULT_STORAGE_BUCKET_NAME.to_string()),
+                    jurisdiction: None,
+                }],
+                ..WranglerConfig::default()
+            },
+            script_name: SCRIPT_GATEWAY.to_string(),
+            entrypoint_part_name: "worker/index.js".to_string(),
+            entrypoint_bytes: Vec::new(),
+            additional_modules: Vec::new(),
+            source_map: None,
+        };
+
+        apply_instance_names_to_bundle(&mut bundle, &instance).unwrap();
+
+        assert_eq!(bundle.script_name, "gsv-work");
+        assert_eq!(
+            bundle.wrangler.r2_buckets[0].bucket_name.as_deref(),
+            Some("gsv-work-storage")
+        );
+    }
+
+    #[test]
     fn service_bindings_skip_telegram_gateway_binding_when_worker_missing() {
+        let instance = DeployInstance::default();
         let bundle = PreparedBundle {
             bundle_dir: PathBuf::from("/tmp/gsv-test-bundle"),
             component: COMPONENT_GATEWAY.to_string(),
@@ -3539,7 +3813,8 @@ bindings = [{ name = "REPOSITORY", class_name = "Repository" }]
             source_map: None,
         };
 
-        let bindings = service_bindings_for_bundle(&bundle, &HashSet::new(), &HashSet::new());
+        let bindings =
+            service_bindings_for_bundle(&bundle, &instance, &HashSet::new(), &HashSet::new());
 
         assert!(!bindings
             .iter()
@@ -3548,6 +3823,7 @@ bindings = [{ name = "REPOSITORY", class_name = "Repository" }]
 
     #[test]
     fn build_upload_metadata_includes_telegram_webhook_url_binding() {
+        let instance = DeployInstance::default();
         let bundle = PreparedBundle {
             bundle_dir: PathBuf::from("/tmp/gsv-test-bundle"),
             component: COMPONENT_CHANNEL_TELEGRAM.to_string(),
@@ -3575,6 +3851,7 @@ bindings = [{ name = "REPOSITORY", class_name = "Repository" }]
         let metadata = build_upload_metadata(
             &bundle,
             UploadMetadataOptions {
+                instance: &instance,
                 selected_components: &HashSet::new(),
                 available_scripts: &HashSet::new(),
                 account_subdomain: Some("example-subdomain"),

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -40,6 +40,14 @@ const SCRIPT_RIPGIT: &str = "ripgit";
 const SCRIPT_CHANNEL_WHATSAPP: &str = "gsv-channel-whatsapp";
 const SCRIPT_CHANNEL_DISCORD: &str = "gsv-channel-discord";
 const SCRIPT_CHANNEL_TELEGRAM: &str = "gsv-channel-telegram";
+const RESERVED_NON_DEFAULT_INSTANCE_NAMES: &[&str] = &[SCRIPT_RIPGIT];
+const RESERVED_INSTANCE_NAME_SUFFIXES: &[&str] = &[
+    "-assembler",
+    "-ripgit",
+    "-channel-whatsapp",
+    "-channel-discord",
+    "-channel-telegram",
+];
 const DEV_RELEASE_TAG: &str = "dev";
 const WORKERS_SUBDOMAIN_API_DATE: &str = "2025-08-01";
 const CLOUDFLARE_MAX_ATTEMPTS: usize = 5;
@@ -131,6 +139,14 @@ fn normalize_instance_name(raw: &str) -> Result<String, Box<dyn std::error::Erro
         return Err(
             "GSV instance name must contain only lowercase letters, numbers, and '-'".into(),
         );
+    }
+    if normalized != DEFAULT_DEPLOY_INSTANCE
+        && (RESERVED_NON_DEFAULT_INSTANCE_NAMES.contains(&normalized.as_str())
+            || RESERVED_INSTANCE_NAME_SUFFIXES
+                .iter()
+                .any(|suffix| normalized.ends_with(suffix)))
+    {
+        return Err("GSV instance name would collide with generated component worker names".into());
     }
     Ok(normalized)
 }
@@ -3549,6 +3565,26 @@ mod tests {
                 "expected invalid instance name: {value}"
             );
         }
+    }
+
+    #[test]
+    fn deploy_instance_rejects_component_worker_collision_names() {
+        for value in [
+            "ripgit",
+            "team-ripgit",
+            "team-assembler",
+            "gsv-channel-whatsapp",
+            "team-channel-discord",
+            "team-channel-telegram",
+        ] {
+            assert!(
+                DeployInstance::parse(value).is_err(),
+                "expected reserved instance name: {value}"
+            );
+        }
+
+        assert!(DeployInstance::parse(DEFAULT_DEPLOY_INSTANCE).is_ok());
+        assert!(DeployInstance::parse("team-channel").is_ok());
     }
 
     #[test]

--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -40,8 +40,10 @@ The instance name scopes Worker script names, service binding targets, and the R
 bucket. The default `gsv` instance keeps existing resource names for
 compatibility, including `gsv`, `ripgit`, `gsv-assembler`, `gsv-channel-*`, and
 `gsv-storage`. A named instance uses names such as `gsv-work`,
-`gsv-work-ripgit`, and `gsv-work-storage`. `GSV_INSTANCE` can be used instead of
-passing `--instance` on every deploy, upgrade, or destroy command.
+`gsv-work-ripgit`, and `gsv-work-storage`. Non-default names cannot be `ripgit`
+or end with generated component suffixes such as `-ripgit`, `-assembler`, or
+`-channel-whatsapp`. `GSV_INSTANCE` can be used instead of passing `--instance`
+on every deploy, upgrade, or destroy command.
 
 The components are `ripgit`, `assembler`, `gateway`, `channel-whatsapp`,
 `channel-discord`, and `channel-telegram`. To deploy only a subset:

--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -28,6 +28,21 @@ Deploy all current components:
 gsv infra deploy --all
 ```
 
+By default this deploys the historical `gsv` instance. To run multiple GSVs in
+the same Cloudflare account, choose a distinct instance name:
+
+```bash
+gsv infra deploy --instance gsv-personal --all
+gsv infra deploy --instance gsv-work --all
+```
+
+The instance name scopes Worker script names, service binding targets, and the R2
+bucket. The default `gsv` instance keeps existing resource names for
+compatibility, including `gsv`, `ripgit`, `gsv-assembler`, `gsv-channel-*`, and
+`gsv-storage`. A named instance uses names such as `gsv-work`,
+`gsv-work-ripgit`, and `gsv-work-storage`. `GSV_INSTANCE` can be used instead of
+passing `--instance` on every deploy, upgrade, or destroy command.
+
 The components are `ripgit`, `assembler`, `gateway`, `channel-whatsapp`,
 `channel-discord`, and `channel-telegram`. To deploy only a subset:
 
@@ -117,11 +132,18 @@ Remove only selected components:
 gsv infra destroy -c channel-whatsapp
 ```
 
-Delete the shared R2 bucket only when you intend to destroy stored files,
+Delete the instance R2 bucket only when you intend to destroy stored files,
 artifacts, media, and archives:
 
 ```bash
 gsv infra destroy --all --delete-bucket --purge-bucket
+```
+
+For a named instance, pass the same instance name when upgrading or destroying:
+
+```bash
+gsv infra upgrade --instance gsv-work --all
+gsv infra destroy --instance gsv-work --all --delete-bucket --purge-bucket
 ```
 
 By default, destroy also tries to uninstall the local device daemon. Use

--- a/docs/how-to/manage-channels.md
+++ b/docs/how-to/manage-channels.md
@@ -14,6 +14,13 @@ gsv infra deploy -c channel-discord --discord-bot-token "$DISCORD_BOT_TOKEN"
 gsv infra deploy -c channel-telegram --telegram-bot-token "$TELEGRAM_BOT_TOKEN"
 ```
 
+If your GSV was deployed with a named instance, pass the same instance name or
+set `GSV_INSTANCE`:
+
+```bash
+gsv infra deploy --instance gsv-work -c channel-whatsapp
+```
+
 When adding Telegram to an existing installation, deploy or upgrade the gateway
 at the same time so it has the `CHANNEL_TELEGRAM` service binding:
 

--- a/docs/how-to/write-a-package-app.md
+++ b/docs/how-to/write-a-package-app.md
@@ -178,6 +178,9 @@ gsv infra deploy -c assembler -c gateway
 gsv packages sync
 ```
 
+For a named deployment, pass the same `--instance NAME` to the infrastructure
+deploy command.
+
 Treat package review like code review. Check requested Kernel syscalls,
 filesystem writes, shell usage, adapter behavior, and network assumptions before
 enabling non-builtin packages.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -207,9 +207,9 @@ the `pkg.sync` syscall and prints the resolved package commits.
 ## Infrastructure Commands
 
 ```bash
-gsv infra deploy [--version REF] [-c COMPONENT ... | --all] [--force-fetch]
-gsv infra upgrade [--version REF] [-c COMPONENT ... | --all] [--force-fetch]
-gsv infra destroy [-c COMPONENT ... | --all] [--delete-bucket] [--purge-bucket]
+gsv infra deploy [--instance NAME] [--version REF] [-c COMPONENT ... | --all] [--force-fetch]
+gsv infra upgrade [--instance NAME] [--version REF] [-c COMPONENT ... | --all] [--force-fetch]
+gsv infra destroy [--instance NAME] [-c COMPONENT ... | --all] [--delete-bucket] [--purge-bucket]
 ```
 
 Valid components are `ripgit`, `assembler`, `gateway`, `channel-whatsapp`,
@@ -223,10 +223,18 @@ Both accept `--bundle-dir PATH` for local bundles, `--api-token` or
 `CF_API_TOKEN`, `--account-id` or `CF_ACCOUNT_ID`, `--discord-bot-token` or
 `DISCORD_BOT_TOKEN`, and `--telegram-bot-token` or `TELEGRAM_BOT_TOKEN`.
 
-`destroy` tears down Workers. If no component or `--all` is supplied, it targets
-all components. `--delete-bucket` removes the shared R2 bucket; `--purge-bucket`
-must be combined with it. Unless `--keep-node` is passed, `destroy` also attempts
-to uninstall the local device service.
+`--instance NAME` or `GSV_INSTANCE` scopes Worker script names and the R2 bucket
+so multiple GSVs can coexist in one Cloudflare account. The default instance is
+`gsv`, which preserves the historical names: `gsv`, `ripgit`, `gsv-assembler`,
+`gsv-channel-*`, and `gsv-storage`. A named instance such as `gsv-personal`
+deploys `gsv-personal`, `gsv-personal-ripgit`,
+`gsv-personal-channel-whatsapp`, and `gsv-personal-storage`.
+
+`destroy` tears down Workers for the selected instance. If no component or
+`--all` is supplied, it targets all components. `--delete-bucket` removes that
+instance's R2 bucket; `--purge-bucket` must be combined with it. Unless
+`--keep-node` is passed, `destroy` also attempts to uninstall the local device
+service.
 
 ## Version
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -228,7 +228,9 @@ so multiple GSVs can coexist in one Cloudflare account. The default instance is
 `gsv`, which preserves the historical names: `gsv`, `ripgit`, `gsv-assembler`,
 `gsv-channel-*`, and `gsv-storage`. A named instance such as `gsv-personal`
 deploys `gsv-personal`, `gsv-personal-ripgit`,
-`gsv-personal-channel-whatsapp`, and `gsv-personal-storage`.
+`gsv-personal-channel-whatsapp`, and `gsv-personal-storage`. Non-default
+instance names cannot be `ripgit` or end with generated component suffixes such
+as `-ripgit`, `-assembler`, or `-channel-whatsapp`.
 
 `destroy` tears down Workers for the selected instance. If no component or
 `--all` is supplied, it targets all components. `--delete-bucket` removes that

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -32,7 +32,7 @@ Deploy the current Cloudflare components:
 gsv infra deploy --all
 ```
 
-This deploys the Gateway, Kernel-facing services, shared storage, and adapter
+This deploys the Gateway, Kernel-facing services, instance storage, and adapter
 Workers for WhatsApp and Discord. The command prints a Gateway URL such as:
 
 ```text
@@ -40,6 +40,13 @@ https://gsv.<your-subdomain>.workers.dev
 ```
 
 Open that URL in your browser.
+
+To deploy more than one GSV in the same Cloudflare account, give each deployment
+a unique instance prefix:
+
+```bash
+gsv infra deploy --instance gsv-personal --all
+```
 
 ## 2. Complete Web Setup
 

--- a/docs/tutorials/setting-up-a-channel.md
+++ b/docs/tutorials/setting-up-a-channel.md
@@ -21,6 +21,8 @@ gsv infra deploy -c channel-telegram --telegram-bot-token "$TELEGRAM_BOT_TOKEN"
 ```
 
 Deploying everything with `gsv infra deploy --all` includes all adapter Workers.
+If your deployment uses a named instance, pass the same `--instance NAME` or set
+`GSV_INSTANCE` for adapter deploys.
 
 ## 2. Connect WhatsApp
 


### PR DESCRIPTION
## Summary

- add a deploy instance model with `gsv` as the compatibility default
- scope Worker names, R2 buckets, service binding targets, destroy/status paths, and adapter secrets by instance
- document `--instance` and `GSV_INSTANCE` for running multiple GSV deployments in one Cloudflare account

## Validation

- `cargo fmt --manifest-path cli/Cargo.toml -- --check`
- `cargo test --manifest-path cli/Cargo.toml --no-default-features --features rustls`
- `git diff --check`