### PR TITLE
App socket transport

### DIFF
--- a/assembler/src/runtime.rs
+++ b/assembler/src/runtime.rs
@@ -404,7 +404,7 @@ function buildAppClient(env, props) {{
       return api.emitAppEvent(event, payload);
     }},
     async emitTo(clientId, event, payload) {{
-      return api.emitAppEvent(event, payload, clientId);
+      return api.emitAppEvent(event, payload, clientId, session?.sessionId);
     }},
   }};
 }}

--- a/assembler/src/runtime.rs
+++ b/assembler/src/runtime.rs
@@ -401,7 +401,7 @@ function buildAppClient(env, props) {{
   return {{
     ...(session ?? {{}}),
     async emit(event, payload) {{
-      return api.emitAppEvent(event, payload);
+      return api.emitAppEvent(event, payload, undefined, session?.sessionId);
     }},
     async emitTo(clientId, event, payload) {{
       return api.emitAppEvent(event, payload, clientId, session?.sessionId);

--- a/assembler/tests/assembly_artifact.rs
+++ b/assembler/tests/assembly_artifact.rs
@@ -377,6 +377,7 @@ fn builds_runtime_artifact_for_declarative_backend_and_commands() {
     assert!(wrapper.contains("function buildAppClient(env, props)"));
     assert!(wrapper.contains("typeof api.packageSqlExec !== \"function\""));
     assert!(wrapper.contains("async invoke(method, args)"));
+    assert!(wrapper.contains("api.emitAppEvent(event, payload, clientId, session?.sessionId)"));
     assert!(wrapper.contains("const api = env.GSV_API;"));
 }
 

--- a/assembler/tests/assembly_artifact.rs
+++ b/assembler/tests/assembly_artifact.rs
@@ -377,6 +377,7 @@ fn builds_runtime_artifact_for_declarative_backend_and_commands() {
     assert!(wrapper.contains("function buildAppClient(env, props)"));
     assert!(wrapper.contains("typeof api.packageSqlExec !== \"function\""));
     assert!(wrapper.contains("async invoke(method, args)"));
+    assert!(wrapper.contains("api.emitAppEvent(event, payload, undefined, session?.sessionId)"));
     assert!(wrapper.contains("api.emitAppEvent(event, payload, clientId, session?.sessionId)"));
     assert!(wrapper.contains("const api = env.GSV_API;"));
 }

--- a/builtin-packages/chat/src/app/app.tsx
+++ b/builtin-packages/chat/src/app/app.tsx
@@ -69,6 +69,7 @@ import {
 } from "./view-helpers";
 
 const HISTORY_PAGE_SIZE = 50;
+const SIGNAL_WATCH_RENEW_INTERVAL_MS = 60 * 60 * 1000;
 
 function historyTargetKey(target: Pick<ThreadContext, "pid" | "conversationId">): string {
   return `${target.pid}\n${target.conversationId || "default"}`;
@@ -407,7 +408,12 @@ export function App({ backend }: { backend: ChatBackend }) {
 
   useEffect(() => {
     if (active?.pid) {
-      void backend.watchProcessSignals({ pid: active.pid }).catch((error) => setHostError(formatError(error)));
+      const pid = active.pid;
+      const renewSignalWatch = () => {
+        void backend.watchProcessSignals({ pid }).catch((error) => setHostError(formatError(error)));
+      };
+      renewSignalWatch();
+      const renewTimer = window.setInterval(renewSignalWatch, SIGNAL_WATCH_RENEW_INTERVAL_MS);
       void loadConversations(active.pid);
       const historyKey = historyTargetKey(active);
       if (skipNextHistoryLoadRef.current === historyKey) {
@@ -416,7 +422,8 @@ export function App({ backend }: { backend: ChatBackend }) {
         void loadHistory(active);
       }
       return () => {
-        void backend.unwatchProcessSignals({ pid: active.pid }).catch(() => {});
+        window.clearInterval(renewTimer);
+        void backend.unwatchProcessSignals({ pid }).catch(() => {});
       };
     }
     void backend.unwatchProcessSignals({ pid: "" }).catch(() => {});

--- a/builtin-packages/chat/src/app/app.tsx
+++ b/builtin-packages/chat/src/app/app.tsx
@@ -69,7 +69,6 @@ import {
 } from "./view-helpers";
 
 const HISTORY_PAGE_SIZE = 50;
-const SIGNAL_WATCH_RENEW_INTERVAL_MS = 60 * 60 * 1000;
 
 function historyTargetKey(target: Pick<ThreadContext, "pid" | "conversationId">): string {
   return `${target.pid}\n${target.conversationId || "default"}`;
@@ -409,11 +408,7 @@ export function App({ backend }: { backend: ChatBackend }) {
   useEffect(() => {
     if (active?.pid) {
       const pid = active.pid;
-      const renewSignalWatch = () => {
-        void backend.watchProcessSignals({ pid }).catch((error) => setHostError(formatError(error)));
-      };
-      renewSignalWatch();
-      const renewTimer = window.setInterval(renewSignalWatch, SIGNAL_WATCH_RENEW_INTERVAL_MS);
+      void backend.watchProcessSignals({ pid }).catch((error) => setHostError(formatError(error)));
       void loadConversations(active.pid);
       const historyKey = historyTargetKey(active);
       if (skipNextHistoryLoadRef.current === historyKey) {
@@ -422,7 +417,6 @@ export function App({ backend }: { backend: ChatBackend }) {
         void loadHistory(active);
       }
       return () => {
-        window.clearInterval(renewTimer);
         void backend.unwatchProcessSignals({ pid }).catch(() => {});
       };
     }

--- a/builtin-packages/chat/src/app/hooks/useTargetProcessEvent.ts
+++ b/builtin-packages/chat/src/app/hooks/useTargetProcessEvent.ts
@@ -1,10 +1,11 @@
+import { getAppClientId } from "@gsv/package/host";
 import { useEffect } from "preact/hooks";
 import type { ThreadContext } from "../types";
 import { asRecord, asString, normalizeThreadContext } from "../view-helpers";
 
 const TARGET_CHAT_PROCESS_EVENT = "gsv:target-chat-process";
 const PENDING_TARGETS_KEY = "__gsvPendingChatProcessTargets";
-const WINDOW_ID = new URL(window.location.href).searchParams.get("windowId")?.trim() || "";
+const WINDOW_ID = getAppClientId();
 
 export function useTargetProcessEvent(onTarget: (target: ThreadContext) => void) {
   useEffect(() => {

--- a/builtin-packages/chat/src/backend/api.ts
+++ b/builtin-packages/chat/src/backend/api.ts
@@ -22,6 +22,7 @@ const CHAT_RUNTIME_SIGNALS = [
   "proc.run.hil.requested",
   "process.exit",
 ];
+const CHAT_RUNTIME_SIGNAL_WATCH_TTL_MS = 24 * 60 * 60 * 1000;
 
 function normalizeArgs(value: unknown) {
   return value && typeof value === "object" ? value as Record<string, unknown> : {};
@@ -221,6 +222,7 @@ export async function watchProcessSignals(kernel: KernelClient, app: AppBinding 
     key: buildSignalWatchKey(clientId, pid, signal),
     state: { clientId, pid },
     once: false,
+    ttlMs: CHAT_RUNTIME_SIGNAL_WATCH_TTL_MS,
   })));
   return {
     pid,

--- a/builtin-packages/chat/src/backend/api.ts
+++ b/builtin-packages/chat/src/backend/api.ts
@@ -9,6 +9,7 @@ type ViewerRuntime = {
 };
 
 type AppBinding = {
+  sessionId?: string;
   clientId?: string;
 };
 
@@ -22,8 +23,6 @@ const CHAT_RUNTIME_SIGNALS = [
   "proc.run.hil.requested",
   "process.exit",
 ];
-const CHAT_RUNTIME_SIGNAL_WATCH_TTL_MS = 24 * 60 * 60 * 1000;
-
 function normalizeArgs(value: unknown) {
   return value && typeof value === "object" ? value as Record<string, unknown> : {};
 }
@@ -40,8 +39,8 @@ function normalizeLimit(value: unknown, fallback = 50) {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
 }
 
-function buildSignalWatchKey(clientId: string, pid: string, signal: string) {
-  return `chat:${clientId}:${pid}:${signal}`;
+function buildSignalWatchKey(sessionId: string, clientId: string, pid: string, signal: string) {
+  return `chat:${sessionId}:${clientId}:${pid}:${signal}`;
 }
 
 export async function listProfiles(kernel: KernelClient, input: unknown) {
@@ -212,17 +211,18 @@ export async function watchProcessSignals(kernel: KernelClient, app: AppBinding 
   if (!pid) {
     throw new Error("pid is required");
   }
+  const sessionId = normalizeClientId(app?.sessionId);
   const clientId = normalizeClientId(app?.clientId);
-  if (!clientId) {
+  if (!sessionId || !clientId) {
     throw new Error("client signal watch requires an app session");
   }
   await Promise.all(CHAT_RUNTIME_SIGNALS.map((signal) => kernel.request("signal.watch", {
     signal,
     processId: pid,
-    key: buildSignalWatchKey(clientId, pid, signal),
-    state: { clientId, pid },
+    key: buildSignalWatchKey(sessionId, clientId, pid, signal),
+    owner: { appSessionId: sessionId, clientId },
+    state: { appSessionId: sessionId, clientId, pid },
     once: false,
-    ttlMs: CHAT_RUNTIME_SIGNAL_WATCH_TTL_MS,
   })));
   return {
     pid,
@@ -235,14 +235,16 @@ export async function unwatchProcessSignals(kernel: KernelClient, app: AppBindin
   if (!pid) {
     return { pid: "", removed: 0 };
   }
+  const sessionId = normalizeClientId(app?.sessionId);
   const clientId = normalizeClientId(app?.clientId);
-  if (!clientId) {
+  if (!sessionId || !clientId) {
     return { pid, removed: 0 };
   }
   let removed = 0;
   await Promise.all(CHAT_RUNTIME_SIGNALS.map(async (signal) => {
     const result = await kernel.request("signal.unwatch", {
-      key: buildSignalWatchKey(clientId, pid, signal),
+      key: buildSignalWatchKey(sessionId, clientId, pid, signal),
+      owner: { appSessionId: sessionId, clientId },
     });
     const count = result && typeof result === "object" && "removed" in result && typeof result.removed === "number"
       ? result.removed

--- a/builtin-packages/files/src/app/app.tsx
+++ b/builtin-packages/files/src/app/app.tsx
@@ -1,4 +1,4 @@
-import { consumePendingAppOpen } from "@gsv/package/host";
+import { consumePendingAppOpen, getAppClientId } from "@gsv/package/host";
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { Stage } from "./stage";
 import { Toolbar } from "./toolbar";
@@ -31,30 +31,28 @@ function readLaunchUrl(): URL {
     return current;
   }
 
-  const currentHasWindowId = current.searchParams.has("windowId");
   const currentHasExplicitState =
     current.searchParams.has("path")
     || current.searchParams.has("open")
     || current.searchParams.has("q")
     || current.searchParams.has("target");
-  if (currentHasWindowId && currentHasExplicitState) {
+  if (currentHasExplicitState) {
     return current;
   }
 
-  const frameHasWindowId = frame.searchParams.has("windowId");
   const frameHasExplicitState =
     frame.searchParams.has("path")
     || frame.searchParams.has("open")
     || frame.searchParams.has("q")
     || frame.searchParams.has("target");
-  if (!frameHasWindowId && !frameHasExplicitState) {
+  if (!frameHasExplicitState) {
     return current;
   }
 
   return frame;
 }
 
-const WINDOW_ID = readLaunchUrl().searchParams.get("windowId")?.trim() || "";
+const WINDOW_ID = getAppClientId();
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : null;

--- a/builtin-packages/shell/src/route-context.ts
+++ b/builtin-packages/shell/src/route-context.ts
@@ -1,4 +1,4 @@
-import { consumePendingAppOpen } from "@gsv/package/host";
+import { consumePendingAppOpen, getAppClientId } from "@gsv/package/host";
 import type { ShellRoute } from "./types";
 
 export function readLaunchUrl(): URL {
@@ -8,15 +8,13 @@ export function readLaunchUrl(): URL {
     return current;
   }
 
-  const currentHasWindowId = current.searchParams.has("windowId");
   const currentHasExplicitState = hasExplicitShellState(current);
-  if (currentHasWindowId && currentHasExplicitState) {
+  if (currentHasExplicitState) {
     return current;
   }
 
-  const frameHasWindowId = frame.searchParams.has("windowId");
   const frameHasExplicitState = hasExplicitShellState(frame);
-  if (!frameHasWindowId && !frameHasExplicitState) {
+  if (!frameHasExplicitState) {
     return current;
   }
 
@@ -24,7 +22,7 @@ export function readLaunchUrl(): URL {
 }
 
 export function readWindowId(): string {
-  return readLaunchUrl().searchParams.get("windowId")?.trim() || "";
+  return getAppClientId();
 }
 
 export function readRouteParams(windowId: string): ShellRoute {

--- a/builtin-packages/wiki/main.tsx
+++ b/builtin-packages/wiki/main.tsx
@@ -1,5 +1,5 @@
 import { render } from "preact";
-import { getBackend } from "@gsv/package/browser";
+import { getAppBoot, getBackend } from "@gsv/package/browser";
 import { App } from "./src/app/app";
 import type { WikiBackend } from "./src/app/types";
 
@@ -9,8 +9,9 @@ async function boot(): Promise<void> {
   if (!root) {
     throw new Error("wiki root missing");
   }
+  const boot = getAppBoot();
   const backend = await getBackend<WikiBackend>();
-  render(<App backend={backend} />, root);
+  render(<App backend={backend} routeBase={boot.routeBase} />, root);
 }
 
 void boot().catch((error) => {

--- a/builtin-packages/wiki/src/app/app.tsx
+++ b/builtin-packages/wiki/src/app/app.tsx
@@ -32,7 +32,7 @@ const EMPTY_STATE: WikiWorkspaceState = {
   errorText: "",
 };
 
-export function App({ backend }: { backend: WikiBackend }) {
+export function App({ backend, routeBase }: { backend: WikiBackend; routeBase: string }) {
   const [mode, setMode] = useState<WikiMode>(readMode());
   const [route, setRoute] = useState(readRoute());
   const [state, setState] = useState<WikiWorkspaceState>(EMPTY_STATE);
@@ -318,6 +318,7 @@ export function App({ backend }: { backend: WikiBackend }) {
       <div class="wiki-layout">
         <WikiRail
           mode={mode}
+          routeBase={routeBase}
           onChangeMode={changeMode}
           state={state}
           route={route}
@@ -354,6 +355,7 @@ export function App({ backend }: { backend: WikiBackend }) {
                 <BrowsePane
                   state={state}
                   currentTitle={currentTitle}
+                  routeBase={routeBase}
                   selectedDb={selectedDb}
                   onOpenPage={openPage}
                   onPreviewOpen={handleArticlePreviewOpen}
@@ -423,6 +425,7 @@ export function App({ backend }: { backend: WikiBackend }) {
               {mode === "inbox" ? (
                 <InboxPane
                   state={state}
+                  routeBase={routeBase}
                   selectedDb={selectedDb}
                   selectedInboxPath={selectedInboxPath}
                   mutating={mutating}

--- a/builtin-packages/wiki/src/app/components/navigation/wiki-rail.tsx
+++ b/builtin-packages/wiki/src/app/components/navigation/wiki-rail.tsx
@@ -6,6 +6,7 @@ import { WikiIcon, type WikiIconName } from "../ui/wiki-icon";
 
 type Props = {
   mode: WikiMode;
+  routeBase: string;
   onChangeMode(mode: WikiMode): void;
   state: WikiWorkspaceState;
   route: WikiRoute;
@@ -151,6 +152,7 @@ export function WikiRail(props: Props) {
           </div>
           <PageList
             entries={props.visiblePages}
+            routeBase={props.routeBase}
             selectedPath={props.state.selectedPath}
             selectedDb={props.selectedDb}
             onOpenPage={props.onOpenPage}
@@ -176,6 +178,7 @@ export function WikiRail(props: Props) {
           </div>
           <PageList
             entries={props.state.inbox}
+            routeBase={props.routeBase}
             selectedPath={props.selectedInboxPath}
             selectedDb={props.selectedDb}
             onOpenPage={props.onOpenInboxNote}
@@ -189,12 +192,14 @@ export function WikiRail(props: Props) {
 
 function PageList({
   entries,
+  routeBase,
   selectedPath,
   selectedDb,
   onOpenPage,
   emptyText,
 }: {
   entries: WikiEntry[];
+  routeBase: string;
   selectedPath: string;
   selectedDb: string;
   onOpenPage(path: string): void;
@@ -209,7 +214,7 @@ function PageList({
       {entries.map((entry) => (
         <a
           key={entry.path}
-          href={buildEntryHref("/apps/wiki", selectedDb, entry.path)}
+          href={buildEntryHref(routeBase, selectedDb, entry.path)}
           class={`wiki-entry-row${selectedPath === entry.path ? " is-active" : ""}`}
           onClick={(event) => {
             event.preventDefault();

--- a/builtin-packages/wiki/src/app/components/panes/browse-pane.tsx
+++ b/builtin-packages/wiki/src/app/components/panes/browse-pane.tsx
@@ -4,6 +4,7 @@ import type { WikiPreviewRequest, WikiWorkspaceState } from "../../types";
 type Props = {
   state: WikiWorkspaceState;
   currentTitle: string;
+  routeBase: string;
   selectedDb: string;
   onOpenPage(path: string): void;
   onPreviewOpen(anchor: HTMLElement, request: WikiPreviewRequest, pin: boolean): void;
@@ -22,7 +23,7 @@ export function BrowsePane(props: Props) {
       <ArticleView
         markdown={props.state.selectedNote?.markdown || ""}
         articleTitle={props.currentTitle || "Untitled"}
-        routeBase="/apps/wiki"
+        routeBase={props.routeBase}
         selectedDb={props.selectedDb}
         selectedPath={props.state.selectedPath}
         onNavigate={props.onOpenPage}

--- a/builtin-packages/wiki/src/app/components/panes/inbox-pane.tsx
+++ b/builtin-packages/wiki/src/app/components/panes/inbox-pane.tsx
@@ -4,6 +4,7 @@ import type { WikiPreviewRequest, WikiWorkspaceState } from "../../types";
 
 type Props = {
   state: WikiWorkspaceState;
+  routeBase: string;
   selectedDb: string;
   selectedInboxPath: string;
   mutating: boolean;
@@ -29,7 +30,7 @@ export function InboxPane(props: Props) {
         <ArticleView
           markdown={props.state.selectedNote.markdown || ""}
           articleTitle={extractTitle(props.state.selectedNote.markdown || "", props.state.selectedNote.path)}
-          routeBase="/apps/wiki"
+          routeBase={props.routeBase}
           selectedDb={props.selectedDb}
           selectedPath={props.state.selectedPath}
           onNavigate={props.onOpenPageAndBrowse}

--- a/docs/explanation/process-ipc-and-scheduler.md
+++ b/docs/explanation/process-ipc-and-scheduler.md
@@ -471,7 +471,8 @@ Completed initial cleanup:
 - removed archivist/curator default profile config
 - removed archivist/curator profile list entries
 
-Keep the existing `SignalFrame` protocol and `signal.watch` behavior unchanged.
+Keep the existing `SignalFrame` protocol. `signal.watch` remains the durable
+watch primitive, with app-session/client owner scoping added for UI watches.
 
 ### 2. Add process event and conversation types
 

--- a/docs/how-to/write-a-package-app.md
+++ b/docs/how-to/write-a-package-app.md
@@ -124,8 +124,8 @@ function App() {
 render(<App />, document.getElementById("root")!);
 ```
 
-`connectBackend()` caches a stable RPC proxy and retries once after a transport
-disconnect.
+`connectBackend()` caches a stable RPC proxy and retries once after the app
+socket disconnects.
 
 ## Add a CLI Command
 

--- a/docs/reference/package-sdk.md
+++ b/docs/reference/package-sdk.md
@@ -108,6 +108,10 @@ type PackageAppBoot = {
 };
 ```
 
+`rpcBase` is the platform app-socket endpoint used by the browser SDK. Package
+apps should treat it as opaque and use `connectBackend()` instead of speaking
+the wire protocol directly.
+
 ### `hasAppBoot()`
 
 Returns `true` when the package boot payload is present.
@@ -118,7 +122,7 @@ Connects to the package backend RPC surface and returns a stable proxy.
 
 Behavior:
 
-- opens the backend websocket session on first use
+- opens the backend app-socket session on first use
 - caches the backend proxy for reuse
 - reconnects automatically on transport disconnect and retries the failed call
   once
@@ -127,6 +131,12 @@ Behavior:
 ### `getBackend<T>()`
 
 Alias for `connectBackend<T>()`.
+
+### `onAppEvent(listener)`
+
+Subscribes to app events emitted by the backend with `this.app.emit(...)` or
+`this.app.emitTo(...)`. Events are delivered over the same app socket used by
+backend RPC.
 
 ## CLI
 

--- a/docs/reference/package-sdk.md
+++ b/docs/reference/package-sdk.md
@@ -101,16 +101,17 @@ type PackageAppBoot = {
   routeBase: string;
   rpcBase: string;
   sessionId: string;
-  sessionSecret: string;
   clientId: string;
   expiresAt: number;
   hasBackend: boolean;
 };
 ```
 
-`rpcBase` is the platform app-socket endpoint used by the browser SDK. Package
-apps should treat it as opaque and use `connectBackend()` instead of speaking
-the wire protocol directly.
+`routeBase` is the mounted app-session route for the current app instance.
+`rpcBase` is the platform app-socket endpoint under that session mount.
+Package apps should treat it as opaque and use `connectBackend()` instead of
+speaking the wire protocol directly. App session credentials are carried in
+HttpOnly cookies and are not exposed to package JavaScript.
 
 ### `hasAppBoot()`
 

--- a/docs/reference/r2-storage.md
+++ b/docs/reference/r2-storage.md
@@ -47,7 +47,7 @@ Kernel SQLite is the authoritative control-plane store. Important tables include
 | `packages` | Installed package manifests, scopes, grants, and artifact hashes. |
 | `identity_links`, `surface_routes`, `link_challenges` | Adapter actor links and inbound surface routing. |
 | `run_routes` | Routes process run signals back to clients or adapter surfaces. |
-| `notifications`, `signal_watches`, `app_client_sessions` | Notifications, watches, and package UI sessions. |
+| `notifications`, `signal_watches`, `app_client_sessions`, `app_client_session_keys` | Notifications, watches, package UI sessions, and additional app launch/session keys. |
 
 ## Process SQLite
 

--- a/docs/reference/r2-storage.md
+++ b/docs/reference/r2-storage.md
@@ -47,7 +47,7 @@ Kernel SQLite is the authoritative control-plane store. Important tables include
 | `packages` | Installed package manifests, scopes, grants, and artifact hashes. |
 | `identity_links`, `surface_routes`, `link_challenges` | Adapter actor links and inbound surface routing. |
 | `run_routes` | Routes process run signals back to clients or adapter surfaces. |
-| `notifications`, `signal_watches`, `app_client_sessions`, `app_client_session_keys` | Notifications, watches, package UI sessions, and additional app launch/session keys. |
+| `notifications`, `signal_watches`, `app_sessions`, `app_session_clients`, `app_session_client_keys` | Notifications, watches, package UI sessions, attached app clients, and per-client launch/session keys. |
 
 ## Process SQLite
 

--- a/docs/reference/syscalls.md
+++ b/docs/reference/syscalls.md
@@ -390,16 +390,18 @@ return output;
 
 App session syscalls are Kernel-owned. They let any authenticated app host open
 or reattach a package UI without knowing the Web shell route conventions.
-Launch results contain a URL under `/apps/sessions/<sid>/launch`; the gateway
-validates that launch token, sets the HttpOnly app-session cookie, and redirects
-to the canonical `/apps/sessions/<sid>/...` runtime namespace.
+Launch results contain a secret-free URL under
+`/apps/sessions/<sid>/clients/<clientId>/...` plus a launch token. The app host
+POSTs that token to `/apps/sessions/<sid>/launch` before navigating the client
+URL. The gateway validates the token and sets an HttpOnly cookie scoped to the
+specific app client path.
 
 Runtime behavior:
 
 | Syscall | Handler | Behavior |
 |---|---|---|
-| `app.open` | `handleAppOpen` | Resolves an enabled web-ui package and UI entrypoint visible to the current user, creates an app session with one app client, and returns a launch URL plus window defaults. |
-| `app.attach` | `handleAppAttach` | Attaches a new app client to an existing current-user app session and returns a fresh launch URL. Existing app clients are not invalidated. |
+| `app.open` | `handleAppOpen` | Resolves an enabled web-ui package and UI entrypoint visible to the current user, creates an app session with one app client, and returns a client launch URL, launch token, and window defaults. |
+| `app.attach` | `handleAppAttach` | Attaches a new app client to an existing current-user app session and returns a fresh client launch URL and launch token. Existing app clients are not invalidated. |
 | `app.list` | `handleAppList` | Lists active app sessions for the current user. Secrets are never returned. |
 | `app.detach` | `handleAppDetach` | Detaches one app client from a current-user app session, removes that client's watches, revokes that client's launch keys, and asks the AppRunner to close that client's live socket. |
 | `app.close` | `handleAppClose` | Closes a current-user app session, revokes its launch keys, and asks the AppRunner to close live app sockets for that session. |
@@ -408,12 +410,12 @@ Runtime behavior:
 type AppSyscalls = {
   "app.open": {
     args: { packageName: string; entrypointName?: string; clientId?: string; suffix?: string; search?: string; hash?: string };
-    result: { sessionId: string; packageId: string; packageName: string; entrypointName: string; routeBase: string; clientId: string; launchUrl: string; expiresAt: number; window: AppLaunchWindowHint };
+    result: { sessionId: string; packageId: string; packageName: string; entrypointName: string; routeBase: string; clientId: string; launchUrl: string; launchToken: string; expiresAt: number; window: AppLaunchWindowHint };
   };
 
   "app.attach": {
     args: { sessionId: string; clientId?: string; suffix?: string; search?: string; hash?: string };
-    result: { sessionId: string; packageId: string; packageName: string; entrypointName: string; routeBase: string; clientId: string; launchUrl: string; expiresAt: number; window: AppLaunchWindowHint };
+    result: { sessionId: string; packageId: string; packageName: string; entrypointName: string; routeBase: string; clientId: string; launchUrl: string; launchToken: string; expiresAt: number; window: AppLaunchWindowHint };
   };
 
   "app.list": {

--- a/docs/reference/syscalls.md
+++ b/docs/reference/syscalls.md
@@ -401,6 +401,7 @@ Runtime behavior:
 | `app.open` | `handleAppOpen` | Resolves an enabled web-ui package and UI entrypoint visible to the current user, creates an app session with one app client, and returns a launch URL plus window defaults. |
 | `app.attach` | `handleAppAttach` | Attaches a new app client to an existing current-user app session and returns a fresh launch URL. Existing app clients are not invalidated. |
 | `app.list` | `handleAppList` | Lists active app sessions for the current user. Secrets are never returned. |
+| `app.detach` | `handleAppDetach` | Detaches one app client from a current-user app session, removes that client's watches, revokes that client's launch keys, and asks the AppRunner to close that client's live socket. |
 | `app.close` | `handleAppClose` | Closes a current-user app session, revokes its launch keys, and asks the AppRunner to close live app sockets for that session. |
 
 ```ts
@@ -418,6 +419,11 @@ type AppSyscalls = {
   "app.list": {
     args: Empty;
     result: { sessions: AppSessionSummary[] };
+  };
+
+  "app.detach": {
+    args: { sessionId: string; clientId: string };
+    result: { detached: boolean };
   };
 
   "app.close": {

--- a/docs/reference/syscalls.md
+++ b/docs/reference/syscalls.md
@@ -122,17 +122,28 @@ type AppLaunchWindowHint = {
   minHeight?: number;
 };
 
+type AppSessionState = "active" | "detached" | "closing" | "closed" | "expired";
+type AppSessionClientState = "active" | "closed" | "expired";
+
+type AppSessionClientSummary = {
+  clientId: string;
+  createdAt: number;
+  lastUsedAt: number | null;
+  expiresAt: number;
+  state: AppSessionClientState;
+};
+
 type AppSessionSummary = {
   sessionId: string;
   packageId: string;
   packageName: string;
   entrypointName: string;
   routeBase: string;
-  clientId: string;
   createdAt: number;
   lastUsedAt: number | null;
   expiresAt: number;
-  state: "active";
+  state: AppSessionState;
+  clients: AppSessionClientSummary[];
 };
 
 type ConnectionIdentity =
@@ -387,10 +398,10 @@ Runtime behavior:
 
 | Syscall | Handler | Behavior |
 |---|---|---|
-| `app.open` | `handleAppOpen` | Resolves an enabled web-ui package and UI entrypoint visible to the current user, creates an app session, and returns a launch URL plus window defaults. |
-| `app.attach` | `handleAppAttach` | Mints a fresh launch secret for an existing current-user app session and returns a launch URL. Existing app clients are not invalidated. |
+| `app.open` | `handleAppOpen` | Resolves an enabled web-ui package and UI entrypoint visible to the current user, creates an app session with one app client, and returns a launch URL plus window defaults. |
+| `app.attach` | `handleAppAttach` | Attaches a new app client to an existing current-user app session and returns a fresh launch URL. Existing app clients are not invalidated. |
 | `app.list` | `handleAppList` | Lists active app sessions for the current user. Secrets are never returned. |
-| `app.close` | `handleAppClose` | Revokes a current-user app session and its additional launch keys. |
+| `app.close` | `handleAppClose` | Closes a current-user app session, revokes its launch keys, and asks the AppRunner to close live app sockets for that session. |
 
 ```ts
 type AppSyscalls = {
@@ -400,7 +411,7 @@ type AppSyscalls = {
   };
 
   "app.attach": {
-    args: { sessionId: string; suffix?: string; search?: string; hash?: string };
+    args: { sessionId: string; clientId?: string; suffix?: string; search?: string; hash?: string };
     result: { sessionId: string; packageId: string; packageName: string; entrypointName: string; routeBase: string; clientId: string; launchUrl: string; expiresAt: number; window: AppLaunchWindowHint };
   };
 

--- a/docs/reference/syscalls.md
+++ b/docs/reference/syscalls.md
@@ -114,6 +114,27 @@ type BootstrapPackageSummary = {
   }>;
 };
 
+type AppLaunchWindowHint = {
+  title: string;
+  width?: number;
+  height?: number;
+  minWidth?: number;
+  minHeight?: number;
+};
+
+type AppSessionSummary = {
+  sessionId: string;
+  packageId: string;
+  packageName: string;
+  entrypointName: string;
+  routeBase: string;
+  clientId: string;
+  createdAt: number;
+  lastUsedAt: number | null;
+  expiresAt: number;
+  state: "active";
+};
+
 type ConnectionIdentity =
   | { role: "user"; process: ProcessIdentity; capabilities: string[] }
   | { role: "driver"; process: ProcessIdentity; capabilities: string[]; device: string; implements: string[] }
@@ -352,6 +373,47 @@ while (res.status === "running") {
 }
 
 return output;
+```
+
+## App Sessions: `app.*`
+
+App session syscalls are Kernel-owned. They let any authenticated app host open
+or reattach a package UI without knowing the Web shell route conventions.
+Launch results contain a URL under `/apps/sessions/<sid>/launch`; the gateway
+validates that launch token, sets the HttpOnly app-session cookie, and redirects
+to the canonical `/apps/sessions/<sid>/...` runtime namespace.
+
+Runtime behavior:
+
+| Syscall | Handler | Behavior |
+|---|---|---|
+| `app.open` | `handleAppOpen` | Resolves an enabled web-ui package and UI entrypoint visible to the current user, creates an app session, and returns a launch URL plus window defaults. |
+| `app.attach` | `handleAppAttach` | Mints a fresh launch secret for an existing current-user app session and returns a launch URL. Existing app clients are not invalidated. |
+| `app.list` | `handleAppList` | Lists active app sessions for the current user. Secrets are never returned. |
+| `app.close` | `handleAppClose` | Revokes a current-user app session and its additional launch keys. |
+
+```ts
+type AppSyscalls = {
+  "app.open": {
+    args: { packageName: string; entrypointName?: string; clientId?: string; suffix?: string; search?: string; hash?: string };
+    result: { sessionId: string; packageId: string; packageName: string; entrypointName: string; routeBase: string; clientId: string; launchUrl: string; expiresAt: number; window: AppLaunchWindowHint };
+  };
+
+  "app.attach": {
+    args: { sessionId: string; suffix?: string; search?: string; hash?: string };
+    result: { sessionId: string; packageId: string; packageName: string; entrypointName: string; routeBase: string; clientId: string; launchUrl: string; expiresAt: number; window: AppLaunchWindowHint };
+  };
+
+  "app.list": {
+    args: Empty;
+    result: { sessions: AppSessionSummary[] };
+  };
+
+  "app.close": {
+    args: { sessionId: string };
+    result: { closed: boolean };
+  };
+};
 ```
 
 ## CodeMode: `codemode.exec`, `codemode.run`

--- a/docs/reference/syscalls.md
+++ b/docs/reference/syscalls.md
@@ -1241,10 +1241,13 @@ Runtime behavior:
 | `notification.list` | `handleNotificationList` | Prunes expired notifications, then lists current user notifications. Defaults include read notifications, exclude dismissed notifications, and limit to 100; limit clamps to 1-500. |
 | `notification.mark_read` | `handleNotificationMarkRead` | Marks a current-user notification read if found and resets expiry to seven days. Missing, expired, or wrong-user ids return `notification: null`. Broadcasts update when found. |
 | `notification.dismiss` | `handleNotificationDismiss` | Marks a current-user notification dismissed and expires it after three days. Missing ids return `notification: null`. Broadcasts dismissal when found. |
-| `signal.watch` | `handleSignalWatch` | App/process-originated only. Creates or upserts a durable signal watch. Requires non-empty signal; TTL defaults to 24 hours and clamps to 1 second through 30 days; `once` defaults true. Process runtimes must pass an explicit `processId` and cannot watch themselves. |
-| `signal.unwatch` | `handleSignalUnwatch` | App/process-originated only. Removes watches for the current app entrypoint or target process by `watchId` or `key`. Returns number removed. |
+| `signal.watch` | `handleSignalWatch` | App/process-originated only. Creates or upserts a durable signal watch. Requires non-empty signal; TTL defaults to 24 hours and clamps to 1 second through 30 days; `once` defaults true. App runtimes may pass an `owner` for an active app session/client, in which case the watch is removed on app close and has no silent expiry unless `ttlMs` is explicitly set. Process runtimes must pass an explicit `processId` and cannot watch themselves. |
+| `signal.unwatch` | `handleSignalUnwatch` | App/process-originated only. Removes watches for the current app entrypoint/session client or target process by `watchId` or `key`. Returns number removed. |
 
 Signal watch delivery is handled by the kernel when matching signals are emitted. Once-watches are deleted after successful handling; failed deliveries mark the watch failed.
+For app-owned watches, `owner` is validated against Kernel app sessions and
+contains `{ appSessionId, clientId }`. `signal.unwatch` should pass the same
+owner when removing an app-client scoped watch.
 
 ```ts
 type NotificationAndSignalSyscalls = {
@@ -1269,12 +1272,14 @@ type NotificationAndSignalSyscalls = {
   };
 
   "signal.watch": {
-    args: { signal: string; processId?: string; key?: string; state?: unknown; once?: boolean; ttlMs?: number };
+    args: { signal: string; processId?: string; key?: string; state?: unknown; owner?: { appSessionId: string; clientId: string }; once?: boolean; ttlMs?: number };
     result: { watchId: string; created: boolean; createdAt: number; expiresAt: number | null };
   };
 
   "signal.unwatch": {
-    args: { watchId: string; key?: never } | { watchId?: never; key: string };
+    args:
+      | { watchId: string; key?: never; owner?: { appSessionId: string; clientId: string } }
+      | { watchId?: never; key: string; owner?: { appSessionId: string; clientId: string } };
     result: { removed: number };
   };
 };

--- a/gateway/package-lock.json
+++ b/gateway/package-lock.json
@@ -12,7 +12,6 @@
         "@earendil-works/pi-ai": "^0.74.0",
         "@gsv/protocol": "file:../shared/protocol",
         "agents": "^0.10.2",
-        "capnweb": "^0.6.1",
         "just-bash": "^2.12.6",
         "marked": "^16.4.2"
       },
@@ -6066,12 +6065,6 @@
       ],
       "license": "CC-BY-4.0",
       "peer": true
-    },
-    "node_modules/capnweb": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/capnweb/-/capnweb-0.6.1.tgz",
-      "integrity": "sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg==",
-      "license": "MIT"
     },
     "node_modules/chai": {
       "version": "5.3.3",

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -24,7 +24,6 @@
     "@earendil-works/pi-ai": "^0.74.0",
     "@gsv/protocol": "file:../shared/protocol",
     "agents": "^0.10.2",
-    "capnweb": "^0.6.1",
     "just-bash": "^2.12.6",
     "marked": "^16.4.2"
   }

--- a/gateway/src/app-runner.ts
+++ b/gateway/src/app-runner.ts
@@ -502,9 +502,7 @@ export class AppRunner extends DurableObject<Env> {
       });
     }
 
-    const pair = new WebSocketPair();
-    const server = pair[0];
-    const client = pair[1];
+    const [client, server] = Object.values(new WebSocketPair());
     this.ctx.acceptWebSocket(server, [APP_SOCKET_TAG]);
     this.#registerAppSocket(server, context.session, context.appFrame);
     return new Response(null, {
@@ -649,7 +647,9 @@ export class AppRunner extends DurableObject<Env> {
       const registration = this.appClients.get(key);
       targets = registration ? [[key, registration]] : [];
     } else {
-      targets = [...this.appClients.entries()];
+      targets = sessionId
+        ? [...this.appClients.entries()].filter(([, registration]) => registration.session.sessionId === sessionId)
+        : [...this.appClients.entries()];
     }
     let delivered = 0;
     for (const [key, registration] of targets) {

--- a/gateway/src/app-runner.ts
+++ b/gateway/src/app-runner.ts
@@ -31,6 +31,7 @@ type AppRunnerSignalInput = {
   payload?: unknown;
   sourcePid?: string | null;
   watch: PackageAppSignalWatchInfo;
+  appSession?: AppSessionInfo;
 };
 
 type AppSessionInfo = {
@@ -569,6 +570,10 @@ export class AppRunner extends DurableObject<Env> {
   }
 
   #runtimeForSignal(input: AppRunnerSignalInput): AppRuntimeContext {
+    if (this.#isAppSessionInfo(input.appSession)) {
+      return this.#defaultRuntime(input.appSession);
+    }
+
     const state = input.watch.state && typeof input.watch.state === "object"
       ? input.watch.state as Record<string, unknown>
       : null;

--- a/gateway/src/app-runner.ts
+++ b/gateway/src/app-runner.ts
@@ -162,6 +162,10 @@ type RegisteredAppClient = {
   registeredAt: number;
 };
 
+function appClientKey(session: AppSessionInfo): string {
+  return `${session.sessionId}:${session.clientId}`;
+}
+
 const APP_SOCKET_TAG = "app-client";
 
 class AppSocketError extends Error {
@@ -429,6 +433,28 @@ export class AppRunner extends DurableObject<Env> {
     return { delivered };
   }
 
+  async closeAppSession(sessionId: string): Promise<{ closed: number }> {
+    const normalizedSessionId = typeof sessionId === "string" ? sessionId.trim() : "";
+    if (!normalizedSessionId) {
+      return { closed: 0 };
+    }
+
+    this.#restoreAppClients();
+    let closed = 0;
+    for (const [key, registration] of [...this.appClients.entries()]) {
+      if (registration.session.sessionId !== normalizedSessionId) {
+        continue;
+      }
+      this.appClients.delete(key);
+      try {
+        registration.socket.close(1000, "app session closed");
+      } catch {
+      }
+      closed += 1;
+    }
+    return { closed };
+  }
+
   #acceptAppSocket(request: Request): Response {
     const context = this.#appSocketContextFromRequest(request);
     if (!context) {
@@ -516,7 +542,7 @@ export class AppRunner extends DurableObject<Env> {
     if (clientId) {
       this.#restoreAppClients();
     }
-    const appSession = clientId ? this.appClients.get(clientId)?.session : undefined;
+    const appSession = clientId ? this.#appSessionForClientId(clientId) : undefined;
     return this.#defaultRuntime(appSession);
   }
 
@@ -530,7 +556,8 @@ export class AppRunner extends DurableObject<Env> {
   }
 
   #registerAppSocket(ws: WebSocket, session: AppSessionInfo, appFrame: AppFrameContext): void {
-    const previous = this.appClients.get(session.clientId);
+    const key = appClientKey(session);
+    const previous = this.appClients.get(key);
     if (previous && previous.socket !== ws) {
       this.#closeSocket(previous.socket, 1000, "Replaced by newer app connection");
     }
@@ -541,7 +568,7 @@ export class AppRunner extends DurableObject<Env> {
       appFrame,
       connectedAt: Date.now(),
     } satisfies AppSocketAttachment);
-    this.appClients.set(session.clientId, {
+    this.appClients.set(key, {
       socket: ws,
       session,
       appFrame,
@@ -556,7 +583,7 @@ export class AppRunner extends DurableObject<Env> {
       if (!attachment?.connected || !attachment.session || !attachment.appFrame) {
         continue;
       }
-      this.appClients.set(attachment.session.clientId, {
+      this.appClients.set(appClientKey(attachment.session), {
         socket,
         session: attachment.session,
         appFrame: attachment.appFrame,
@@ -568,10 +595,10 @@ export class AppRunner extends DurableObject<Env> {
   async #emitAppEventToClients(event: string, payload: unknown, clientId: string | null): Promise<number> {
     this.#restoreAppClients();
     const targets = clientId
-      ? [...this.appClients.entries()].filter(([id]) => id === clientId)
+      ? [...this.appClients.entries()].filter(([, registration]) => registration.session.clientId === clientId)
       : [...this.appClients.entries()];
     let delivered = 0;
-    for (const [targetClientId, registration] of targets) {
+    for (const [key, registration] of targets) {
       try {
         this.#sendSocketFrame(registration.socket, {
           type: "sig",
@@ -581,19 +608,19 @@ export class AppRunner extends DurableObject<Env> {
         delivered += 1;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.warn(`[app-runner] app event delivery failed for ${targetClientId}: ${message}`);
-        this.#removeAppClient(targetClientId);
+        console.warn(`[app-runner] app event delivery failed for ${registration.session.clientId}: ${message}`);
+        this.#removeAppClient(key);
       }
     }
     return delivered;
   }
 
-  #removeAppClient(clientId: string): void {
-    const registration = this.appClients.get(clientId);
+  #removeAppClient(key: string): void {
+    const registration = this.appClients.get(key);
     if (!registration) {
       return;
     }
-    this.appClients.delete(clientId);
+    this.appClients.delete(key);
     try {
       registration.socket.close(1011, "app client removed");
     } catch {
@@ -601,9 +628,9 @@ export class AppRunner extends DurableObject<Env> {
   }
 
   #removeAppClientBySocket(socket: WebSocket): void {
-    for (const [clientId, registration] of this.appClients) {
+    for (const [key, registration] of this.appClients) {
       if (registration.socket === socket) {
-        this.appClients.delete(clientId);
+        this.appClients.delete(key);
       }
     }
   }
@@ -613,7 +640,8 @@ export class AppRunner extends DurableObject<Env> {
     if (!attachment?.connected || !attachment.session || !attachment.appFrame) {
       return null;
     }
-    const existing = this.appClients.get(attachment.session.clientId);
+    const key = appClientKey(attachment.session);
+    const existing = this.appClients.get(key);
     if (existing?.socket === socket) {
       return existing;
     }
@@ -623,8 +651,17 @@ export class AppRunner extends DurableObject<Env> {
       appFrame: attachment.appFrame,
       registeredAt: attachment.connectedAt ?? Date.now(),
     };
-    this.appClients.set(attachment.session.clientId, restored);
+    this.appClients.set(key, restored);
     return restored;
+  }
+
+  #appSessionForClientId(clientId: string): AppSessionInfo | undefined {
+    for (const registration of this.appClients.values()) {
+      if (registration.session.clientId === clientId) {
+        return registration.session;
+      }
+    }
+    return undefined;
   }
 
   #sendSocketFrame(socket: WebSocket, frame: AppSocketFrame): void {

--- a/gateway/src/app-runner.ts
+++ b/gateway/src/app-runner.ts
@@ -1,4 +1,4 @@
-import { DurableObject, RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
+import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
 import { getAgentByName } from "agents";
 import {
   loadPackageArtifact,
@@ -40,6 +40,83 @@ type AppSessionInfo = {
   expiresAt: number;
 };
 
+type ResolvePackageAppRpcResult =
+  | {
+      ok: true;
+      packageId: string;
+      packageName: string;
+      routeBase: string;
+      artifact: PackageArtifactMetadata;
+      appFrame: AppFrameContext;
+      clientSession: AppSessionInfo & {
+        packageId: string;
+        packageName: string;
+        routeBase: string;
+        createdAt: number;
+        lastUsedAt?: number | null;
+      };
+      hasRpc: boolean;
+      auth: {
+        uid: number;
+        username: string;
+        capabilities: string[];
+      };
+    }
+  | {
+      ok: false;
+      status: number;
+      message: string;
+    };
+
+type AppSocketExpectedRoute = {
+  uid: number;
+  packageId: string;
+  packageName: string;
+  sessionId: string;
+};
+
+type AppSocketAttachment = {
+  kind: "app-client";
+  expected: AppSocketExpectedRoute;
+  connected: boolean;
+  session?: AppSessionInfo;
+  appFrame?: AppFrameContext;
+  connectedAt?: number;
+};
+
+type AppRequestFrame = {
+  type: "req";
+  id: string;
+  call: string;
+  args?: unknown;
+};
+
+type AppResponseFrame =
+  | {
+      type: "res";
+      id: string;
+      ok: true;
+      data?: unknown;
+    }
+  | {
+      type: "res";
+      id: string;
+      ok: false;
+      error: {
+        code: number;
+        message: string;
+        details?: unknown;
+      };
+    };
+
+type AppSignalFrame = {
+  type: "sig";
+  signal: string;
+  payload?: unknown;
+};
+
+type AppSocketFrame = AppRequestFrame | AppResponseFrame | AppSignalFrame;
+
 type AppRuntimeContext = {
   appFrame: AppFrameContext;
   appSession?: AppSessionInfo;
@@ -76,12 +153,11 @@ export type AppRunnerCommandInput = {
 
 type KernelAppStub = {
   appRequest(appFrame: AppFrameContext, frame: RequestFrame): Promise<ResponseFrame>;
-};
-
-type AppClientStub = Rpc.RpcTargetBranded & {
-  onAppEvent(event: string, payload?: unknown): Promise<void>;
-  dup?: () => AppClientStub;
-  [Symbol.dispose]?: () => void;
+  resolvePackageAppRpcSession(input: {
+    packageName: string;
+    sessionId: string;
+    secret: string;
+  }): Promise<ResolvePackageAppRpcResult>;
 };
 
 type AppFetchEntrypointStub = Rpc.WorkerEntrypointBranded & {
@@ -116,29 +192,22 @@ const PROPS_KEY = "app-runner:props";
 const RUNTIME_TTL_MS = 365 * 24 * 60 * 60 * 1000;
 
 type RegisteredAppClient = {
-  client: AppClientStub;
+  socket: WebSocket;
   session: AppSessionInfo;
+  appFrame: AppFrameContext;
   registeredAt: number;
 };
 
-/**
- * Browser-facing RPC shim for package backends.
- *
- * Keep the public browser-facing surface to a single generic `invoke(...)`.
- * App-specific methods still belong to the package backend surface; AppRunner
- * just forwards them after registering the connected client.
- */
-class AppRunnerBackendTarget extends RpcTarget {
-  constructor(
-    private readonly runner: AppRunner,
-    private readonly runtime: AppRuntimeContext,
-    private readonly client: AppClientStub | null,
-  ) {
-    super();
-  }
+const APP_SOCKET_TAG = "app-client";
+const APP_SOCKET_PROTOCOL_VERSION = 1;
 
-  async invoke(method: string, args?: unknown): Promise<unknown> {
-    return this.runner.invokeAppRpc(method, args, this.runtime);
+class AppSocketError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AppSocketError";
   }
 }
 
@@ -240,6 +309,7 @@ export class AppRunner extends DurableObject<Env> {
     super(ctx, env);
     this.daemonSchedules = new AppRpcScheduleStore(ctx.storage.sql);
     this.daemonSchedules.init();
+    this.#restoreAppClients();
   }
 
   async ensureRuntime(props: AppRunnerProps): Promise<void> {
@@ -265,20 +335,65 @@ export class AppRunner extends DurableObject<Env> {
   }
 
   async fetch(request: Request): Promise<Response> {
+    if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+      return this.#acceptAppSocket(request);
+    }
     const response = await this.gsvFetch(await serializeAppHttpRequest(request));
     return deserializeAppHttpResponse(response);
-  }
-
-  async getBackend(appSession: AppSessionInfo, client?: AppClientStub | null): Promise<AppRunnerBackendTarget> {
-    if (client) {
-      this.registerAppClient(appSession, client);
-    }
-    return new AppRunnerBackendTarget(this, this.#defaultRuntime(appSession), client ?? null);
   }
 
   async deliverSignal(input: AppRunnerSignalInput): Promise<void> {
     const runtime = this.#runtimeForSignal(input);
     await this.#getSignalEntrypoint(runtime, input).run(input.signal);
+  }
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (typeof message !== "string") {
+      this.#closeSocket(ws, 1003, "App socket only accepts text frames");
+      return;
+    }
+
+    let frame: unknown;
+    try {
+      frame = JSON.parse(message);
+    } catch {
+      this.#closeSocket(ws, 1003, "Invalid JSON frame");
+      return;
+    }
+
+    if (!this.#isAppRequestFrame(frame)) {
+      this.#closeSocket(ws, 1003, "Expected app request frame");
+      return;
+    }
+
+    try {
+      const data = await this.#handleAppSocketRequest(ws, frame);
+      this.#sendSocketFrame(ws, {
+        type: "res",
+        id: frame.id,
+        ok: true,
+        ...(data === undefined ? {} : { data }),
+      });
+    } catch (error) {
+      const { code, message: errorMessage } = this.#frameError(error);
+      this.#sendSocketFrame(ws, {
+        type: "res",
+        id: frame.id,
+        ok: false,
+        error: {
+          code,
+          message: errorMessage,
+        },
+      });
+    }
+  }
+
+  webSocketClose(ws: WebSocket): void {
+    this.#removeAppClientBySocket(ws);
+  }
+
+  webSocketError(ws: WebSocket): void {
+    this.#removeAppClientBySocket(ws);
   }
 
   async invokeAppRpc(method: string, args: unknown, runtime: AppRuntimeContext): Promise<unknown> {
@@ -351,6 +466,117 @@ export class AppRunner extends DurableObject<Env> {
     return { delivered };
   }
 
+  #acceptAppSocket(request: Request): Response {
+    const expected = this.#expectedRouteFromSocketRequest(request);
+    if (!expected) {
+      return new Response("App socket route is incomplete", {
+        status: 400,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+
+    const pair = new WebSocketPair();
+    const server = pair[0];
+    const client = pair[1];
+    this.ctx.acceptWebSocket(server, [APP_SOCKET_TAG]);
+    server.serializeAttachment({
+      kind: "app-client",
+      expected,
+      connected: false,
+    } satisfies AppSocketAttachment);
+    return new Response(null, {
+      status: 101,
+      webSocket: client,
+    });
+  }
+
+  async #handleAppSocketRequest(ws: WebSocket, frame: AppRequestFrame): Promise<unknown> {
+    switch (frame.call) {
+      case "app.connect":
+        return this.#connectAppSocket(ws, frame.args);
+      case "backend.invoke":
+        return this.#invokeBackendFromSocket(ws, frame.args);
+      case "app.ping":
+        return { ok: true, timestamp: Date.now() };
+      default:
+        throw new AppSocketError(404, `Unknown app call: ${frame.call}`);
+    }
+  }
+
+  async #connectAppSocket(ws: WebSocket, args: unknown): Promise<unknown> {
+    const attachment = this.#getSocketAttachment(ws);
+    if (!attachment?.expected) {
+      throw new AppSocketError(401, "App socket is missing route metadata");
+    }
+    const record = this.#record(args);
+    const secret = typeof record?.secret === "string" ? record.secret.trim() : "";
+    const clientId = typeof record?.clientId === "string" ? record.clientId.trim() : "";
+    if (!secret) {
+      throw new AppSocketError(401, "App socket authentication required");
+    }
+
+    const kernel = await getAgentByName(this.env.KERNEL, "singleton") as unknown as KernelAppStub;
+    const resolved = await kernel.resolvePackageAppRpcSession({
+      packageName: attachment.expected.packageName,
+      sessionId: attachment.expected.sessionId,
+      secret,
+    });
+    if (!resolved.ok) {
+      throw new AppSocketError(resolved.status, resolved.message);
+    }
+    if (
+      resolved.auth.uid !== attachment.expected.uid ||
+      resolved.packageId !== attachment.expected.packageId ||
+      resolved.packageName !== attachment.expected.packageName
+    ) {
+      throw new AppSocketError(403, "App socket runner mismatch");
+    }
+    if (!resolved.hasRpc) {
+      throw new AppSocketError(404, "Package app has no backend rpc");
+    }
+    if (clientId && resolved.clientSession.clientId !== clientId) {
+      throw new AppSocketError(403, "App socket client mismatch");
+    }
+
+    await this.ensureRuntime({
+      packageId: resolved.packageId,
+      packageName: resolved.packageName,
+      routeBase: resolved.routeBase,
+      entrypointName: resolved.appFrame.entrypointName,
+      artifact: resolved.artifact,
+      appFrame: resolved.appFrame,
+    });
+
+    const session: AppSessionInfo = {
+      sessionId: resolved.clientSession.sessionId,
+      clientId: resolved.clientSession.clientId,
+      rpcBase: resolved.clientSession.rpcBase,
+      expiresAt: resolved.clientSession.expiresAt,
+    };
+    this.#registerAppSocket(ws, session, resolved.appFrame);
+    return {
+      protocol: APP_SOCKET_PROTOCOL_VERSION,
+      packageId: resolved.packageId,
+      packageName: resolved.packageName,
+      clientId: session.clientId,
+      expiresAt: session.expiresAt,
+    };
+  }
+
+  async #invokeBackendFromSocket(ws: WebSocket, args: unknown): Promise<unknown> {
+    const client = this.#clientForSocket(ws);
+    if (!client) {
+      throw new AppSocketError(401, "App socket is not connected");
+    }
+    const record = this.#record(args);
+    const method = typeof record?.method === "string" ? record.method.trim() : "";
+    if (!method) {
+      throw new AppSocketError(400, "backend.invoke requires method");
+    }
+    const runtime = this.#runtimeForAppFrame(client.appFrame, client.session);
+    return this.invokeAppRpc(method, record?.args, runtime);
+  }
+
   async #gsvFetch(request: AppHttpRequest, runtime: AppRuntimeContext): Promise<AppHttpResponse> {
     const response = await this.#getAppEntrypoint(runtime).fetch(deserializeAppHttpRequest(request));
     return serializeAppHttpResponseValue(response);
@@ -390,6 +616,9 @@ export class AppRunner extends DurableObject<Env> {
     const clientId = typeof state?.clientId === "string" && state.clientId.trim().length > 0
       ? state.clientId.trim()
       : null;
+    if (clientId) {
+      this.#restoreAppClients();
+    }
     const appSession = clientId ? this.appClients.get(clientId)?.session : undefined;
     return this.#defaultRuntime(appSession);
   }
@@ -403,36 +632,59 @@ export class AppRunner extends DurableObject<Env> {
     };
   }
 
-  registerAppClient(appSession: AppSessionInfo, client: AppClientStub): void {
-    const clientId = appSession.clientId?.trim();
-    if (!clientId) {
-      throw new Error("app client registration requires clientId");
+  #registerAppSocket(ws: WebSocket, session: AppSessionInfo, appFrame: AppFrameContext): void {
+    const previous = this.appClients.get(session.clientId);
+    if (previous && previous.socket !== ws) {
+      this.#closeSocket(previous.socket, 1000, "Replaced by newer app connection");
     }
-    const retainedClient = typeof client.dup === "function"
-      ? client.dup()
-      : client;
-    const previous = this.appClients.get(clientId);
-    if (previous) {
-      try {
-        previous.client[Symbol.dispose]?.();
-      } catch {
-      }
+    const attachment = this.#getSocketAttachment(ws);
+    if (!attachment) {
+      throw new AppSocketError(401, "App socket is missing attachment");
     }
-    this.appClients.set(clientId, {
-      client: retainedClient,
-      session: appSession,
+    ws.serializeAttachment({
+      ...attachment,
+      connected: true,
+      session,
+      appFrame,
+      connectedAt: Date.now(),
+    } satisfies AppSocketAttachment);
+    this.appClients.set(session.clientId, {
+      socket: ws,
+      session,
+      appFrame,
       registeredAt: Date.now(),
     });
   }
 
+  #restoreAppClients(): void {
+    this.appClients.clear();
+    for (const socket of this.ctx.getWebSockets(APP_SOCKET_TAG)) {
+      const attachment = this.#getSocketAttachment(socket);
+      if (!attachment?.connected || !attachment.session || !attachment.appFrame) {
+        continue;
+      }
+      this.appClients.set(attachment.session.clientId, {
+        socket,
+        session: attachment.session,
+        appFrame: attachment.appFrame,
+        registeredAt: attachment.connectedAt ?? Date.now(),
+      });
+    }
+  }
+
   async #emitAppEventToClients(event: string, payload: unknown, clientId: string | null): Promise<number> {
+    this.#restoreAppClients();
     const targets = clientId
       ? [...this.appClients.entries()].filter(([id]) => id === clientId)
       : [...this.appClients.entries()];
     let delivered = 0;
     for (const [targetClientId, registration] of targets) {
       try {
-        await registration.client.onAppEvent(event, payload);
+        this.#sendSocketFrame(registration.socket, {
+          type: "sig",
+          signal: event,
+          payload,
+        });
         delivered += 1;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -450,9 +702,138 @@ export class AppRunner extends DurableObject<Env> {
     }
     this.appClients.delete(clientId);
     try {
-      registration.client[Symbol.dispose]?.();
+      registration.socket.close(1011, "app client removed");
     } catch {
     }
+  }
+
+  #removeAppClientBySocket(socket: WebSocket): void {
+    for (const [clientId, registration] of this.appClients) {
+      if (registration.socket === socket) {
+        this.appClients.delete(clientId);
+      }
+    }
+  }
+
+  #clientForSocket(socket: WebSocket): RegisteredAppClient | null {
+    const attachment = this.#getSocketAttachment(socket);
+    if (!attachment?.connected || !attachment.session || !attachment.appFrame) {
+      return null;
+    }
+    const existing = this.appClients.get(attachment.session.clientId);
+    if (existing?.socket === socket) {
+      return existing;
+    }
+    const restored = {
+      socket,
+      session: attachment.session,
+      appFrame: attachment.appFrame,
+      registeredAt: attachment.connectedAt ?? Date.now(),
+    };
+    this.appClients.set(attachment.session.clientId, restored);
+    return restored;
+  }
+
+  #sendSocketFrame(socket: WebSocket, frame: AppSocketFrame): void {
+    socket.send(JSON.stringify(frame));
+  }
+
+  #closeSocket(socket: WebSocket, code: number, reason: string): void {
+    this.#removeAppClientBySocket(socket);
+    try {
+      socket.close(code, reason);
+    } catch {
+    }
+  }
+
+  #getSocketAttachment(socket: WebSocket): AppSocketAttachment | null {
+    const attachment = socket.deserializeAttachment();
+    return this.#isAppSocketAttachment(attachment) ? attachment : null;
+  }
+
+  #expectedRouteFromSocketRequest(request: Request): AppSocketExpectedRoute | null {
+    const url = new URL(request.url);
+    const uid = Number.parseInt(
+      request.headers.get("x-gsv-app-runner-uid") ?? url.searchParams.get("uid") ?? "",
+      10,
+    );
+    const packageId = request.headers.get("x-gsv-app-runner-package-id") ?? url.searchParams.get("packageId") ?? "";
+    const packageName = request.headers.get("x-gsv-app-package-name") ?? this.#pathPart(url.pathname, 1);
+    const sessionId = request.headers.get("x-gsv-app-session-id") ?? this.#pathPart(url.pathname, 3);
+    if (!Number.isInteger(uid) || uid < 0 || !packageId || !packageName || !sessionId) {
+      return null;
+    }
+    return {
+      uid,
+      packageId,
+      packageName,
+      sessionId,
+    };
+  }
+
+  #pathPart(pathname: string, index: number): string {
+    return pathname.split("/").filter(Boolean)[index]?.trim() ?? "";
+  }
+
+  #isAppRequestFrame(value: unknown): value is AppRequestFrame {
+    const record = this.#record(value);
+    return record?.type === "req" &&
+      typeof record.id === "string" &&
+      record.id.trim().length > 0 &&
+      typeof record.call === "string" &&
+      record.call.trim().length > 0;
+  }
+
+  #isAppSocketAttachment(value: unknown): value is AppSocketAttachment {
+    const record = this.#record(value);
+    if (record?.kind !== "app-client" || typeof record.connected !== "boolean") {
+      return false;
+    }
+    const expected = this.#record(record.expected);
+    if (
+      !expected ||
+      typeof expected.uid !== "number" ||
+      typeof expected.packageId !== "string" ||
+      typeof expected.packageName !== "string" ||
+      typeof expected.sessionId !== "string"
+    ) {
+      return false;
+    }
+    if (!record.connected) {
+      return true;
+    }
+    const session = this.#record(record.session);
+    const appFrame = this.#record(record.appFrame);
+    return Boolean(
+      session &&
+      typeof session.sessionId === "string" &&
+      typeof session.clientId === "string" &&
+      typeof session.rpcBase === "string" &&
+      typeof session.expiresAt === "number" &&
+      appFrame &&
+      typeof appFrame.uid === "number" &&
+      typeof appFrame.username === "string" &&
+      typeof appFrame.packageId === "string" &&
+      typeof appFrame.packageName === "string" &&
+      typeof appFrame.entrypointName === "string" &&
+      typeof appFrame.routeBase === "string" &&
+      typeof appFrame.issuedAt === "number" &&
+      typeof appFrame.expiresAt === "number",
+    );
+  }
+
+  #record(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === "object" ? value as Record<string, unknown> : null;
+  }
+
+  #frameError(error: unknown): { code: number; message: string } {
+    if (error instanceof AppSocketError) {
+      return { code: error.code, message: error.message };
+    }
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : String(error),
+    };
   }
 
   #getProps(): AppRunnerProps {

--- a/gateway/src/app-runner.ts
+++ b/gateway/src/app-runner.ts
@@ -40,44 +40,13 @@ type AppSessionInfo = {
   expiresAt: number;
 };
 
-type ResolvePackageAppRpcResult =
-  | {
-      ok: true;
-      packageId: string;
-      packageName: string;
-      routeBase: string;
-      artifact: PackageArtifactMetadata;
-      appFrame: AppFrameContext;
-      clientSession: AppSessionInfo & {
-        packageId: string;
-        packageName: string;
-        routeBase: string;
-        createdAt: number;
-        lastUsedAt?: number | null;
-      };
-      hasRpc: boolean;
-      auth: {
-        uid: number;
-        username: string;
-        capabilities: string[];
-      };
-    }
-  | {
-      ok: false;
-      status: number;
-      message: string;
-    };
-
-type AppSocketExpectedRoute = {
-  uid: number;
-  packageId: string;
-  packageName: string;
-  sessionId: string;
+type AppSocketContext = {
+  session: AppSessionInfo;
+  appFrame: AppFrameContext;
 };
 
 type AppSocketAttachment = {
   kind: "app-client";
-  expected: AppSocketExpectedRoute;
   connected: boolean;
   session?: AppSessionInfo;
   appFrame?: AppFrameContext;
@@ -153,11 +122,6 @@ export type AppRunnerCommandInput = {
 
 type KernelAppStub = {
   appRequest(appFrame: AppFrameContext, frame: RequestFrame): Promise<ResponseFrame>;
-  resolvePackageAppRpcSession(input: {
-    packageName: string;
-    sessionId: string;
-    secret: string;
-  }): Promise<ResolvePackageAppRpcResult>;
 };
 
 type AppFetchEntrypointStub = Rpc.WorkerEntrypointBranded & {
@@ -199,7 +163,6 @@ type RegisteredAppClient = {
 };
 
 const APP_SOCKET_TAG = "app-client";
-const APP_SOCKET_PROTOCOL_VERSION = 1;
 
 class AppSocketError extends Error {
   constructor(
@@ -467,9 +430,9 @@ export class AppRunner extends DurableObject<Env> {
   }
 
   #acceptAppSocket(request: Request): Response {
-    const expected = this.#expectedRouteFromSocketRequest(request);
-    if (!expected) {
-      return new Response("App socket route is incomplete", {
+    const context = this.#appSocketContextFromRequest(request);
+    if (!context) {
+      return new Response("App socket context is missing or invalid", {
         status: 400,
         headers: { "cache-control": "no-store" },
       });
@@ -479,11 +442,7 @@ export class AppRunner extends DurableObject<Env> {
     const server = pair[0];
     const client = pair[1];
     this.ctx.acceptWebSocket(server, [APP_SOCKET_TAG]);
-    server.serializeAttachment({
-      kind: "app-client",
-      expected,
-      connected: false,
-    } satisfies AppSocketAttachment);
+    this.#registerAppSocket(server, context.session, context.appFrame);
     return new Response(null, {
       status: 101,
       webSocket: client,
@@ -492,8 +451,6 @@ export class AppRunner extends DurableObject<Env> {
 
   async #handleAppSocketRequest(ws: WebSocket, frame: AppRequestFrame): Promise<unknown> {
     switch (frame.call) {
-      case "app.connect":
-        return this.#connectAppSocket(ws, frame.args);
       case "backend.invoke":
         return this.#invokeBackendFromSocket(ws, frame.args);
       case "app.ping":
@@ -501,66 +458,6 @@ export class AppRunner extends DurableObject<Env> {
       default:
         throw new AppSocketError(404, `Unknown app call: ${frame.call}`);
     }
-  }
-
-  async #connectAppSocket(ws: WebSocket, args: unknown): Promise<unknown> {
-    const attachment = this.#getSocketAttachment(ws);
-    if (!attachment?.expected) {
-      throw new AppSocketError(401, "App socket is missing route metadata");
-    }
-    const record = this.#record(args);
-    const secret = typeof record?.secret === "string" ? record.secret.trim() : "";
-    const clientId = typeof record?.clientId === "string" ? record.clientId.trim() : "";
-    if (!secret) {
-      throw new AppSocketError(401, "App socket authentication required");
-    }
-
-    const kernel = await getAgentByName(this.env.KERNEL, "singleton") as unknown as KernelAppStub;
-    const resolved = await kernel.resolvePackageAppRpcSession({
-      packageName: attachment.expected.packageName,
-      sessionId: attachment.expected.sessionId,
-      secret,
-    });
-    if (!resolved.ok) {
-      throw new AppSocketError(resolved.status, resolved.message);
-    }
-    if (
-      resolved.auth.uid !== attachment.expected.uid ||
-      resolved.packageId !== attachment.expected.packageId ||
-      resolved.packageName !== attachment.expected.packageName
-    ) {
-      throw new AppSocketError(403, "App socket runner mismatch");
-    }
-    if (!resolved.hasRpc) {
-      throw new AppSocketError(404, "Package app has no backend rpc");
-    }
-    if (clientId && resolved.clientSession.clientId !== clientId) {
-      throw new AppSocketError(403, "App socket client mismatch");
-    }
-
-    await this.ensureRuntime({
-      packageId: resolved.packageId,
-      packageName: resolved.packageName,
-      routeBase: resolved.routeBase,
-      entrypointName: resolved.appFrame.entrypointName,
-      artifact: resolved.artifact,
-      appFrame: resolved.appFrame,
-    });
-
-    const session: AppSessionInfo = {
-      sessionId: resolved.clientSession.sessionId,
-      clientId: resolved.clientSession.clientId,
-      rpcBase: resolved.clientSession.rpcBase,
-      expiresAt: resolved.clientSession.expiresAt,
-    };
-    this.#registerAppSocket(ws, session, resolved.appFrame);
-    return {
-      protocol: APP_SOCKET_PROTOCOL_VERSION,
-      packageId: resolved.packageId,
-      packageName: resolved.packageName,
-      clientId: session.clientId,
-      expiresAt: session.expiresAt,
-    };
   }
 
   async #invokeBackendFromSocket(ws: WebSocket, args: unknown): Promise<unknown> {
@@ -637,12 +534,8 @@ export class AppRunner extends DurableObject<Env> {
     if (previous && previous.socket !== ws) {
       this.#closeSocket(previous.socket, 1000, "Replaced by newer app connection");
     }
-    const attachment = this.#getSocketAttachment(ws);
-    if (!attachment) {
-      throw new AppSocketError(401, "App socket is missing attachment");
-    }
     ws.serializeAttachment({
-      ...attachment,
+      kind: "app-client",
       connected: true,
       session,
       appFrame,
@@ -751,28 +644,18 @@ export class AppRunner extends DurableObject<Env> {
     return this.#isAppSocketAttachment(attachment) ? attachment : null;
   }
 
-  #expectedRouteFromSocketRequest(request: Request): AppSocketExpectedRoute | null {
-    const url = new URL(request.url);
-    const uid = Number.parseInt(
-      request.headers.get("x-gsv-app-runner-uid") ?? url.searchParams.get("uid") ?? "",
-      10,
-    );
-    const packageId = request.headers.get("x-gsv-app-runner-package-id") ?? url.searchParams.get("packageId") ?? "";
-    const packageName = request.headers.get("x-gsv-app-package-name") ?? this.#pathPart(url.pathname, 1);
-    const sessionId = request.headers.get("x-gsv-app-session-id") ?? this.#pathPart(url.pathname, 3);
-    if (!Number.isInteger(uid) || uid < 0 || !packageId || !packageName || !sessionId) {
+  #appSocketContextFromRequest(request: Request): AppSocketContext | null {
+    const raw = request.headers.get("x-gsv-app-socket-context");
+    if (!raw) {
       return null;
     }
-    return {
-      uid,
-      packageId,
-      packageName,
-      sessionId,
-    };
-  }
-
-  #pathPart(pathname: string, index: number): string {
-    return pathname.split("/").filter(Boolean)[index]?.trim() ?? "";
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(decodeURIComponent(raw));
+    } catch {
+      return null;
+    }
+    return this.#isAppSocketContext(parsed) ? parsed : null;
   }
 
   #isAppRequestFrame(value: unknown): value is AppRequestFrame {
@@ -789,27 +672,35 @@ export class AppRunner extends DurableObject<Env> {
     if (record?.kind !== "app-client" || typeof record.connected !== "boolean") {
       return false;
     }
-    const expected = this.#record(record.expected);
-    if (
-      !expected ||
-      typeof expected.uid !== "number" ||
-      typeof expected.packageId !== "string" ||
-      typeof expected.packageName !== "string" ||
-      typeof expected.sessionId !== "string"
-    ) {
-      return false;
-    }
     if (!record.connected) {
       return true;
     }
-    const session = this.#record(record.session);
-    const appFrame = this.#record(record.appFrame);
+    return this.#isAppSessionInfo(record.session) && this.#isAppFrameContext(record.appFrame);
+  }
+
+  #isAppSocketContext(value: unknown): value is AppSocketContext {
+    const record = this.#record(value);
+    return Boolean(
+      record &&
+      this.#isAppSessionInfo(record.session) &&
+      this.#isAppFrameContext(record.appFrame),
+    );
+  }
+
+  #isAppSessionInfo(value: unknown): value is AppSessionInfo {
+    const session = this.#record(value);
     return Boolean(
       session &&
       typeof session.sessionId === "string" &&
       typeof session.clientId === "string" &&
       typeof session.rpcBase === "string" &&
-      typeof session.expiresAt === "number" &&
+      typeof session.expiresAt === "number",
+    );
+  }
+
+  #isAppFrameContext(value: unknown): value is AppFrameContext {
+    const appFrame = this.#record(value);
+    return Boolean(
       appFrame &&
       typeof appFrame.uid === "number" &&
       typeof appFrame.username === "string" &&

--- a/gateway/src/app-runner.ts
+++ b/gateway/src/app-runner.ts
@@ -536,13 +536,16 @@ export class AppRunner extends DurableObject<Env> {
     const state = input.watch.state && typeof input.watch.state === "object"
       ? input.watch.state as Record<string, unknown>
       : null;
+    const sessionId = typeof state?.appSessionId === "string" && state.appSessionId.trim().length > 0
+      ? state.appSessionId.trim()
+      : null;
     const clientId = typeof state?.clientId === "string" && state.clientId.trim().length > 0
       ? state.clientId.trim()
       : null;
     if (clientId) {
       this.#restoreAppClients();
     }
-    const appSession = clientId ? this.#appSessionForClientId(clientId) : undefined;
+    const appSession = clientId ? this.#appSessionForClientId(clientId, sessionId) : undefined;
     return this.#defaultRuntime(appSession);
   }
 
@@ -655,9 +658,12 @@ export class AppRunner extends DurableObject<Env> {
     return restored;
   }
 
-  #appSessionForClientId(clientId: string): AppSessionInfo | undefined {
+  #appSessionForClientId(clientId: string, sessionId?: string | null): AppSessionInfo | undefined {
     for (const registration of this.appClients.values()) {
-      if (registration.session.clientId === clientId) {
+      if (
+        registration.session.clientId === clientId &&
+        (!sessionId || registration.session.sessionId === sessionId)
+      ) {
         return registration.session;
       }
     }

--- a/gateway/src/app-runner.ts
+++ b/gateway/src/app-runner.ts
@@ -163,7 +163,11 @@ type RegisteredAppClient = {
 };
 
 function appClientKey(session: AppSessionInfo): string {
-  return `${session.sessionId}:${session.clientId}`;
+  return appClientKeyFor(session.sessionId, session.clientId);
+}
+
+function appClientKeyFor(sessionId: string, clientId: string): string {
+  return `${sessionId}:${clientId}`;
 }
 
 const APP_SOCKET_TAG = "app-client";
@@ -453,6 +457,27 @@ export class AppRunner extends DurableObject<Env> {
       closed += 1;
     }
     return { closed };
+  }
+
+  async closeAppClient(sessionId: string, clientId: string): Promise<{ closed: number }> {
+    const normalizedSessionId = typeof sessionId === "string" ? sessionId.trim() : "";
+    const normalizedClientId = typeof clientId === "string" ? clientId.trim() : "";
+    if (!normalizedSessionId || !normalizedClientId) {
+      return { closed: 0 };
+    }
+
+    this.#restoreAppClients();
+    const key = appClientKeyFor(normalizedSessionId, normalizedClientId);
+    const registration = this.appClients.get(key);
+    if (!registration) {
+      return { closed: 0 };
+    }
+    this.appClients.delete(key);
+    try {
+      registration.socket.close(1000, "app client detached");
+    } catch {
+    }
+    return { closed: 1 };
   }
 
   #acceptAppSocket(request: Request): Response {

--- a/gateway/src/app-runner.ts
+++ b/gateway/src/app-runner.ts
@@ -145,7 +145,7 @@ type AppRunnerDaemonStub = Rpc.RpcTargetBranded & {
   removeRpcSchedule(key: string): Promise<{ removed: boolean }>;
   listRpcSchedules(): Promise<unknown[]>;
   packageSqlExec(statement: string, bindings?: unknown[]): Promise<unknown[]>;
-  emitAppEvent(event: string, payload?: unknown, clientId?: string): Promise<{ delivered: number }>;
+  emitAppEvent(event: string, payload?: unknown, clientId?: string, sessionId?: string): Promise<{ delivered: number }>;
 };
 
 type GsvApiBindingProps = {
@@ -214,8 +214,13 @@ export class GsvApiBinding extends WorkerEntrypoint<Env, GsvApiBindingProps> {
     return this.#getRunner().packageSqlExec(statement, bindings);
   }
 
-  async emitAppEvent(event: string, payload?: unknown, clientId?: string): Promise<{ delivered: number }> {
-    return this.#getRunner().emitAppEvent(event, payload, clientId);
+  async emitAppEvent(
+    event: string,
+    payload?: unknown,
+    clientId?: string,
+    sessionId?: string,
+  ): Promise<{ delivered: number }> {
+    return this.#getRunner().emitAppEvent(event, payload, clientId, sessionId);
   }
 
   #getRunner(): AppRunnerDaemonStub {
@@ -425,7 +430,12 @@ export class AppRunner extends DurableObject<Env> {
     return rows.map((row) => this.#serializeSqlRow(row));
   }
 
-  async emitAppEvent(event: string, payload?: unknown, clientId?: string): Promise<{ delivered: number }> {
+  async emitAppEvent(
+    event: string,
+    payload?: unknown,
+    clientId?: string,
+    sessionId?: string,
+  ): Promise<{ delivered: number }> {
     const normalizedEvent = typeof event === "string" ? event.trim() : "";
     if (!normalizedEvent) {
       throw new Error("app event name is required");
@@ -433,7 +443,10 @@ export class AppRunner extends DurableObject<Env> {
     const targetClientId = typeof clientId === "string" && clientId.trim().length > 0
       ? clientId.trim()
       : null;
-    const delivered = await this.#emitAppEventToClients(normalizedEvent, payload, targetClientId);
+    const targetSessionId = typeof sessionId === "string" && sessionId.trim().length > 0
+      ? sessionId.trim()
+      : null;
+    const delivered = await this.#emitAppEventToClients(normalizedEvent, payload, targetClientId, targetSessionId);
     return { delivered };
   }
 
@@ -620,11 +633,24 @@ export class AppRunner extends DurableObject<Env> {
     }
   }
 
-  async #emitAppEventToClients(event: string, payload: unknown, clientId: string | null): Promise<number> {
+  async #emitAppEventToClients(
+    event: string,
+    payload: unknown,
+    clientId: string | null,
+    sessionId: string | null,
+  ): Promise<number> {
     this.#restoreAppClients();
-    const targets = clientId
-      ? [...this.appClients.entries()].filter(([, registration]) => registration.session.clientId === clientId)
-      : [...this.appClients.entries()];
+    let targets: Array<[string, RegisteredAppClient]>;
+    if (clientId) {
+      if (!sessionId) {
+        throw new Error("targeted app events require an app session id");
+      }
+      const key = appClientKeyFor(sessionId, clientId);
+      const registration = this.appClients.get(key);
+      targets = registration ? [[key, registration]] : [];
+    } else {
+      targets = [...this.appClients.entries()];
+    }
     let delivered = 0;
     for (const [key, registration] of targets) {
       try {

--- a/gateway/src/index.test.ts
+++ b/gateway/src/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { packageWorkerPath } from "./index";
+
+describe("gateway app session routing", () => {
+  it("preserves the package app root slash when proxying app sessions", () => {
+    expect(packageWorkerPath("/apps/chat", "/")).toBe("/apps/chat/");
+    expect(packageWorkerPath("/apps/chat", "")).toBe("/apps/chat/");
+  });
+
+  it("keeps nested app session paths under the package route", () => {
+    expect(packageWorkerPath("/apps/chat", "/assets/main.js")).toBe("/apps/chat/assets/main.js");
+  });
+});

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -104,34 +104,6 @@ export default {
       return handlePackageAppSessionRequest(request, env, ctx, appSessionMatch);
     }
 
-    const appMatch = matchPackageAppPath(url.pathname);
-    if (appMatch) {
-      const session = getPackageAppSession(request);
-      if (!session) {
-        return new Response("Unauthorized", { status: 401 });
-      }
-      if (request.method !== "GET" && request.method !== "HEAD") {
-        return new Response("Method Not Allowed", {
-          status: 405,
-          headers: { allow: "GET, HEAD" },
-        });
-      }
-
-      const kernel = await getAgentByName(env.KERNEL, "singleton");
-      const resolved = await kernel.resolvePackageHttpRoute({
-        packageName: appMatch.packageName,
-        username: session.username,
-        token: session.token,
-        clientId: url.searchParams.get("windowId")?.trim() || undefined,
-      });
-
-      if (!resolved.ok) {
-        return new Response(resolved.message, { status: resolved.status });
-      }
-
-      return redirectToPackageAppSession(request, resolved, appMatch.suffix);
-    }
-
     return new Response("Not Found", { status: 404 });
   },
 } satisfies ExportedHandler<Env>;
@@ -235,11 +207,6 @@ const PACKAGE_APP_RUNTIME_SCRIPT = [
   "})();",
 ].join("");
 
-type PackageAppSession = {
-  username: string;
-  token: string;
-};
-
 const PACKAGE_APP_SESSION_COOKIE_PREFIX = "gsv_app_session_";
 
 type BasicAuth = {
@@ -256,11 +223,6 @@ type GitPathMatch = {
 
 type PackageAppSessionRefreshMatch = {
   sessionId: string;
-};
-
-type PackageAppLaunchMatch = {
-  packageName: string;
-  suffix: string;
 };
 
 type PackageAppSessionPathMatch = {
@@ -282,7 +244,6 @@ type ResolvedPackageRoute = {
     packageName: string;
     routeBase: string;
     rpcBase: string;
-    secret?: string;
     createdAt: number;
     expiresAt: number;
   };
@@ -293,27 +254,6 @@ type ResolvedPackageRoute = {
     capabilities: string[];
   };
 };
-
-function matchPackageAppPath(pathname: string): PackageAppLaunchMatch | null {
-  const parts = pathname.split("/").filter(Boolean);
-  if (parts.length < 2 || parts[0] !== "apps") {
-    return null;
-  }
-  if (parts[1] === "sessions") {
-    return null;
-  }
-
-  const rawName = parts[1]?.trim();
-  if (!rawName || !/^[a-z0-9][a-z0-9-]*$/.test(rawName)) {
-    return null;
-  }
-
-  const suffixParts = parts.slice(2);
-  return {
-    packageName: rawName,
-    suffix: suffixParts.length > 0 ? `/${suffixParts.join("/")}` : "/",
-  };
-}
 
 function matchPackageAppSessionPath(pathname: string): PackageAppSessionPathMatch | null {
   const parts = pathname.split("/").filter(Boolean);
@@ -393,26 +333,6 @@ function basicAuthChallenge(message: string): Response {
       "WWW-Authenticate": 'Basic realm="gsv"',
     },
   });
-}
-
-function getPackageAppSession(request: Request): PackageAppSession | null {
-  const authHeader = request.headers.get("authorization");
-  if (authHeader?.startsWith("Bearer ")) {
-    const token = authHeader.slice("Bearer ".length).trim();
-    const username = request.headers.get("x-gsv-username")?.trim() ?? "";
-    if (username && token) {
-      return { username, token };
-    }
-  }
-
-  const cookies = parseCookieHeader(request.headers.get("cookie"));
-  const username = cookies.get("gsv_app_user") ?? "";
-  const token = cookies.get("gsv_app_token") ?? "";
-  if (!username || !token) {
-    return null;
-  }
-
-  return { username, token };
 }
 
 function parseCookieHeader(raw: string | null): Map<string, string> {
@@ -685,24 +605,6 @@ async function resolvePackageAppSessionFromCookie(
   });
 }
 
-function redirectToPackageAppSession(
-  request: Request,
-  resolved: ResolvedPackageRoute,
-  suffix: string,
-): Response {
-  const secret = resolved.clientSession.secret;
-  if (!secret) {
-    return new Response("Package app session is missing secret", { status: 500 });
-  }
-
-  return redirectToPackageAppSessionLocation(
-    request,
-    resolved,
-    urlPathFromSuffix(request, suffix),
-    secret,
-  );
-}
-
 function redirectToPackageAppSessionLocation(
   request: Request,
   resolved: ResolvedPackageRoute,
@@ -724,12 +626,6 @@ function redirectToPackageAppSessionLocation(
     status: 303,
     headers,
   });
-}
-
-function urlPathFromSuffix(request: Request, suffix: string): string {
-  const url = new URL(request.url);
-  const normalizedSuffix = suffix && suffix !== "/" ? suffix : "/";
-  return `${normalizedSuffix}${url.search}${url.hash}`;
 }
 
 function normalizePackageAppLaunchNext(raw: string | null): string {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -394,9 +394,9 @@ function packageAppSessionCookiePath(sessionId: string): string {
   return `/apps/sessions/${encodeURIComponent(sessionId)}`;
 }
 
-function packageWorkerPath(routeBase: string, suffix: string): string {
+export function packageWorkerPath(routeBase: string, suffix: string): string {
   if (!suffix || suffix === "/") {
-    return routeBase;
+    return `${routeBase}/`;
   }
   return `${routeBase}${suffix}`;
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -6,7 +6,7 @@ import type {
 import type { Frame } from "./protocol/frames";
 import { getAgentByName } from "agents";
 import type { AppFrameContext } from "./protocol/app-frame";
-import { buildAppRunnerName } from "./protocol/app-session";
+import { buildAppClientRouteBase, buildAppRunnerName } from "./protocol/app-session";
 import { deserializeAppHttpResponse, serializeAppHttpRequest } from "./app-runner";
 import type { PackageArtifactMetadata } from "./kernel/packages";
 import { buildOAuthClientMetadata } from "./oauth-http";
@@ -223,10 +223,12 @@ type GitPathMatch = {
 
 type PackageAppSessionRefreshMatch = {
   sessionId: string;
+  clientId: string;
 };
 
 type PackageAppSessionPathMatch = {
   sessionId: string;
+  clientId: string | null;
   suffix: string;
 };
 
@@ -270,8 +272,31 @@ function matchPackageAppSessionPath(pathname: string): PackageAppSessionPathMatc
   }
 
   const suffixParts = parts.slice(3);
+  if (suffixParts[0] === "clients") {
+    const rawClientId = suffixParts[1]?.trim();
+    if (!rawClientId) {
+      return null;
+    }
+    let clientId = "";
+    try {
+      clientId = decodeURIComponent(rawClientId).trim();
+    } catch {
+      return null;
+    }
+    if (!clientId) {
+      return null;
+    }
+    const clientSuffixParts = suffixParts.slice(2);
+    return {
+      sessionId,
+      clientId,
+      suffix: clientSuffixParts.length > 0 ? `/${clientSuffixParts.join("/")}` : "/",
+    };
+  }
+
   return {
     sessionId,
+    clientId: null,
     suffix: suffixParts.length > 0 ? `/${suffixParts.join("/")}` : "/",
   };
 }
@@ -361,23 +386,24 @@ function parseCookieHeader(raw: string | null): Map<string, string> {
   return map;
 }
 
-function getPackageAppSessionSecret(request: Request, sessionId: string): string {
-  return parseCookieHeader(request.headers.get("cookie")).get(packageAppSessionCookieName(sessionId)) ?? "";
+function getPackageAppSessionSecret(request: Request, sessionId: string, clientId: string): string {
+  return parseCookieHeader(request.headers.get("cookie")).get(packageAppSessionCookieName(sessionId, clientId)) ?? "";
 }
 
 function buildPackageAppSessionCookie(
   request: Request,
   sessionId: string,
+  clientId: string,
   secret: string,
   expiresAt: number,
 ): string {
   const url = new URL(request.url);
   const maxAgeSeconds = Math.max(1, Math.ceil((expiresAt - Date.now()) / 1000));
   const parts = [
-    `${packageAppSessionCookieName(sessionId)}=${encodeURIComponent(secret)}`,
+    `${packageAppSessionCookieName(sessionId, clientId)}=${encodeURIComponent(secret)}`,
     "HttpOnly",
     "SameSite=Strict",
-    `Path=${packageAppSessionCookiePath(sessionId)}`,
+    `Path=${packageAppSessionCookiePath(sessionId, clientId)}`,
     `Max-Age=${maxAgeSeconds}`,
   ];
   if (url.protocol === "https:") {
@@ -386,12 +412,16 @@ function buildPackageAppSessionCookie(
   return parts.join("; ");
 }
 
-function packageAppSessionCookieName(sessionId: string): string {
-  return `${PACKAGE_APP_SESSION_COOKIE_PREFIX}${sessionId.replace(/[^A-Za-z0-9]/g, "_")}`;
+function packageAppSessionCookieName(sessionId: string, clientId: string): string {
+  return `${PACKAGE_APP_SESSION_COOKIE_PREFIX}${cookieNameSegment(sessionId)}_${cookieNameSegment(clientId)}`;
 }
 
-function packageAppSessionCookiePath(sessionId: string): string {
-  return `/apps/sessions/${encodeURIComponent(sessionId)}`;
+function cookieNameSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9]/g, "_") || "id";
+}
+
+function packageAppSessionCookiePath(sessionId: string, clientId: string): string {
+  return buildAppClientRouteBase(sessionId, clientId);
 }
 
 export function packageWorkerPath(routeBase: string, suffix: string): string {
@@ -435,6 +465,14 @@ async function handlePackageAppSessionRequest(
   ctx: ExecutionContext,
   match: PackageAppSessionPathMatch,
 ): Promise<Response> {
+  if (match.suffix === "/launch" && !match.clientId) {
+    return handlePackageAppSessionLaunchRequest(request, env, match);
+  }
+
+  if (!match.clientId) {
+    return new Response("App client route required", { status: 404 });
+  }
+
   if (match.suffix === "/socket") {
     if (!isWebSocketRequest(request)) {
       return new Response("App socket requires WebSocket", {
@@ -449,14 +487,17 @@ async function handlePackageAppSessionRequest(
   }
 
   if (match.suffix === "/refresh") {
-    return handlePackageAppSessionRefreshRequest(request, env, match);
+    return handlePackageAppSessionRefreshRequest(request, env, {
+      sessionId: match.sessionId,
+      clientId: match.clientId,
+    });
   }
 
   if (match.suffix === "/launch") {
-    return handlePackageAppSessionLaunchRequest(request, env, match);
+    return new Response("Not Found", { status: 404 });
   }
 
-  const resolved = await resolvePackageAppSessionFromCookie(request, env, match.sessionId);
+  const resolved = await resolvePackageAppSessionFromCookie(request, env, match.sessionId, match.clientId);
   if (!resolved.ok) {
     return new Response(resolved.message, { status: resolved.status });
   }
@@ -482,15 +523,14 @@ async function handlePackageAppSessionLaunchRequest(
   env: Env,
   match: PackageAppSessionPathMatch,
 ): Promise<Response> {
-  if (request.method !== "GET" && request.method !== "HEAD") {
+  if (request.method !== "POST") {
     return new Response("Method Not Allowed", {
       status: 405,
-      headers: { allow: "GET, HEAD" },
+      headers: { allow: "POST" },
     });
   }
 
-  const url = new URL(request.url);
-  const secret = url.searchParams.get("token")?.trim() ?? "";
+  const secret = await readPackageAppLaunchToken(request);
   if (!secret) {
     return new Response("Unauthorized", { status: 401 });
   }
@@ -505,10 +545,9 @@ async function handlePackageAppSessionLaunchRequest(
     return new Response(resolved.message, { status: resolved.status });
   }
 
-  return redirectToPackageAppSessionLocation(
+  return packageAppSessionLaunchResponse(
     request,
     resolved,
-    normalizePackageAppLaunchNext(url.searchParams.get("next")),
     secret,
   );
 }
@@ -525,7 +564,7 @@ async function handlePackageAppSessionRefreshRequest(
     });
   }
 
-  const secret = getPackageAppSessionSecret(request, match.sessionId);
+  const secret = getPackageAppSessionSecret(request, match.sessionId, match.clientId);
 
   const kernel = await getAgentByName(env.KERNEL, "singleton");
   const resolved = await kernel.refreshPackageAppRpcSession({
@@ -536,11 +575,20 @@ async function handlePackageAppSessionRefreshRequest(
   if (!resolved.ok) {
     return new Response(resolved.message, { status: resolved.status });
   }
+  if (resolved.clientSession.clientId !== match.clientId) {
+    return new Response("Unauthorized", { status: 401 });
+  }
 
   return Response.json(buildPackageAppBoot(resolved), {
     headers: {
       "cache-control": "no-store",
-      "set-cookie": buildPackageAppSessionCookie(request, match.sessionId, secret, resolved.clientSession.expiresAt),
+      "set-cookie": buildPackageAppSessionCookie(
+        request,
+        match.sessionId,
+        match.clientId,
+        secret,
+        resolved.clientSession.expiresAt,
+      ),
     },
   });
 }
@@ -551,7 +599,13 @@ async function handlePackageAppSocketRequest(
   ctx: ExecutionContext,
   match: PackageAppSessionPathMatch,
 ): Promise<Response> {
-  const resolved = await resolvePackageAppSessionFromCookie(request, env, match.sessionId);
+  if (!match.clientId) {
+    return new Response("App client route required", {
+      status: 404,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+  const resolved = await resolvePackageAppSessionFromCookie(request, env, match.sessionId, match.clientId);
   if (!resolved.ok) {
     return new Response(resolved.message, {
       status: resolved.status,
@@ -592,60 +646,51 @@ async function resolvePackageAppSessionFromCookie(
   request: Request,
   env: Env,
   sessionId: string,
+  clientId: string,
 ): Promise<ResolvedPackageRoute | { ok: false; status: number; message: string }> {
-  const secret = getPackageAppSessionSecret(request, sessionId);
+  const secret = getPackageAppSessionSecret(request, sessionId, clientId);
   if (!secret) {
     return { ok: false, status: 401, message: "Unauthorized" };
   }
 
   const kernel = await getAgentByName(env.KERNEL, "singleton");
-  return kernel.resolvePackageAppRpcSession({
+  const resolved = await kernel.resolvePackageAppRpcSession({
     sessionId,
     secret,
   });
+  if (!resolved.ok) {
+    return resolved;
+  }
+  if (resolved.clientSession.clientId !== clientId) {
+    return { ok: false, status: 401, message: "Unauthorized" };
+  }
+  return resolved;
 }
 
-function redirectToPackageAppSessionLocation(
+function packageAppSessionLaunchResponse(
   request: Request,
   resolved: ResolvedPackageRoute,
-  next: string,
   secret: string,
 ): Response {
-  const location = `${packageAppSessionCookiePath(resolved.clientSession.sessionId)}${next}`;
   const headers = new Headers({
-    location,
     "cache-control": "no-store",
     "set-cookie": buildPackageAppSessionCookie(
       request,
       resolved.clientSession.sessionId,
+      resolved.clientSession.clientId,
       secret,
       resolved.clientSession.expiresAt,
     ),
   });
-  return new Response(null, {
-    status: 303,
-    headers,
-  });
+  return Response.json({ ok: true }, { headers });
 }
 
-function normalizePackageAppLaunchNext(raw: string | null): string {
-  if (!raw) {
-    return "/";
-  }
-
-  try {
-    const base = "https://gsv.invalid";
-    const parsed = new URL(raw, base);
-    if (parsed.origin !== base) {
-      return "/";
-    }
-    if (parsed.pathname === "/launch" || parsed.pathname === "/refresh" || parsed.pathname === "/socket") {
-      return "/";
-    }
-    return `${parsed.pathname || "/"}${parsed.search}${parsed.hash}`;
-  } catch {
-    return "/";
-  }
+async function readPackageAppLaunchToken(request: Request): Promise<string> {
+  const body = await request.json().catch(() => null);
+  const token = body && typeof body === "object" && typeof (body as { token?: unknown }).token === "string"
+    ? (body as { token: string }).token.trim()
+    : "";
+  return token;
 }
 
 async function withPackageAppClientSession(
@@ -714,7 +759,7 @@ function buildPackageAppBoot(resolved: ResolvedPackageRoute) {
   return {
     packageId: resolved.packageId,
     packageName: resolved.packageName,
-    routeBase: packageAppSessionCookiePath(resolved.clientSession.sessionId),
+    routeBase: packageAppSessionCookiePath(resolved.clientSession.sessionId, resolved.clientSession.clientId),
     rpcBase: resolved.clientSession.rpcBase,
     sessionId: resolved.clientSession.sessionId,
     clientId: resolved.clientSession.clientId,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -99,11 +99,22 @@ export default {
       );
     }
 
+    const appSessionMatch = matchPackageAppSessionPath(url.pathname);
+    if (appSessionMatch) {
+      return handlePackageAppSessionRequest(request, env, ctx, appSessionMatch);
+    }
+
     const appMatch = matchPackageAppPath(url.pathname);
     if (appMatch) {
       const session = getPackageAppSession(request);
       if (!session) {
         return new Response("Unauthorized", { status: 401 });
+      }
+      if (request.method !== "GET" && request.method !== "HEAD") {
+        return new Response("Method Not Allowed", {
+          status: 405,
+          headers: { allow: "GET, HEAD" },
+        });
       }
 
       const kernel = await getAgentByName(env.KERNEL, "singleton");
@@ -118,39 +129,7 @@ export default {
         return new Response(resolved.message, { status: resolved.status });
       }
 
-      const runner = ctx.exports.AppRunner.getByName(buildAppRunnerName(resolved.auth.uid, resolved.packageId));
-      await runner.ensureRuntime({
-        packageId: resolved.packageId,
-        packageName: resolved.packageName,
-        routeBase: resolved.routeBase,
-        entrypointName: resolved.appFrame.entrypointName,
-        artifact: resolved.artifact,
-        appFrame: resolved.appFrame,
-      });
-
-      const response = deserializeAppHttpResponse(
-        await runner.gsvFetch(await serializeAppHttpRequest(buildPackageWorkerRequest(request, resolved))),
-      );
-      return await withPackageAppClientSession(response, resolved);
-    }
-
-    const appRpcMatch = matchPackageAppRpcPath(url.pathname);
-    if (appRpcMatch) {
-      if (!isWebSocketRequest(request)) {
-        return new Response("App RPC requires WebSocket", {
-          status: 426,
-          headers: {
-            "cache-control": "no-store",
-            upgrade: "websocket",
-          },
-        });
-      }
-      return handlePackageAppSocketRequest(request, env, ctx, appRpcMatch);
-    }
-
-    const appSessionRefreshMatch = matchPackageAppSessionRefreshPath(url.pathname);
-    if (appSessionRefreshMatch) {
-      return handlePackageAppSessionRefreshRequest(request, env, appSessionRefreshMatch);
+      return redirectToPackageAppSession(request, resolved, appMatch.suffix);
     }
 
     return new Response("Not Found", { status: 404 });
@@ -261,6 +240,8 @@ type PackageAppSession = {
   token: string;
 };
 
+const PACKAGE_APP_SESSION_COOKIE_PREFIX = "gsv_app_session_";
+
 type BasicAuth = {
   username: string;
   credential: string;
@@ -274,8 +255,17 @@ type GitPathMatch = {
 };
 
 type PackageAppSessionRefreshMatch = {
-  packageName: string;
   sessionId: string;
+};
+
+type PackageAppLaunchMatch = {
+  packageName: string;
+  suffix: string;
+};
+
+type PackageAppSessionPathMatch = {
+  sessionId: string;
+  suffix: string;
 };
 
 type ResolvedPackageRoute = {
@@ -287,12 +277,12 @@ type ResolvedPackageRoute = {
   appFrame: AppFrameContext;
   clientSession: {
     sessionId: string;
-    secret: string;
     clientId: string;
     packageId: string;
     packageName: string;
     routeBase: string;
     rpcBase: string;
+    secret?: string;
     createdAt: number;
     expiresAt: number;
   };
@@ -304,9 +294,12 @@ type ResolvedPackageRoute = {
   };
 };
 
-function matchPackageAppPath(pathname: string): { packageName: string } | null {
+function matchPackageAppPath(pathname: string): PackageAppLaunchMatch | null {
   const parts = pathname.split("/").filter(Boolean);
   if (parts.length < 2 || parts[0] !== "apps") {
+    return null;
+  }
+  if (parts[1] === "sessions") {
     return null;
   }
 
@@ -315,51 +308,32 @@ function matchPackageAppPath(pathname: string): { packageName: string } | null {
     return null;
   }
 
-  return { packageName: rawName };
+  const suffixParts = parts.slice(2);
+  return {
+    packageName: rawName,
+    suffix: suffixParts.length > 0 ? `/${suffixParts.join("/")}` : "/",
+  };
 }
 
-function matchPackageAppRpcPath(
-  pathname: string,
-): { packageName: string; sessionId: string } | null {
+function matchPackageAppSessionPath(pathname: string): PackageAppSessionPathMatch | null {
   const parts = pathname.split("/").filter(Boolean);
-  if (parts.length !== 4 || parts[0] !== "app-rpc" || parts[2] !== "sessions") {
+  if (parts.length < 3 || parts[0] !== "apps" || parts[1] !== "sessions") {
     return null;
   }
 
-  const packageName = parts[1]?.trim();
-  const sessionId = parts[3]?.trim();
-  if (!packageName || !sessionId) {
-    return null;
-  }
-  if (!/^[a-z0-9][a-z0-9-]*$/.test(packageName)) {
+  const sessionId = parts[2]?.trim();
+  if (!sessionId) {
     return null;
   }
   if (!/^[a-f0-9-]+$/i.test(sessionId)) {
     return null;
   }
 
-  return { packageName, sessionId };
-}
-
-function matchPackageAppSessionRefreshPath(pathname: string): PackageAppSessionRefreshMatch | null {
-  const parts = pathname.split("/").filter(Boolean);
-  if (parts.length !== 5 || parts[0] !== "app-rpc" || parts[2] !== "sessions" || parts[4] !== "refresh") {
-    return null;
-  }
-
-  const packageName = parts[1]?.trim();
-  const sessionId = parts[3]?.trim();
-  if (!packageName || !sessionId) {
-    return null;
-  }
-  if (!/^[a-z0-9][a-z0-9-]*$/.test(packageName)) {
-    return null;
-  }
-  if (!/^[a-f0-9-]+$/i.test(sessionId)) {
-    return null;
-  }
-
-  return { packageName, sessionId };
+  const suffixParts = parts.slice(3);
+  return {
+    sessionId,
+    suffix: suffixParts.length > 0 ? `/${suffixParts.join("/")}` : "/",
+  };
 }
 
 function matchGitPath(url: URL): GitPathMatch | null {
@@ -467,7 +441,56 @@ function parseCookieHeader(raw: string | null): Map<string, string> {
   return map;
 }
 
-function buildPackageWorkerRequest(request: Request, resolved: ResolvedPackageRoute): Request {
+function getPackageAppSessionSecret(request: Request, sessionId: string): string {
+  return parseCookieHeader(request.headers.get("cookie")).get(packageAppSessionCookieName(sessionId)) ?? "";
+}
+
+function buildPackageAppSessionCookie(
+  request: Request,
+  sessionId: string,
+  secret: string,
+  expiresAt: number,
+): string {
+  const url = new URL(request.url);
+  const maxAgeSeconds = Math.max(1, Math.ceil((expiresAt - Date.now()) / 1000));
+  const parts = [
+    `${packageAppSessionCookieName(sessionId)}=${encodeURIComponent(secret)}`,
+    "HttpOnly",
+    "SameSite=Strict",
+    `Path=${packageAppSessionCookiePath(sessionId)}`,
+    `Max-Age=${maxAgeSeconds}`,
+  ];
+  if (url.protocol === "https:") {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+function packageAppSessionCookieName(sessionId: string): string {
+  return `${PACKAGE_APP_SESSION_COOKIE_PREFIX}${sessionId.replace(/[^A-Za-z0-9]/g, "_")}`;
+}
+
+function packageAppSessionCookiePath(sessionId: string): string {
+  return `/apps/sessions/${encodeURIComponent(sessionId)}`;
+}
+
+function packageSessionPath(sessionId: string, suffix: string): string {
+  const normalizedSuffix = suffix && suffix !== "/" ? suffix : "/";
+  return `${packageAppSessionCookiePath(sessionId)}${normalizedSuffix}`;
+}
+
+function packageWorkerPath(routeBase: string, suffix: string): string {
+  if (!suffix || suffix === "/") {
+    return routeBase;
+  }
+  return `${routeBase}${suffix}`;
+}
+
+function buildPackageWorkerRequest(
+  request: Request,
+  resolved: ResolvedPackageRoute,
+  sessionSuffix = "/",
+): Request {
   const headers = new Headers(request.headers);
   headers.delete("cookie");
   headers.delete("authorization");
@@ -478,46 +501,61 @@ function buildPackageWorkerRequest(request: Request, resolved: ResolvedPackageRo
   headers.set("x-gsv-package-id", resolved.packageId);
   headers.set("x-gsv-package-name", resolved.packageName);
 
-  return new Request(request, { headers });
+  const url = new URL(request.url);
+  url.pathname = packageWorkerPath(resolved.routeBase, sessionSuffix);
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+  };
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = request.body;
+  }
+  return new Request(url.toString(), init);
 }
 
-function handlePackageAppSocketRequest(
+async function handlePackageAppSessionRequest(
   request: Request,
   env: Env,
   ctx: ExecutionContext,
-  match: { packageName: string; sessionId: string },
-): Promise<Response> | Response {
-  const url = new URL(request.url);
-  const routeToken = url.searchParams.get("routeToken")?.trim() ?? "";
-  if (!routeToken) {
-    return new Response("App RPC route is missing route token", {
-      status: 400,
-      headers: { "cache-control": "no-store" },
-    });
-  }
-
-  return (async () => {
-    const kernel = await getAgentByName(env.KERNEL, "singleton");
-    const resolved = await kernel.resolvePackageAppRpcRoute({
-      packageName: match.packageName,
-      sessionId: match.sessionId,
-      routeToken,
-    });
-    if (!resolved.ok) {
-      return new Response(resolved.message, {
-        status: resolved.status,
-        headers: { "cache-control": "no-store" },
+  match: PackageAppSessionPathMatch,
+): Promise<Response> {
+  if (match.suffix === "/socket") {
+    if (!isWebSocketRequest(request)) {
+      return new Response("App socket requires WebSocket", {
+        status: 426,
+        headers: {
+          "cache-control": "no-store",
+          upgrade: "websocket",
+        },
       });
     }
+    return handlePackageAppSocketRequest(request, env, ctx, match);
+  }
 
-    const runner = ctx.exports.AppRunner.getByName(buildAppRunnerName(resolved.uid, resolved.packageId));
-    const headers = new Headers(request.headers);
-    headers.set("x-gsv-app-package-name", resolved.packageName);
-    headers.set("x-gsv-app-session-id", resolved.sessionId);
-    headers.set("x-gsv-app-runner-uid", String(resolved.uid));
-    headers.set("x-gsv-app-runner-package-id", resolved.packageId);
-    return runner.fetch(new Request(request, { headers }));
-  })();
+  if (match.suffix === "/refresh") {
+    return handlePackageAppSessionRefreshRequest(request, env, match);
+  }
+
+  const resolved = await resolvePackageAppSessionFromCookie(request, env, match.sessionId);
+  if (!resolved.ok) {
+    return new Response(resolved.message, { status: resolved.status });
+  }
+
+  const runner = ctx.exports.AppRunner.getByName(buildAppRunnerName(resolved.auth.uid, resolved.packageId));
+  await runner.ensureRuntime({
+    packageId: resolved.packageId,
+    packageName: resolved.packageName,
+    routeBase: resolved.routeBase,
+    entrypointName: resolved.appFrame.entrypointName,
+    artifact: resolved.artifact,
+    appFrame: resolved.appFrame,
+  });
+
+  const response = deserializeAppHttpResponse(
+    await runner.gsvFetch(await serializeAppHttpRequest(buildPackageWorkerRequest(request, resolved, match.suffix))),
+  );
+  return await withPackageAppClientSession(response, resolved);
 }
 
 async function handlePackageAppSessionRefreshRequest(
@@ -532,24 +570,12 @@ async function handlePackageAppSessionRefreshRequest(
     });
   }
 
-  const session = getPackageAppSession(request);
-  if (!session) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-
-  let clientId: string | undefined;
-  try {
-    clientId = await readRefreshClientId(request);
-  } catch {
-    return new Response("Invalid JSON", { status: 400 });
-  }
+  const secret = getPackageAppSessionSecret(request, match.sessionId);
 
   const kernel = await getAgentByName(env.KERNEL, "singleton");
-  const resolved = await kernel.resolvePackageHttpRoute({
-    packageName: match.packageName,
-    username: session.username,
-    token: session.token,
-    clientId,
+  const resolved = await kernel.refreshPackageAppRpcSession({
+    sessionId: match.sessionId,
+    secret,
   });
 
   if (!resolved.ok) {
@@ -559,25 +585,97 @@ async function handlePackageAppSessionRefreshRequest(
   return Response.json(buildPackageAppBoot(resolved), {
     headers: {
       "cache-control": "no-store",
+      "set-cookie": buildPackageAppSessionCookie(request, match.sessionId, secret, resolved.clientSession.expiresAt),
     },
   });
 }
 
-async function readRefreshClientId(request: Request): Promise<string | undefined> {
-  const text = await request.text();
-  if (!text.trim()) {
-    return undefined;
+async function handlePackageAppSocketRequest(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  match: PackageAppSessionPathMatch,
+): Promise<Response> {
+  const resolved = await resolvePackageAppSessionFromCookie(request, env, match.sessionId);
+  if (!resolved.ok) {
+    return new Response(resolved.message, {
+      status: resolved.status,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+  if (!resolved.hasRpc) {
+    return new Response("Package app has no backend rpc", {
+      status: 404,
+      headers: { "cache-control": "no-store" },
+    });
   }
 
-  const parsed = JSON.parse(text) as unknown;
-  if (!parsed || typeof parsed !== "object") {
-    return undefined;
+  const runner = ctx.exports.AppRunner.getByName(buildAppRunnerName(resolved.auth.uid, resolved.packageId));
+  await runner.ensureRuntime({
+    packageId: resolved.packageId,
+    packageName: resolved.packageName,
+    routeBase: resolved.routeBase,
+    entrypointName: resolved.appFrame.entrypointName,
+    artifact: resolved.artifact,
+    appFrame: resolved.appFrame,
+  });
+
+  const headers = new Headers(request.headers);
+  headers.set("x-gsv-app-socket-context", encodeURIComponent(JSON.stringify({
+    session: {
+      sessionId: resolved.clientSession.sessionId,
+      clientId: resolved.clientSession.clientId,
+      rpcBase: resolved.clientSession.rpcBase,
+      expiresAt: resolved.clientSession.expiresAt,
+    },
+    appFrame: resolved.appFrame,
+  })));
+  return runner.fetch(new Request(request, { headers }));
+}
+
+async function resolvePackageAppSessionFromCookie(
+  request: Request,
+  env: Env,
+  sessionId: string,
+): Promise<ResolvedPackageRoute | { ok: false; status: number; message: string }> {
+  const secret = getPackageAppSessionSecret(request, sessionId);
+  if (!secret) {
+    return { ok: false, status: 401, message: "Unauthorized" };
   }
 
-  const clientId = (parsed as { clientId?: unknown }).clientId;
-  return typeof clientId === "string" && clientId.trim().length > 0
-    ? clientId.trim()
-    : undefined;
+  const kernel = await getAgentByName(env.KERNEL, "singleton");
+  return kernel.resolvePackageAppRpcSession({
+    sessionId,
+    secret,
+  });
+}
+
+function redirectToPackageAppSession(
+  request: Request,
+  resolved: ResolvedPackageRoute,
+  suffix: string,
+): Response {
+  const secret = resolved.clientSession.secret;
+  if (!secret) {
+    return new Response("Package app session is missing secret", { status: 500 });
+  }
+
+  const url = new URL(request.url);
+  url.pathname = packageSessionPath(resolved.clientSession.sessionId, suffix);
+  const headers = new Headers({
+    location: url.pathname + url.search + url.hash,
+    "cache-control": "no-store",
+    "set-cookie": buildPackageAppSessionCookie(
+      request,
+      resolved.clientSession.sessionId,
+      secret,
+      resolved.clientSession.expiresAt,
+    ),
+  });
+  return new Response(null, {
+    status: 303,
+    headers,
+  });
 }
 
 async function withPackageAppClientSession(
@@ -646,10 +744,9 @@ function buildPackageAppBoot(resolved: ResolvedPackageRoute) {
   return {
     packageId: resolved.packageId,
     packageName: resolved.packageName,
-    routeBase: resolved.routeBase,
+    routeBase: packageAppSessionCookiePath(resolved.clientSession.sessionId),
     rpcBase: resolved.clientSession.rpcBase,
     sessionId: resolved.clientSession.sessionId,
-    sessionSecret: resolved.clientSession.secret,
     clientId: resolved.clientSession.clientId,
     expiresAt: resolved.clientSession.expiresAt,
     hasBackend: resolved.hasRpc,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,5 +1,4 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
-import { RpcTarget, newWorkersRpcResponse } from "capnweb";
 import { isWebSocketRequest } from "./shared//utils";
 import type {
   GatewayAdapterInterface,
@@ -137,12 +136,16 @@ export default {
 
     const appRpcMatch = matchPackageAppRpcPath(url.pathname);
     if (appRpcMatch) {
-      const response = await newWorkersRpcResponse(
-        request,
-        new PackageAppSessionRpcTarget(env, ctx, appRpcMatch.packageName, appRpcMatch.sessionId),
-      );
-      response.headers.set("cache-control", "no-store");
-      return response;
+      if (!isWebSocketRequest(request)) {
+        return new Response("App RPC requires WebSocket", {
+          status: 426,
+          headers: {
+            "cache-control": "no-store",
+            upgrade: "websocket",
+          },
+        });
+      }
+      return handlePackageAppSocketRequest(request, env, ctx, appRpcMatch);
     }
 
     const appSessionRefreshMatch = matchPackageAppSessionRefreshPath(url.pathname);
@@ -300,37 +303,6 @@ type ResolvedPackageRoute = {
     capabilities: string[];
   };
 };
-
-type ResolvedPackageAppRpcSession =
-  | {
-      ok: true;
-      packageId: string;
-      packageName: string;
-      routeBase: string;
-      artifact: PackageArtifactMetadata;
-      appFrame: AppFrameContext;
-      clientSession: {
-        sessionId: string;
-      clientId: string;
-      packageId: string;
-      packageName: string;
-        routeBase: string;
-        rpcBase: string;
-        createdAt: number;
-        expiresAt: number;
-      };
-      hasRpc: boolean;
-      auth: {
-        uid: number;
-        username: string;
-        capabilities: string[];
-      };
-    }
-  | {
-      ok: false;
-      status: number;
-      message: string;
-    };
 
 function matchPackageAppPath(pathname: string): { packageName: string } | null {
   const parts = pathname.split("/").filter(Boolean);
@@ -509,6 +481,45 @@ function buildPackageWorkerRequest(request: Request, resolved: ResolvedPackageRo
   return new Request(request, { headers });
 }
 
+function handlePackageAppSocketRequest(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  match: { packageName: string; sessionId: string },
+): Promise<Response> | Response {
+  const url = new URL(request.url);
+  const routeToken = url.searchParams.get("routeToken")?.trim() ?? "";
+  if (!routeToken) {
+    return new Response("App RPC route is missing route token", {
+      status: 400,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+
+  return (async () => {
+    const kernel = await getAgentByName(env.KERNEL, "singleton");
+    const resolved = await kernel.resolvePackageAppRpcRoute({
+      packageName: match.packageName,
+      sessionId: match.sessionId,
+      routeToken,
+    });
+    if (!resolved.ok) {
+      return new Response(resolved.message, {
+        status: resolved.status,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+
+    const runner = ctx.exports.AppRunner.getByName(buildAppRunnerName(resolved.uid, resolved.packageId));
+    const headers = new Headers(request.headers);
+    headers.set("x-gsv-app-package-name", resolved.packageName);
+    headers.set("x-gsv-app-session-id", resolved.sessionId);
+    headers.set("x-gsv-app-runner-uid", String(resolved.uid));
+    headers.set("x-gsv-app-runner-package-id", resolved.packageId);
+    return runner.fetch(new Request(request, { headers }));
+  })();
+}
+
 async function handlePackageAppSessionRefreshRequest(
   request: Request,
   env: Env,
@@ -605,14 +616,6 @@ function injectAppBootstrapHtml(html: string, resolved: ResolvedPackageRoute): s
   const scriptLines = [
     `<script>window.__GSV_APP_BOOT__=${boot};${PACKAGE_APP_RUNTIME_SCRIPT}</script>`,
   ];
-  if (resolved.hasRpc) {
-    scriptLines.push(
-      `<script type="module">`,
-      `import { RpcTarget, newWebSocketRpcSession } from "https://cdn.jsdelivr.net/npm/capnweb@0.6.1/+esm";`,
-      `window.capnweb={ RpcTarget, newWebSocketRpcSession };`,
-      "</script>",
-    );
-  }
   const headExtras = [
     htmlHasViewportMeta(html) ? "" : PACKAGE_APP_VIEWPORT_META,
     PACKAGE_APP_RUNTIME_STYLE,
@@ -651,52 +654,6 @@ function buildPackageAppBoot(resolved: ResolvedPackageRoute) {
     expiresAt: resolved.clientSession.expiresAt,
     hasBackend: resolved.hasRpc,
   };
-}
-
-class PackageAppSessionRpcTarget extends RpcTarget {
-  constructor(
-    private readonly env: Env,
-    private readonly ctx: ExecutionContext,
-    private readonly packageName: string,
-    private readonly sessionId: string,
-  ) {
-    super();
-  }
-
-  async authenticate(secret: string, clientTarget?: unknown): Promise<unknown> {
-    const kernel = await getAgentByName(this.env.KERNEL, "singleton");
-    const resolved = await kernel.resolvePackageAppRpcSession({
-      packageName: this.packageName,
-      sessionId: this.sessionId,
-      secret,
-    }) as ResolvedPackageAppRpcSession;
-
-    if (!resolved.ok) {
-      throw new Error(resolved.message);
-    }
-
-    const runner = this.ctx.exports.AppRunner.getByName(buildAppRunnerName(resolved.auth.uid, resolved.packageId));
-    await runner.ensureRuntime({
-      packageId: resolved.packageId,
-      packageName: resolved.packageName,
-      routeBase: resolved.routeBase,
-      entrypointName: resolved.appFrame.entrypointName,
-      artifact: resolved.artifact,
-      appFrame: resolved.appFrame,
-    });
-
-    return runner.getBackend(
-      {
-        sessionId: resolved.clientSession.sessionId,
-        clientId: resolved.clientSession.clientId,
-        rpcBase: resolved.clientSession.rpcBase,
-        expiresAt: resolved.clientSession.expiresAt,
-      },
-      clientTarget && (typeof clientTarget === "object" || typeof clientTarget === "function")
-        ? clientTarget as never
-        : null,
-    );
-  }
 }
 
 async function buildGitProxyRequest(

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -474,11 +474,6 @@ function packageAppSessionCookiePath(sessionId: string): string {
   return `/apps/sessions/${encodeURIComponent(sessionId)}`;
 }
 
-function packageSessionPath(sessionId: string, suffix: string): string {
-  const normalizedSuffix = suffix && suffix !== "/" ? suffix : "/";
-  return `${packageAppSessionCookiePath(sessionId)}${normalizedSuffix}`;
-}
-
 function packageWorkerPath(routeBase: string, suffix: string): string {
   if (!suffix || suffix === "/") {
     return routeBase;
@@ -537,6 +532,10 @@ async function handlePackageAppSessionRequest(
     return handlePackageAppSessionRefreshRequest(request, env, match);
   }
 
+  if (match.suffix === "/launch") {
+    return handlePackageAppSessionLaunchRequest(request, env, match);
+  }
+
   const resolved = await resolvePackageAppSessionFromCookie(request, env, match.sessionId);
   if (!resolved.ok) {
     return new Response(resolved.message, { status: resolved.status });
@@ -556,6 +555,42 @@ async function handlePackageAppSessionRequest(
     await runner.gsvFetch(await serializeAppHttpRequest(buildPackageWorkerRequest(request, resolved, match.suffix))),
   );
   return await withPackageAppClientSession(response, resolved);
+}
+
+async function handlePackageAppSessionLaunchRequest(
+  request: Request,
+  env: Env,
+  match: PackageAppSessionPathMatch,
+): Promise<Response> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { allow: "GET, HEAD" },
+    });
+  }
+
+  const url = new URL(request.url);
+  const secret = url.searchParams.get("token")?.trim() ?? "";
+  if (!secret) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const kernel = await getAgentByName(env.KERNEL, "singleton");
+  const resolved = await kernel.resolvePackageAppRpcSession({
+    sessionId: match.sessionId,
+    secret,
+  });
+
+  if (!resolved.ok) {
+    return new Response(resolved.message, { status: resolved.status });
+  }
+
+  return redirectToPackageAppSessionLocation(
+    request,
+    resolved,
+    normalizePackageAppLaunchNext(url.searchParams.get("next")),
+    secret,
+  );
 }
 
 async function handlePackageAppSessionRefreshRequest(
@@ -660,10 +695,23 @@ function redirectToPackageAppSession(
     return new Response("Package app session is missing secret", { status: 500 });
   }
 
-  const url = new URL(request.url);
-  url.pathname = packageSessionPath(resolved.clientSession.sessionId, suffix);
+  return redirectToPackageAppSessionLocation(
+    request,
+    resolved,
+    urlPathFromSuffix(request, suffix),
+    secret,
+  );
+}
+
+function redirectToPackageAppSessionLocation(
+  request: Request,
+  resolved: ResolvedPackageRoute,
+  next: string,
+  secret: string,
+): Response {
+  const location = `${packageAppSessionCookiePath(resolved.clientSession.sessionId)}${next}`;
   const headers = new Headers({
-    location: url.pathname + url.search + url.hash,
+    location,
     "cache-control": "no-store",
     "set-cookie": buildPackageAppSessionCookie(
       request,
@@ -676,6 +724,32 @@ function redirectToPackageAppSession(
     status: 303,
     headers,
   });
+}
+
+function urlPathFromSuffix(request: Request, suffix: string): string {
+  const url = new URL(request.url);
+  const normalizedSuffix = suffix && suffix !== "/" ? suffix : "/";
+  return `${normalizedSuffix}${url.search}${url.hash}`;
+}
+
+function normalizePackageAppLaunchNext(raw: string | null): string {
+  if (!raw) {
+    return "/";
+  }
+
+  try {
+    const base = "https://gsv.invalid";
+    const parsed = new URL(raw, base);
+    if (parsed.origin !== base) {
+      return "/";
+    }
+    if (parsed.pathname === "/launch" || parsed.pathname === "/refresh" || parsed.pathname === "/socket") {
+      return "/";
+    }
+    return `${parsed.pathname || "/"}${parsed.search}${parsed.hash}`;
+  } catch {
+    return "/";
+  }
 }
 
 async function withPackageAppClientSession(

--- a/gateway/src/kernel/app-sessions.test.ts
+++ b/gateway/src/kernel/app-sessions.test.ts
@@ -13,12 +13,17 @@ function result<T = Row>(rows: T[] = []) {
 }
 
 function createMockSql() {
-  const table = new Map<string, Row>();
+  const sessions = new Map<string, Row>();
+  const clients = new Map<string, Row>();
   const keys = new Map<string, Row>();
+  const clientKey = (sessionId: string, clientId: string) => `${sessionId}:${clientId}`;
 
   function exec<T = Row>(query: string, ...bindings: unknown[]) {
     const q = query.trim();
 
+    if (q.startsWith("DROP TABLE IF EXISTS")) {
+      return result<T>();
+    }
     if (q.startsWith("CREATE TABLE IF NOT EXISTS")) {
       return result<T>();
     }
@@ -26,17 +31,7 @@ function createMockSql() {
       return result<T>();
     }
 
-    if (q.startsWith("DELETE FROM app_client_sessions WHERE expires_at <= ?")) {
-      const [now] = bindings as [number];
-      for (const [sessionId, row] of table.entries()) {
-        if ((row.expires_at as number) <= now || row.revoked_at !== null) {
-          table.delete(sessionId);
-        }
-      }
-      return result<T>();
-    }
-
-    if (q.startsWith("DELETE FROM app_client_session_keys WHERE expires_at <= ?")) {
+    if (q.startsWith("DELETE FROM app_session_client_keys WHERE expires_at <= ?")) {
       const [now] = bindings as [number];
       for (const [keyId, row] of keys.entries()) {
         if ((row.expires_at as number) <= now || row.revoked_at !== null) {
@@ -46,7 +41,45 @@ function createMockSql() {
       return result<T>();
     }
 
-    if (q.startsWith("INSERT INTO app_client_sessions")) {
+    if (q.startsWith("DELETE FROM app_session_clients WHERE expires_at <= ?")) {
+      const [now] = bindings as [number];
+      for (const [key, row] of clients.entries()) {
+        if ((row.expires_at as number) <= now || row.closed_at !== null) {
+          clients.delete(key);
+        }
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("DELETE FROM app_sessions WHERE expires_at <= ?")) {
+      const [now] = bindings as [number];
+      for (const [sessionId, row] of sessions.entries()) {
+        if ((row.expires_at as number) <= now || row.closed_at !== null) {
+          sessions.delete(sessionId);
+        }
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("DELETE FROM app_session_client_keys WHERE session_id NOT IN")) {
+      for (const [keyId, row] of keys.entries()) {
+        if (!sessions.has(row.session_id as string)) {
+          keys.delete(keyId);
+        }
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("DELETE FROM app_session_clients WHERE session_id NOT IN")) {
+      for (const [key, row] of clients.entries()) {
+        if (!sessions.has(row.session_id as string)) {
+          clients.delete(key);
+        }
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("INSERT INTO app_sessions")) {
       const [
         sessionId,
         uid,
@@ -55,17 +88,13 @@ function createMockSql() {
         packageName,
         entrypointName,
         routeBase,
-        clientId,
-        secretHash,
         createdAt,
         lastUsedAt,
         expiresAt,
-        revokedAt,
+        closedAt,
       ] = bindings as [
         string,
         number,
-        string,
-        string,
         string,
         string,
         string,
@@ -76,7 +105,7 @@ function createMockSql() {
         number,
         number | null,
       ];
-      table.set(sessionId, {
+      sessions.set(sessionId, {
         session_id: sessionId,
         uid,
         username,
@@ -84,28 +113,48 @@ function createMockSql() {
         package_name: packageName,
         entrypoint_name: entrypointName,
         route_base: routeBase,
-        client_id: clientId,
-        secret_hash: secretHash,
         created_at: createdAt,
         last_used_at: lastUsedAt,
         expires_at: expiresAt,
-        revoked_at: revokedAt,
+        closed_at: closedAt,
       });
       return result<T>();
     }
 
-    if (q.startsWith("INSERT INTO app_client_session_keys")) {
+    if (q.startsWith("INSERT INTO app_session_clients")) {
+      const [
+        sessionId,
+        clientId,
+        createdAt,
+        lastUsedAt,
+        expiresAt,
+        closedAt,
+      ] = bindings as [string, string, number, number | null, number, number | null];
+      clients.set(clientKey(sessionId, clientId), {
+        session_id: sessionId,
+        client_id: clientId,
+        created_at: createdAt,
+        last_used_at: lastUsedAt,
+        expires_at: expiresAt,
+        closed_at: closedAt,
+      });
+      return result<T>();
+    }
+
+    if (q.startsWith("INSERT INTO app_session_client_keys")) {
       const [
         keyId,
         sessionId,
+        clientId,
         secretHash,
         createdAt,
         expiresAt,
         revokedAt,
-      ] = bindings as [string, string, string, number, number, number | null];
+      ] = bindings as [string, string, string, string, number, number, number | null];
       keys.set(keyId, {
         key_id: keyId,
         session_id: sessionId,
+        client_id: clientId,
         secret_hash: secretHash,
         created_at: createdAt,
         expires_at: expiresAt,
@@ -114,16 +163,16 @@ function createMockSql() {
       return result<T>();
     }
 
-    if (q.startsWith("SELECT * FROM app_client_sessions WHERE session_id = ?")) {
+    if (q.startsWith("SELECT * FROM app_sessions WHERE session_id = ?")) {
       const [sessionId] = bindings as [string];
-      const row = table.get(sessionId);
+      const row = sessions.get(sessionId);
       return result<T>(row ? [row as T] : []);
     }
 
-    if (q.startsWith("SELECT * FROM app_client_sessions") && q.includes("WHERE uid = ?")) {
+    if (q.startsWith("SELECT * FROM app_sessions") && q.includes("WHERE uid = ?")) {
       const [uid, now] = bindings as [number, number];
-      return result<T>([...table.values()]
-        .filter((row) => row.uid === uid && row.revoked_at === null && (row.expires_at as number) > now)
+      return result<T>([...sessions.values()]
+        .filter((row) => row.uid === uid && row.closed_at === null && (row.expires_at as number) > now)
         .sort((left, right) => {
           const leftTime = (left.last_used_at as number | null) ?? (left.created_at as number);
           const rightTime = (right.last_used_at as number | null) ?? (right.created_at as number);
@@ -131,15 +180,51 @@ function createMockSql() {
         }) as T[]);
     }
 
-    if (q.startsWith("SELECT * FROM app_client_session_keys")) {
+    if (q.startsWith("SELECT * FROM app_session_clients") && q.includes("client_id = ?")) {
+      const [sessionId, clientId] = bindings as [string, string];
+      const row = clients.get(clientKey(sessionId, clientId));
+      return result<T>(row ? [row as T] : []);
+    }
+
+    if (q.startsWith("SELECT * FROM app_session_clients")) {
+      const [sessionId, now] = bindings as [string, number];
+      return result<T>([...clients.values()]
+        .filter((row) => row.session_id === sessionId && row.closed_at === null && (row.expires_at as number) > now)
+        .sort((left, right) => {
+          const leftTime = (left.last_used_at as number | null) ?? (left.created_at as number);
+          const rightTime = (right.last_used_at as number | null) ?? (right.created_at as number);
+          return rightTime - leftTime;
+        }) as T[]);
+    }
+
+    if (q.startsWith("SELECT * FROM app_session_client_keys")) {
       const [sessionId, now] = bindings as [string, number];
       return result<T>([...keys.values()]
         .filter((row) => row.session_id === sessionId && row.revoked_at === null && (row.expires_at as number) > now) as T[]);
     }
 
-    if (q.startsWith("UPDATE app_client_sessions SET last_used_at = ?, expires_at = ?")) {
+    if (q.startsWith("UPDATE app_sessions SET last_used_at = ?, expires_at = MAX")) {
       const [lastUsedAt, expiresAt, sessionId] = bindings as [number, number, string];
-      const row = table.get(sessionId);
+      const row = sessions.get(sessionId);
+      if (row) {
+        row.last_used_at = lastUsedAt;
+        row.expires_at = Math.max(row.expires_at as number, expiresAt);
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_sessions SET last_used_at = ?")) {
+      const [lastUsedAt, sessionId] = bindings as [number, string];
+      const row = sessions.get(sessionId);
+      if (row) {
+        row.last_used_at = lastUsedAt;
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_session_clients SET last_used_at = ?, expires_at = ?")) {
+      const [lastUsedAt, expiresAt, sessionId, clientId] = bindings as [number, number, string, string];
+      const row = clients.get(clientKey(sessionId, clientId));
       if (row) {
         row.last_used_at = lastUsedAt;
         row.expires_at = expiresAt;
@@ -147,25 +232,16 @@ function createMockSql() {
       return result<T>();
     }
 
-    if (q.startsWith("UPDATE app_client_sessions SET last_used_at = ?")) {
-      const [lastUsedAt, sessionId] = bindings as [number, string];
-      const row = table.get(sessionId);
+    if (q.startsWith("UPDATE app_session_clients SET last_used_at = ?")) {
+      const [lastUsedAt, sessionId, clientId] = bindings as [number, string, string];
+      const row = clients.get(clientKey(sessionId, clientId));
       if (row) {
         row.last_used_at = lastUsedAt;
       }
       return result<T>();
     }
 
-    if (q.startsWith("UPDATE app_client_sessions SET revoked_at = ?")) {
-      const [revokedAt, sessionId] = bindings as [number, string];
-      const row = table.get(sessionId);
-      if (row) {
-        row.revoked_at = revokedAt;
-      }
-      return result<T>();
-    }
-
-    if (q.startsWith("UPDATE app_client_session_keys SET expires_at = ?")) {
+    if (q.startsWith("UPDATE app_session_client_keys SET expires_at = ?")) {
       const [expiresAt, keyId] = bindings as [number, string];
       const row = keys.get(keyId);
       if (row) {
@@ -174,7 +250,26 @@ function createMockSql() {
       return result<T>();
     }
 
-    if (q.startsWith("UPDATE app_client_session_keys SET revoked_at = ?")) {
+    if (q.startsWith("UPDATE app_sessions SET closed_at = ?")) {
+      const [closedAt, sessionId] = bindings as [number, string];
+      const row = sessions.get(sessionId);
+      if (row) {
+        row.closed_at = closedAt;
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_session_clients SET closed_at = ?")) {
+      const [closedAt, sessionId] = bindings as [number, string];
+      for (const row of clients.values()) {
+        if (row.session_id === sessionId && row.closed_at === null) {
+          row.closed_at = closedAt;
+        }
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_session_client_keys SET revoked_at = ?")) {
       const [revokedAt, sessionId] = bindings as [number, string];
       for (const row of keys.values()) {
         if (row.session_id === sessionId && row.revoked_at === null) {
@@ -250,7 +345,7 @@ describe("AppSessionStore", () => {
     expect(refreshed?.lastUsedAt).toBe(105_000);
   });
 
-  it("mints additional launch secrets without invalidating existing sessions", async () => {
+  it("attaches additional clients without invalidating existing sessions", async () => {
     vi.spyOn(Date, "now").mockReturnValue(200_000);
 
     const store = new AppSessionStore(createMockSql() as unknown as SqlStorage);
@@ -268,7 +363,12 @@ describe("AppSessionStore", () => {
     });
 
     vi.spyOn(Date, "now").mockReturnValue(201_000);
-    const minted = await store.mintSecret(1000, issued.sessionId, 20_000);
+    const minted = await store.attach({
+      uid: 1000,
+      sessionId: issued.sessionId,
+      clientId: "win-2",
+      ttlMs: 20_000,
+    });
     expect(minted?.secret).toMatch(/[0-9a-f-]+/i);
     expect(minted?.secret).not.toBe(issued.secret);
     expect(minted?.expiresAt).toBe(221_000);
@@ -278,6 +378,7 @@ describe("AppSessionStore", () => {
     });
     expect(await store.resolve(issued.sessionId, minted!.secret)).toMatchObject({
       sessionId: issued.sessionId,
+      clientId: "win-2",
     });
   });
 
@@ -298,10 +399,17 @@ describe("AppSessionStore", () => {
       ttlMs: 10_000,
     });
 
-    expect(store.list(1000)).toHaveLength(1);
+    expect(store.list(1000)).toEqual([expect.objectContaining({
+      sessionId: issued.sessionId,
+      clients: [expect.objectContaining({ clientId: "win-1" })],
+      state: "active",
+    })]);
     expect(store.list(1001)).toHaveLength(0);
-    expect(store.close(1001, issued.sessionId)).toBe(false);
-    expect(store.close(1000, issued.sessionId)).toBe(true);
+    expect(store.close(1001, issued.sessionId)).toBeNull();
+    expect(store.close(1000, issued.sessionId)).toMatchObject({
+      sessionId: issued.sessionId,
+      state: "closed",
+    });
     expect(store.list(1000)).toHaveLength(0);
   });
 });

--- a/gateway/src/kernel/app-sessions.test.ts
+++ b/gateway/src/kernel/app-sessions.test.ts
@@ -259,11 +259,30 @@ function createMockSql() {
       return result<T>();
     }
 
+    if (q.startsWith("UPDATE app_session_clients SET closed_at = ?") && q.includes("client_id = ?")) {
+      const [closedAt, sessionId, clientId] = bindings as [number, string, string];
+      const row = clients.get(clientKey(sessionId, clientId));
+      if (row && row.closed_at === null) {
+        row.closed_at = closedAt;
+      }
+      return result<T>();
+    }
+
     if (q.startsWith("UPDATE app_session_clients SET closed_at = ?")) {
       const [closedAt, sessionId] = bindings as [number, string];
       for (const row of clients.values()) {
         if (row.session_id === sessionId && row.closed_at === null) {
           row.closed_at = closedAt;
+        }
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_session_client_keys SET revoked_at = ?") && q.includes("client_id = ?")) {
+      const [revokedAt, sessionId, clientId] = bindings as [number, string, string];
+      for (const row of keys.values()) {
+        if (row.session_id === sessionId && row.client_id === clientId && row.revoked_at === null) {
+          row.revoked_at = revokedAt;
         }
       }
       return result<T>();
@@ -379,6 +398,17 @@ describe("AppSessionStore", () => {
     expect(await store.resolve(issued.sessionId, minted!.secret)).toMatchObject({
       sessionId: issued.sessionId,
       clientId: "win-2",
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(202_000);
+    expect(store.detach(1000, issued.sessionId, "win-2")).toMatchObject({
+      sessionId: issued.sessionId,
+      clientId: "win-2",
+    });
+    expect(await store.resolve(issued.sessionId, minted!.secret)).toBeNull();
+    expect(await store.resolve(issued.sessionId, issued.secret)).toMatchObject({
+      sessionId: issued.sessionId,
+      clientId: "win-1",
     });
   });
 

--- a/gateway/src/kernel/app-sessions.test.ts
+++ b/gateway/src/kernel/app-sessions.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppSessionStore } from "./app-sessions";
+
+type Row = Record<string, unknown>;
+
+function result<T = Row>(rows: T[] = []) {
+  return {
+    toArray: () => rows,
+    *[Symbol.iterator]() {
+      yield* rows;
+    },
+  };
+}
+
+function createMockSql() {
+  const table = new Map<string, Row>();
+
+  function exec<T = Row>(query: string, ...bindings: unknown[]) {
+    const q = query.trim();
+
+    if (q.startsWith("CREATE TABLE IF NOT EXISTS")) {
+      return result<T>();
+    }
+    if (q.startsWith("CREATE INDEX IF NOT EXISTS")) {
+      return result<T>();
+    }
+
+    if (q.startsWith("DELETE FROM app_client_sessions WHERE expires_at <= ?")) {
+      const [now] = bindings as [number];
+      for (const [sessionId, row] of table.entries()) {
+        if ((row.expires_at as number) <= now || row.revoked_at !== null) {
+          table.delete(sessionId);
+        }
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("INSERT INTO app_client_sessions")) {
+      const [
+        sessionId,
+        uid,
+        username,
+        packageId,
+        packageName,
+        entrypointName,
+        routeBase,
+        clientId,
+        secretHash,
+        createdAt,
+        lastUsedAt,
+        expiresAt,
+        revokedAt,
+      ] = bindings as [
+        string,
+        number,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        number,
+        number | null,
+        number,
+        number | null,
+      ];
+      table.set(sessionId, {
+        session_id: sessionId,
+        uid,
+        username,
+        package_id: packageId,
+        package_name: packageName,
+        entrypoint_name: entrypointName,
+        route_base: routeBase,
+        client_id: clientId,
+        secret_hash: secretHash,
+        created_at: createdAt,
+        last_used_at: lastUsedAt,
+        expires_at: expiresAt,
+        revoked_at: revokedAt,
+      });
+      return result<T>();
+    }
+
+    if (q.startsWith("SELECT * FROM app_client_sessions WHERE session_id = ?")) {
+      const [sessionId] = bindings as [string];
+      const row = table.get(sessionId);
+      return result<T>(row ? [row as T] : []);
+    }
+
+    if (q.startsWith("UPDATE app_client_sessions SET last_used_at = ?, expires_at = ?")) {
+      const [lastUsedAt, expiresAt, sessionId] = bindings as [number, number, string];
+      const row = table.get(sessionId);
+      if (row) {
+        row.last_used_at = lastUsedAt;
+        row.expires_at = expiresAt;
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_client_sessions SET last_used_at = ?")) {
+      const [lastUsedAt, sessionId] = bindings as [number, string];
+      const row = table.get(sessionId);
+      if (row) {
+        row.last_used_at = lastUsedAt;
+      }
+      return result<T>();
+    }
+
+    throw new Error(`unexpected query: ${q}`);
+  }
+
+  return { exec };
+}
+
+describe("AppSessionStore", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("issues cookie-backed app sessions with a session socket rpc base", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(10_000);
+
+    const store = new AppSessionStore(createMockSql() as unknown as SqlStorage);
+    store.init();
+
+    const issued = await store.issue({
+      uid: 1000,
+      username: "alice",
+      packageId: "pkg-chat",
+      packageName: "chat",
+      entrypointName: "Chat",
+      routeBase: "/apps/chat",
+      clientId: "win-1",
+      ttlMs: 60_000,
+    });
+
+    expect(issued.secret).toMatch(/[0-9a-f-]+/i);
+    expect(issued.rpcBase).toBe(`/apps/sessions/${issued.sessionId}/socket`);
+    expect(issued.expiresAt).toBe(70_000);
+
+    vi.spyOn(Date, "now").mockReturnValue(20_000);
+    const resolved = await store.resolve(issued.sessionId, issued.secret);
+
+    expect(resolved?.clientId).toBe("win-1");
+    expect(resolved?.rpcBase).toBe(issued.rpcBase);
+    expect(resolved?.lastUsedAt).toBe(20_000);
+  });
+
+  it("refreshes an existing session without changing its socket path", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(100_000);
+
+    const store = new AppSessionStore(createMockSql() as unknown as SqlStorage);
+    store.init();
+
+    const issued = await store.issue({
+      uid: 1000,
+      username: "alice",
+      packageId: "pkg-chat",
+      packageName: "chat",
+      entrypointName: "Chat",
+      routeBase: "/apps/chat",
+      clientId: "win-1",
+      ttlMs: 10_000,
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(105_000);
+    const refreshed = await store.refresh(issued.sessionId, issued.secret, 30_000);
+
+    expect(refreshed?.sessionId).toBe(issued.sessionId);
+    expect(refreshed?.rpcBase).toBe(issued.rpcBase);
+    expect(refreshed?.expiresAt).toBe(135_000);
+    expect(refreshed?.lastUsedAt).toBe(105_000);
+  });
+});

--- a/gateway/src/kernel/app-sessions.test.ts
+++ b/gateway/src/kernel/app-sessions.test.ts
@@ -327,7 +327,7 @@ describe("AppSessionStore", () => {
     });
 
     expect(issued.secret).toMatch(/[0-9a-f-]+/i);
-    expect(issued.rpcBase).toBe(`/apps/sessions/${issued.sessionId}/socket`);
+    expect(issued.rpcBase).toBe(`/apps/sessions/${issued.sessionId}/clients/win-1/socket`);
     expect(issued.expiresAt).toBe(70_000);
 
     vi.spyOn(Date, "now").mockReturnValue(20_000);

--- a/gateway/src/kernel/app-sessions.test.ts
+++ b/gateway/src/kernel/app-sessions.test.ts
@@ -14,6 +14,7 @@ function result<T = Row>(rows: T[] = []) {
 
 function createMockSql() {
   const table = new Map<string, Row>();
+  const keys = new Map<string, Row>();
 
   function exec<T = Row>(query: string, ...bindings: unknown[]) {
     const q = query.trim();
@@ -30,6 +31,16 @@ function createMockSql() {
       for (const [sessionId, row] of table.entries()) {
         if ((row.expires_at as number) <= now || row.revoked_at !== null) {
           table.delete(sessionId);
+        }
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("DELETE FROM app_client_session_keys WHERE expires_at <= ?")) {
+      const [now] = bindings as [number];
+      for (const [keyId, row] of keys.entries()) {
+        if ((row.expires_at as number) <= now || row.revoked_at !== null) {
+          keys.delete(keyId);
         }
       }
       return result<T>();
@@ -83,10 +94,47 @@ function createMockSql() {
       return result<T>();
     }
 
+    if (q.startsWith("INSERT INTO app_client_session_keys")) {
+      const [
+        keyId,
+        sessionId,
+        secretHash,
+        createdAt,
+        expiresAt,
+        revokedAt,
+      ] = bindings as [string, string, string, number, number, number | null];
+      keys.set(keyId, {
+        key_id: keyId,
+        session_id: sessionId,
+        secret_hash: secretHash,
+        created_at: createdAt,
+        expires_at: expiresAt,
+        revoked_at: revokedAt,
+      });
+      return result<T>();
+    }
+
     if (q.startsWith("SELECT * FROM app_client_sessions WHERE session_id = ?")) {
       const [sessionId] = bindings as [string];
       const row = table.get(sessionId);
       return result<T>(row ? [row as T] : []);
+    }
+
+    if (q.startsWith("SELECT * FROM app_client_sessions") && q.includes("WHERE uid = ?")) {
+      const [uid, now] = bindings as [number, number];
+      return result<T>([...table.values()]
+        .filter((row) => row.uid === uid && row.revoked_at === null && (row.expires_at as number) > now)
+        .sort((left, right) => {
+          const leftTime = (left.last_used_at as number | null) ?? (left.created_at as number);
+          const rightTime = (right.last_used_at as number | null) ?? (right.created_at as number);
+          return rightTime - leftTime;
+        }) as T[]);
+    }
+
+    if (q.startsWith("SELECT * FROM app_client_session_keys")) {
+      const [sessionId, now] = bindings as [string, number];
+      return result<T>([...keys.values()]
+        .filter((row) => row.session_id === sessionId && row.revoked_at === null && (row.expires_at as number) > now) as T[]);
     }
 
     if (q.startsWith("UPDATE app_client_sessions SET last_used_at = ?, expires_at = ?")) {
@@ -104,6 +152,34 @@ function createMockSql() {
       const row = table.get(sessionId);
       if (row) {
         row.last_used_at = lastUsedAt;
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_client_sessions SET revoked_at = ?")) {
+      const [revokedAt, sessionId] = bindings as [number, string];
+      const row = table.get(sessionId);
+      if (row) {
+        row.revoked_at = revokedAt;
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_client_session_keys SET expires_at = ?")) {
+      const [expiresAt, keyId] = bindings as [number, string];
+      const row = keys.get(keyId);
+      if (row) {
+        row.expires_at = expiresAt;
+      }
+      return result<T>();
+    }
+
+    if (q.startsWith("UPDATE app_client_session_keys SET revoked_at = ?")) {
+      const [revokedAt, sessionId] = bindings as [number, string];
+      for (const row of keys.values()) {
+        if (row.session_id === sessionId && row.revoked_at === null) {
+          row.revoked_at = revokedAt;
+        }
       }
       return result<T>();
     }
@@ -172,5 +248,60 @@ describe("AppSessionStore", () => {
     expect(refreshed?.rpcBase).toBe(issued.rpcBase);
     expect(refreshed?.expiresAt).toBe(135_000);
     expect(refreshed?.lastUsedAt).toBe(105_000);
+  });
+
+  it("mints additional launch secrets without invalidating existing sessions", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(200_000);
+
+    const store = new AppSessionStore(createMockSql() as unknown as SqlStorage);
+    store.init();
+
+    const issued = await store.issue({
+      uid: 1000,
+      username: "alice",
+      packageId: "pkg-chat",
+      packageName: "chat",
+      entrypointName: "Chat",
+      routeBase: "/apps/chat",
+      clientId: "win-1",
+      ttlMs: 10_000,
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(201_000);
+    const minted = await store.mintSecret(1000, issued.sessionId, 20_000);
+    expect(minted?.secret).toMatch(/[0-9a-f-]+/i);
+    expect(minted?.secret).not.toBe(issued.secret);
+    expect(minted?.expiresAt).toBe(221_000);
+
+    expect(await store.resolve(issued.sessionId, issued.secret)).toMatchObject({
+      sessionId: issued.sessionId,
+    });
+    expect(await store.resolve(issued.sessionId, minted!.secret)).toMatchObject({
+      sessionId: issued.sessionId,
+    });
+  });
+
+  it("lists and closes active sessions for the owning user", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(300_000);
+
+    const store = new AppSessionStore(createMockSql() as unknown as SqlStorage);
+    store.init();
+
+    const issued = await store.issue({
+      uid: 1000,
+      username: "alice",
+      packageId: "pkg-chat",
+      packageName: "chat",
+      entrypointName: "Chat",
+      routeBase: "/apps/chat",
+      clientId: "win-1",
+      ttlMs: 10_000,
+    });
+
+    expect(store.list(1000)).toHaveLength(1);
+    expect(store.list(1001)).toHaveLength(0);
+    expect(store.close(1001, issued.sessionId)).toBe(false);
+    expect(store.close(1000, issued.sessionId)).toBe(true);
+    expect(store.list(1000)).toHaveLength(0);
   });
 });

--- a/gateway/src/kernel/app-sessions.ts
+++ b/gateway/src/kernel/app-sessions.ts
@@ -9,7 +9,6 @@ type AppSessionRow = {
   package_name: string;
   entrypoint_name: string;
   route_base: string;
-  route_token: string | null;
   client_id: string;
   secret_hash: string;
   created_at: number;
@@ -31,7 +30,6 @@ export class AppSessionStore {
         package_name TEXT NOT NULL,
         entrypoint_name TEXT NOT NULL,
         route_base TEXT NOT NULL,
-        route_token TEXT,
         client_id TEXT NOT NULL,
         secret_hash TEXT NOT NULL,
         created_at INTEGER NOT NULL,
@@ -46,7 +44,6 @@ export class AppSessionStore {
     this.sql.exec(
       "CREATE INDEX IF NOT EXISTS idx_app_client_sessions_expires ON app_client_sessions (expires_at)",
     );
-    this.ensureRouteTokenColumn();
   }
 
   async issue(input: {
@@ -63,16 +60,15 @@ export class AppSessionStore {
     const now = Date.now();
     const sessionId = crypto.randomUUID();
     const secret = crypto.randomUUID();
-    const routeToken = crypto.randomUUID();
     const expiresAt = now + input.ttlMs;
     const secretHash = await hashToken(secret);
 
     this.sql.exec(
       `INSERT INTO app_client_sessions (
         session_id, uid, username, package_id, package_name, entrypoint_name,
-        route_base, route_token, client_id, secret_hash, created_at, last_used_at,
+        route_base, client_id, secret_hash, created_at, last_used_at,
         expires_at, revoked_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       sessionId,
       input.uid,
       input.username,
@@ -80,7 +76,6 @@ export class AppSessionStore {
       input.packageName,
       input.entrypointName,
       input.routeBase,
-      routeToken,
       input.clientId,
       secretHash,
       now,
@@ -99,26 +94,11 @@ export class AppSessionStore {
       packageName: input.packageName,
       entrypointName: input.entrypointName,
       routeBase: input.routeBase,
-      rpcBase: buildAppRpcBase(input.packageName, sessionId, routeToken),
+      rpcBase: buildAppRpcBase(sessionId),
       createdAt: now,
       expiresAt,
       lastUsedAt: null,
     };
-  }
-
-  resolveRoute(
-    sessionId: string,
-    routeToken: string,
-  ): AppClientSessionContext | null {
-    this.pruneExpired();
-    const row = this.getRow(sessionId);
-    if (!row || row.revoked_at != null || row.expires_at <= Date.now()) {
-      return null;
-    }
-    if (!row.route_token || row.route_token !== routeToken) {
-      return null;
-    }
-    return toContext(row);
   }
 
   async resolve(
@@ -149,6 +129,38 @@ export class AppSessionStore {
     });
   }
 
+  async refresh(
+    sessionId: string,
+    secret: string,
+    ttlMs: number,
+  ): Promise<AppClientSessionContext | null> {
+    this.pruneExpired();
+    const row = this.getRow(sessionId);
+    if (!row) {
+      return null;
+    }
+    if (row.revoked_at != null || row.expires_at <= Date.now()) {
+      return null;
+    }
+    const ok = await verify(secret, row.secret_hash);
+    if (!ok) {
+      return null;
+    }
+    const now = Date.now();
+    const expiresAt = now + ttlMs;
+    this.sql.exec(
+      "UPDATE app_client_sessions SET last_used_at = ?, expires_at = ? WHERE session_id = ?",
+      now,
+      expiresAt,
+      sessionId,
+    );
+    return toContext({
+      ...row,
+      last_used_at: now,
+      expires_at: expiresAt,
+    });
+  }
+
   private getRow(sessionId: string): AppSessionRow | null {
     const rows = [...this.sql.exec<AppSessionRow>(
       "SELECT * FROM app_client_sessions WHERE session_id = ? LIMIT 1",
@@ -163,14 +175,6 @@ export class AppSessionStore {
       Date.now(),
     );
   }
-
-  private ensureRouteTokenColumn(): void {
-    const columns = [...this.sql.exec<{ name: string }>("PRAGMA table_info(app_client_sessions)")];
-    if (columns.some((column) => column.name === "route_token")) {
-      return;
-    }
-    this.sql.exec("ALTER TABLE app_client_sessions ADD COLUMN route_token TEXT");
-  }
 }
 
 function toContext(row: AppSessionRow): AppClientSessionContext {
@@ -183,20 +187,13 @@ function toContext(row: AppSessionRow): AppClientSessionContext {
     packageName: row.package_name,
     entrypointName: row.entrypoint_name,
     routeBase: row.route_base,
-    rpcBase: buildAppRpcBase(row.package_name, row.session_id, row.route_token ?? ""),
+    rpcBase: buildAppRpcBase(row.session_id),
     createdAt: row.created_at,
     expiresAt: row.expires_at,
     lastUsedAt: row.last_used_at,
   };
 }
 
-function buildAppRpcBase(
-  packageName: string,
-  sessionId: string,
-  routeToken: string,
-): string {
-  const params = new URLSearchParams({
-    routeToken,
-  });
-  return `/app-rpc/${packageName}/sessions/${sessionId}?${params.toString()}`;
+function buildAppRpcBase(sessionId: string): string {
+  return `/apps/sessions/${encodeURIComponent(sessionId)}/socket`;
 }

--- a/gateway/src/kernel/app-sessions.ts
+++ b/gateway/src/kernel/app-sessions.ts
@@ -311,6 +311,46 @@ export class AppSessionStore {
     return this.toSessionContext(row);
   }
 
+  detach(uid: number, sessionId: string, clientId: string): AppClientSessionContext | null {
+    this.pruneExpired();
+    const session = this.getSessionRow(sessionId);
+    if (!this.isActiveSessionForUid(session, uid)) {
+      return null;
+    }
+
+    const client = this.getClientRow(sessionId, clientId);
+    if (!client || client.closed_at != null || client.expires_at <= Date.now()) {
+      return null;
+    }
+
+    const now = Date.now();
+    this.sql.exec(
+      "UPDATE app_sessions SET last_used_at = ? WHERE session_id = ?",
+      now,
+      sessionId,
+    );
+    this.sql.exec(
+      "UPDATE app_session_clients SET closed_at = ? WHERE session_id = ? AND client_id = ? AND closed_at IS NULL",
+      now,
+      sessionId,
+      clientId,
+    );
+    this.sql.exec(
+      "UPDATE app_session_client_keys SET revoked_at = ? WHERE session_id = ? AND client_id = ? AND revoked_at IS NULL",
+      now,
+      sessionId,
+      clientId,
+    );
+
+    return toClientContext({
+      session: {
+        ...session,
+        last_used_at: now,
+      },
+      client,
+    });
+  }
+
   close(uid: number, sessionId: string): AppSessionContext | null {
     this.pruneExpired();
     const session = this.getActiveForUid(uid, sessionId);

--- a/gateway/src/kernel/app-sessions.ts
+++ b/gateway/src/kernel/app-sessions.ts
@@ -1,4 +1,10 @@
-import type { IssuedAppClientSession, AppClientSessionContext } from "../protocol/app-session";
+import type {
+  AppClientSessionContext,
+  AppSessionClientContext,
+  AppSessionContext,
+  AppSessionState,
+  IssuedAppClientSession,
+} from "../protocol/app-session";
 import { hashToken, verify } from "../auth/shadow";
 
 export const APP_CLIENT_SESSION_TTL_MS = 12 * 60 * 60 * 1000;
@@ -11,17 +17,25 @@ type AppSessionRow = {
   package_name: string;
   entrypoint_name: string;
   route_base: string;
-  client_id: string;
-  secret_hash: string;
   created_at: number;
   last_used_at: number | null;
   expires_at: number;
-  revoked_at: number | null;
+  closed_at: number | null;
 };
 
-type AppSessionKeyRow = {
+type AppSessionClientRow = {
+  session_id: string;
+  client_id: string;
+  created_at: number;
+  last_used_at: number | null;
+  expires_at: number;
+  closed_at: number | null;
+};
+
+type AppSessionClientKeyRow = {
   key_id: string;
   session_id: string;
+  client_id: string;
   secret_hash: string;
   created_at: number;
   expires_at: number;
@@ -29,15 +43,22 @@ type AppSessionKeyRow = {
 };
 
 type VerifiedSecret =
-  | { ok: true; keyId: string | null }
+  | {
+      ok: true;
+      session: AppSessionRow;
+      client: AppSessionClientRow;
+      key: AppSessionClientKeyRow;
+    }
   | { ok: false };
 
 export class AppSessionStore {
   constructor(private readonly sql: SqlStorage) {}
 
   init(): void {
+    this.sql.exec("DROP TABLE IF EXISTS app_client_session_keys");
+    this.sql.exec("DROP TABLE IF EXISTS app_client_sessions");
     this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS app_client_sessions (
+      CREATE TABLE IF NOT EXISTS app_sessions (
         session_id TEXT PRIMARY KEY,
         uid INTEGER NOT NULL,
         username TEXT NOT NULL,
@@ -45,24 +66,37 @@ export class AppSessionStore {
         package_name TEXT NOT NULL,
         entrypoint_name TEXT NOT NULL,
         route_base TEXT NOT NULL,
-        client_id TEXT NOT NULL,
-        secret_hash TEXT NOT NULL,
         created_at INTEGER NOT NULL,
         last_used_at INTEGER,
         expires_at INTEGER NOT NULL,
-        revoked_at INTEGER
+        closed_at INTEGER
       )
     `);
     this.sql.exec(
-      "CREATE INDEX IF NOT EXISTS idx_app_client_sessions_uid_pkg ON app_client_sessions (uid, package_id, created_at DESC)",
+      "CREATE INDEX IF NOT EXISTS idx_app_sessions_uid_pkg ON app_sessions (uid, package_id, created_at DESC)",
     );
     this.sql.exec(
-      "CREATE INDEX IF NOT EXISTS idx_app_client_sessions_expires ON app_client_sessions (expires_at)",
+      "CREATE INDEX IF NOT EXISTS idx_app_sessions_expires ON app_sessions (expires_at)",
     );
     this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS app_client_session_keys (
+      CREATE TABLE IF NOT EXISTS app_session_clients (
+        session_id TEXT NOT NULL,
+        client_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        expires_at INTEGER NOT NULL,
+        closed_at INTEGER,
+        PRIMARY KEY (session_id, client_id)
+      )
+    `);
+    this.sql.exec(
+      "CREATE INDEX IF NOT EXISTS idx_app_session_clients_session ON app_session_clients (session_id, expires_at)",
+    );
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS app_session_client_keys (
         key_id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
+        client_id TEXT NOT NULL,
         secret_hash TEXT NOT NULL,
         created_at INTEGER NOT NULL,
         expires_at INTEGER NOT NULL,
@@ -70,7 +104,7 @@ export class AppSessionStore {
       )
     `);
     this.sql.exec(
-      "CREATE INDEX IF NOT EXISTS idx_app_client_session_keys_session ON app_client_session_keys (session_id, expires_at)",
+      "CREATE INDEX IF NOT EXISTS idx_app_session_client_keys_session ON app_session_client_keys (session_id, client_id, expires_at)",
     );
   }
 
@@ -87,16 +121,13 @@ export class AppSessionStore {
     this.pruneExpired();
     const now = Date.now();
     const sessionId = crypto.randomUUID();
-    const secret = crypto.randomUUID();
     const expiresAt = now + input.ttlMs;
-    const secretHash = await hashToken(secret);
 
     this.sql.exec(
-      `INSERT INTO app_client_sessions (
+      `INSERT INTO app_sessions (
         session_id, uid, username, package_id, package_name, entrypoint_name,
-        route_base, client_id, secret_hash, created_at, last_used_at,
-        expires_at, revoked_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        route_base, created_at, last_used_at, expires_at, closed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       sessionId,
       input.uid,
       input.username,
@@ -104,28 +135,78 @@ export class AppSessionStore {
       input.packageName,
       input.entrypointName,
       input.routeBase,
-      input.clientId,
-      secretHash,
       now,
       null,
       expiresAt,
       null,
     );
 
+    this.insertClient(sessionId, input.clientId, now, expiresAt);
+    const secret = await this.insertClientKey(sessionId, input.clientId, now, expiresAt);
+
     return {
-      sessionId,
+      ...toClientContext({
+        session: {
+          session_id: sessionId,
+          uid: input.uid,
+          username: input.username,
+          package_id: input.packageId,
+          package_name: input.packageName,
+          entrypoint_name: input.entrypointName,
+          route_base: input.routeBase,
+          created_at: now,
+          last_used_at: null,
+          expires_at: expiresAt,
+          closed_at: null,
+        },
+        client: {
+          session_id: sessionId,
+          client_id: input.clientId,
+          created_at: now,
+          last_used_at: null,
+          expires_at: expiresAt,
+          closed_at: null,
+        },
+      }),
       secret,
-      clientId: input.clientId,
-      uid: input.uid,
-      username: input.username,
-      packageId: input.packageId,
-      packageName: input.packageName,
-      entrypointName: input.entrypointName,
-      routeBase: input.routeBase,
-      rpcBase: buildAppRpcBase(sessionId),
-      createdAt: now,
-      expiresAt,
-      lastUsedAt: null,
+    };
+  }
+
+  async attach(input: {
+    uid: number;
+    sessionId: string;
+    clientId: string;
+    ttlMs: number;
+  }): Promise<IssuedAppClientSession | null> {
+    this.pruneExpired();
+    const session = this.getSessionRow(input.sessionId);
+    if (!this.isActiveSessionForUid(session, input.uid)) {
+      return null;
+    }
+
+    const now = Date.now();
+    const expiresAt = now + input.ttlMs;
+    this.insertClient(input.sessionId, input.clientId, now, expiresAt);
+    const secret = await this.insertClientKey(input.sessionId, input.clientId, now, expiresAt);
+    this.touchSession(input.sessionId, now, expiresAt);
+
+    return {
+      ...toClientContext({
+        session: {
+          ...session,
+          last_used_at: now,
+          expires_at: Math.max(session.expires_at, expiresAt),
+        },
+        client: {
+          session_id: input.sessionId,
+          client_id: input.clientId,
+          created_at: now,
+          last_used_at: null,
+          expires_at: expiresAt,
+          closed_at: null,
+        },
+      }),
+      secret,
     };
   }
 
@@ -134,26 +215,33 @@ export class AppSessionStore {
     secret: string,
   ): Promise<AppClientSessionContext | null> {
     this.pruneExpired();
-    const row = this.getRow(sessionId);
-    if (!row) {
-      return null;
-    }
-    if (row.revoked_at != null || row.expires_at <= Date.now()) {
-      return null;
-    }
-    const verified = await this.verifySecret(row, secret);
+    const verified = await this.verifySecret(sessionId, secret);
     if (!verified.ok) {
       return null;
     }
+
     const lastUsedAt = Date.now();
     this.sql.exec(
-      "UPDATE app_client_sessions SET last_used_at = ? WHERE session_id = ?",
+      "UPDATE app_sessions SET last_used_at = ? WHERE session_id = ?",
       lastUsedAt,
       sessionId,
     );
-    return toContext({
-      ...row,
-      last_used_at: lastUsedAt,
+    this.sql.exec(
+      "UPDATE app_session_clients SET last_used_at = ? WHERE session_id = ? AND client_id = ?",
+      lastUsedAt,
+      sessionId,
+      verified.client.client_id,
+    );
+
+    return toClientContext({
+      session: {
+        ...verified.session,
+        last_used_at: lastUsedAt,
+      },
+      client: {
+        ...verified.client,
+        last_used_at: lastUsedAt,
+      },
     });
   }
 
@@ -163,179 +251,287 @@ export class AppSessionStore {
     ttlMs: number,
   ): Promise<AppClientSessionContext | null> {
     this.pruneExpired();
-    const row = this.getRow(sessionId);
-    if (!row) {
-      return null;
-    }
-    if (row.revoked_at != null || row.expires_at <= Date.now()) {
-      return null;
-    }
-    const verified = await this.verifySecret(row, secret);
+    const verified = await this.verifySecret(sessionId, secret);
     if (!verified.ok) {
       return null;
     }
+
     const now = Date.now();
     const expiresAt = now + ttlMs;
     this.sql.exec(
-      "UPDATE app_client_sessions SET last_used_at = ?, expires_at = ? WHERE session_id = ?",
+      "UPDATE app_sessions SET last_used_at = ?, expires_at = MAX(expires_at, ?) WHERE session_id = ?",
       now,
       expiresAt,
       sessionId,
     );
-    if (verified.keyId) {
-      this.sql.exec(
-        "UPDATE app_client_session_keys SET expires_at = ? WHERE key_id = ?",
-        expiresAt,
-        verified.keyId,
-      );
-    }
-    return toContext({
-      ...row,
-      last_used_at: now,
-      expires_at: expiresAt,
+    this.sql.exec(
+      "UPDATE app_session_clients SET last_used_at = ?, expires_at = ? WHERE session_id = ? AND client_id = ?",
+      now,
+      expiresAt,
+      sessionId,
+      verified.client.client_id,
+    );
+    this.sql.exec(
+      "UPDATE app_session_client_keys SET expires_at = ? WHERE key_id = ?",
+      expiresAt,
+      verified.key.key_id,
+    );
+
+    return toClientContext({
+      session: {
+        ...verified.session,
+        last_used_at: now,
+        expires_at: Math.max(verified.session.expires_at, expiresAt),
+      },
+      client: {
+        ...verified.client,
+        last_used_at: now,
+        expires_at: expiresAt,
+      },
     });
   }
 
-  list(uid: number): AppClientSessionContext[] {
+  list(uid: number): AppSessionContext[] {
     this.pruneExpired();
     return this.sql.exec<AppSessionRow>(
-      `SELECT * FROM app_client_sessions
-       WHERE uid = ? AND revoked_at IS NULL AND expires_at > ?
+      `SELECT * FROM app_sessions
+       WHERE uid = ? AND closed_at IS NULL AND expires_at > ?
        ORDER BY last_used_at DESC, created_at DESC`,
       uid,
       Date.now(),
-    ).toArray().map(toContext);
+    ).toArray().map((row) => this.toSessionContext(row));
   }
 
-  getActiveForUid(uid: number, sessionId: string): AppClientSessionContext | null {
+  getActiveForUid(uid: number, sessionId: string): AppSessionContext | null {
     this.pruneExpired();
-    const row = this.getRow(sessionId);
-    if (!row || row.uid !== uid || row.revoked_at != null || row.expires_at <= Date.now()) {
+    const row = this.getSessionRow(sessionId);
+    if (!this.isActiveSessionForUid(row, uid)) {
       return null;
     }
-    return toContext(row);
+    return this.toSessionContext(row);
   }
 
-  async mintSecret(uid: number, sessionId: string, ttlMs: number): Promise<IssuedAppClientSession | null> {
+  close(uid: number, sessionId: string): AppSessionContext | null {
     this.pruneExpired();
-    const row = this.getRow(sessionId);
-    if (!row || row.uid !== uid || row.revoked_at != null || row.expires_at <= Date.now()) {
+    const session = this.getActiveForUid(uid, sessionId);
+    if (!session) {
       return null;
     }
 
     const now = Date.now();
-    const keyId = crypto.randomUUID();
-    const secret = crypto.randomUUID();
-    const expiresAt = now + ttlMs;
-    const secretHash = await hashToken(secret);
-
     this.sql.exec(
-      `INSERT INTO app_client_session_keys (
-        key_id, session_id, secret_hash, created_at, expires_at, revoked_at
-      ) VALUES (?, ?, ?, ?, ?, ?)`,
-      keyId,
-      sessionId,
-      secretHash,
+      "UPDATE app_sessions SET closed_at = ? WHERE session_id = ?",
       now,
-      expiresAt,
-      null,
-    );
-    this.sql.exec(
-      "UPDATE app_client_sessions SET last_used_at = ?, expires_at = ? WHERE session_id = ?",
-      now,
-      expiresAt,
       sessionId,
     );
-
+    this.sql.exec(
+      "UPDATE app_session_clients SET closed_at = ? WHERE session_id = ? AND closed_at IS NULL",
+      now,
+      sessionId,
+    );
+    this.sql.exec(
+      "UPDATE app_session_client_keys SET revoked_at = ? WHERE session_id = ? AND revoked_at IS NULL",
+      now,
+      sessionId,
+    );
     return {
-      ...toContext({
-        ...row,
-        last_used_at: now,
-        expires_at: expiresAt,
-      }),
-      secret,
+      ...session,
+      state: "closed",
     };
   }
 
-  close(uid: number, sessionId: string): boolean {
-    this.pruneExpired();
-    const row = this.getRow(sessionId);
-    if (!row || row.uid !== uid || row.revoked_at != null || row.expires_at <= Date.now()) {
-      return false;
-    }
-
-    const now = Date.now();
-    this.sql.exec(
-      "UPDATE app_client_sessions SET revoked_at = ? WHERE session_id = ?",
-      now,
-      sessionId,
-    );
-    this.sql.exec(
-      "UPDATE app_client_session_keys SET revoked_at = ? WHERE session_id = ? AND revoked_at IS NULL",
-      now,
-      sessionId,
-    );
-    return true;
-  }
-
-  private getRow(sessionId: string): AppSessionRow | null {
+  private getSessionRow(sessionId: string): AppSessionRow | null {
     const rows = [...this.sql.exec<AppSessionRow>(
-      "SELECT * FROM app_client_sessions WHERE session_id = ? LIMIT 1",
+      "SELECT * FROM app_sessions WHERE session_id = ? LIMIT 1",
       sessionId,
     )];
     return rows[0] ?? null;
   }
 
-  private getKeyRows(sessionId: string): AppSessionKeyRow[] {
-    return this.sql.exec<AppSessionKeyRow>(
-      `SELECT * FROM app_client_session_keys
+  private getActiveClientRows(sessionId: string): AppSessionClientRow[] {
+    return this.sql.exec<AppSessionClientRow>(
+      `SELECT * FROM app_session_clients
+       WHERE session_id = ? AND closed_at IS NULL AND expires_at > ?
+       ORDER BY last_used_at DESC, created_at DESC`,
+      sessionId,
+      Date.now(),
+    ).toArray();
+  }
+
+  private getClientRow(sessionId: string, clientId: string): AppSessionClientRow | null {
+    const rows = [...this.sql.exec<AppSessionClientRow>(
+      `SELECT * FROM app_session_clients
+       WHERE session_id = ? AND client_id = ? LIMIT 1`,
+      sessionId,
+      clientId,
+    )];
+    return rows[0] ?? null;
+  }
+
+  private getKeyRows(sessionId: string): AppSessionClientKeyRow[] {
+    return this.sql.exec<AppSessionClientKeyRow>(
+      `SELECT * FROM app_session_client_keys
        WHERE session_id = ? AND revoked_at IS NULL AND expires_at > ?`,
       sessionId,
       Date.now(),
     ).toArray();
   }
 
-  private async verifySecret(row: AppSessionRow, secret: string): Promise<VerifiedSecret> {
-    if (await verify(secret, row.secret_hash)) {
-      return { ok: true, keyId: null };
+  private insertClient(sessionId: string, clientId: string, now: number, expiresAt: number): void {
+    this.sql.exec(
+      `INSERT INTO app_session_clients (
+        session_id, client_id, created_at, last_used_at, expires_at, closed_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(session_id, client_id) DO UPDATE SET
+        last_used_at = excluded.last_used_at,
+        expires_at = excluded.expires_at,
+        closed_at = NULL`,
+      sessionId,
+      clientId,
+      now,
+      null,
+      expiresAt,
+      null,
+    );
+  }
+
+  private async insertClientKey(
+    sessionId: string,
+    clientId: string,
+    now: number,
+    expiresAt: number,
+  ): Promise<string> {
+    const keyId = crypto.randomUUID();
+    const secret = crypto.randomUUID();
+    const secretHash = await hashToken(secret);
+    this.sql.exec(
+      `INSERT INTO app_session_client_keys (
+        key_id, session_id, client_id, secret_hash, created_at, expires_at, revoked_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      keyId,
+      sessionId,
+      clientId,
+      secretHash,
+      now,
+      expiresAt,
+      null,
+    );
+    return secret;
+  }
+
+  private touchSession(sessionId: string, lastUsedAt: number, expiresAt: number): void {
+    this.sql.exec(
+      "UPDATE app_sessions SET last_used_at = ?, expires_at = MAX(expires_at, ?) WHERE session_id = ?",
+      lastUsedAt,
+      expiresAt,
+      sessionId,
+    );
+  }
+
+  private async verifySecret(sessionId: string, secret: string): Promise<VerifiedSecret> {
+    const session = this.getSessionRow(sessionId);
+    if (!session || session.closed_at != null || session.expires_at <= Date.now()) {
+      return { ok: false };
     }
 
-    for (const key of this.getKeyRows(row.session_id)) {
-      if (await verify(secret, key.secret_hash)) {
-        return { ok: true, keyId: key.key_id };
+    for (const key of this.getKeyRows(sessionId)) {
+      if (!(await verify(secret, key.secret_hash))) {
+        continue;
       }
+      const client = this.getClientRow(sessionId, key.client_id);
+      if (!client || client.closed_at != null || client.expires_at <= Date.now()) {
+        return { ok: false };
+      }
+      return {
+        ok: true,
+        session,
+        client,
+        key,
+      };
     }
 
     return { ok: false };
   }
 
+  private isActiveSessionForUid(row: AppSessionRow | null, uid: number): row is AppSessionRow {
+    return Boolean(
+      row &&
+      row.uid === uid &&
+      row.closed_at == null &&
+      row.expires_at > Date.now(),
+    );
+  }
+
+  private toSessionContext(row: AppSessionRow): AppSessionContext {
+    const clients = this.getActiveClientRows(row.session_id)
+      .map((client) => toClientContext({ session: row, client }));
+    return {
+      sessionId: row.session_id,
+      uid: row.uid,
+      username: row.username,
+      packageId: row.package_id,
+      packageName: row.package_name,
+      entrypointName: row.entrypoint_name,
+      routeBase: row.route_base,
+      createdAt: row.created_at,
+      expiresAt: row.expires_at,
+      lastUsedAt: row.last_used_at,
+      state: sessionState(row, clients),
+      clients,
+    };
+  }
+
   private pruneExpired(): void {
+    const now = Date.now();
     this.sql.exec(
-      "DELETE FROM app_client_sessions WHERE expires_at <= ? OR revoked_at IS NOT NULL",
-      Date.now(),
+      "DELETE FROM app_session_client_keys WHERE expires_at <= ? OR revoked_at IS NOT NULL",
+      now,
     );
     this.sql.exec(
-      "DELETE FROM app_client_session_keys WHERE expires_at <= ? OR revoked_at IS NOT NULL",
-      Date.now(),
+      "DELETE FROM app_session_clients WHERE expires_at <= ? OR closed_at IS NOT NULL",
+      now,
+    );
+    this.sql.exec(
+      "DELETE FROM app_sessions WHERE expires_at <= ? OR closed_at IS NOT NULL",
+      now,
+    );
+    this.sql.exec(
+      "DELETE FROM app_session_client_keys WHERE session_id NOT IN (SELECT session_id FROM app_sessions)",
+    );
+    this.sql.exec(
+      "DELETE FROM app_session_clients WHERE session_id NOT IN (SELECT session_id FROM app_sessions)",
     );
   }
 }
 
-function toContext(row: AppSessionRow): AppClientSessionContext {
+function toClientContext(input: {
+  session: AppSessionRow;
+  client: AppSessionClientRow;
+}): AppSessionClientContext {
   return {
-    sessionId: row.session_id,
-    clientId: row.client_id,
-    uid: row.uid,
-    username: row.username,
-    packageId: row.package_id,
-    packageName: row.package_name,
-    entrypointName: row.entrypoint_name,
-    routeBase: row.route_base,
-    rpcBase: buildAppRpcBase(row.session_id),
-    createdAt: row.created_at,
-    expiresAt: row.expires_at,
-    lastUsedAt: row.last_used_at,
+    sessionId: input.session.session_id,
+    clientId: input.client.client_id,
+    uid: input.session.uid,
+    username: input.session.username,
+    packageId: input.session.package_id,
+    packageName: input.session.package_name,
+    entrypointName: input.session.entrypoint_name,
+    routeBase: input.session.route_base,
+    rpcBase: buildAppRpcBase(input.session.session_id),
+    createdAt: input.client.created_at,
+    expiresAt: input.client.expires_at,
+    lastUsedAt: input.client.last_used_at,
   };
+}
+
+function sessionState(row: AppSessionRow, clients: AppClientSessionContext[]): AppSessionState {
+  if (row.closed_at != null) {
+    return "closed";
+  }
+  if (row.expires_at <= Date.now()) {
+    return "expired";
+  }
+  return clients.length > 0 ? "active" : "detached";
 }
 
 function buildAppRpcBase(sessionId: string): string {

--- a/gateway/src/kernel/app-sessions.ts
+++ b/gateway/src/kernel/app-sessions.ts
@@ -9,6 +9,7 @@ type AppSessionRow = {
   package_name: string;
   entrypoint_name: string;
   route_base: string;
+  route_token: string | null;
   client_id: string;
   secret_hash: string;
   created_at: number;
@@ -30,6 +31,7 @@ export class AppSessionStore {
         package_name TEXT NOT NULL,
         entrypoint_name TEXT NOT NULL,
         route_base TEXT NOT NULL,
+        route_token TEXT,
         client_id TEXT NOT NULL,
         secret_hash TEXT NOT NULL,
         created_at INTEGER NOT NULL,
@@ -44,6 +46,7 @@ export class AppSessionStore {
     this.sql.exec(
       "CREATE INDEX IF NOT EXISTS idx_app_client_sessions_expires ON app_client_sessions (expires_at)",
     );
+    this.ensureRouteTokenColumn();
   }
 
   async issue(input: {
@@ -60,15 +63,16 @@ export class AppSessionStore {
     const now = Date.now();
     const sessionId = crypto.randomUUID();
     const secret = crypto.randomUUID();
+    const routeToken = crypto.randomUUID();
     const expiresAt = now + input.ttlMs;
     const secretHash = await hashToken(secret);
 
     this.sql.exec(
       `INSERT INTO app_client_sessions (
         session_id, uid, username, package_id, package_name, entrypoint_name,
-        route_base, client_id, secret_hash, created_at, last_used_at,
+        route_base, route_token, client_id, secret_hash, created_at, last_used_at,
         expires_at, revoked_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       sessionId,
       input.uid,
       input.username,
@@ -76,6 +80,7 @@ export class AppSessionStore {
       input.packageName,
       input.entrypointName,
       input.routeBase,
+      routeToken,
       input.clientId,
       secretHash,
       now,
@@ -94,11 +99,26 @@ export class AppSessionStore {
       packageName: input.packageName,
       entrypointName: input.entrypointName,
       routeBase: input.routeBase,
-      rpcBase: buildAppRpcBase(input.packageName, sessionId),
+      rpcBase: buildAppRpcBase(input.packageName, sessionId, routeToken),
       createdAt: now,
       expiresAt,
       lastUsedAt: null,
     };
+  }
+
+  resolveRoute(
+    sessionId: string,
+    routeToken: string,
+  ): AppClientSessionContext | null {
+    this.pruneExpired();
+    const row = this.getRow(sessionId);
+    if (!row || row.revoked_at != null || row.expires_at <= Date.now()) {
+      return null;
+    }
+    if (!row.route_token || row.route_token !== routeToken) {
+      return null;
+    }
+    return toContext(row);
   }
 
   async resolve(
@@ -143,6 +163,14 @@ export class AppSessionStore {
       Date.now(),
     );
   }
+
+  private ensureRouteTokenColumn(): void {
+    const columns = [...this.sql.exec<{ name: string }>("PRAGMA table_info(app_client_sessions)")];
+    if (columns.some((column) => column.name === "route_token")) {
+      return;
+    }
+    this.sql.exec("ALTER TABLE app_client_sessions ADD COLUMN route_token TEXT");
+  }
 }
 
 function toContext(row: AppSessionRow): AppClientSessionContext {
@@ -155,13 +183,20 @@ function toContext(row: AppSessionRow): AppClientSessionContext {
     packageName: row.package_name,
     entrypointName: row.entrypoint_name,
     routeBase: row.route_base,
-    rpcBase: buildAppRpcBase(row.package_name, row.session_id),
+    rpcBase: buildAppRpcBase(row.package_name, row.session_id, row.route_token ?? ""),
     createdAt: row.created_at,
     expiresAt: row.expires_at,
     lastUsedAt: row.last_used_at,
   };
 }
 
-function buildAppRpcBase(packageName: string, sessionId: string): string {
-  return `/app-rpc/${packageName}/sessions/${sessionId}`;
+function buildAppRpcBase(
+  packageName: string,
+  sessionId: string,
+  routeToken: string,
+): string {
+  const params = new URLSearchParams({
+    routeToken,
+  });
+  return `/app-rpc/${packageName}/sessions/${sessionId}?${params.toString()}`;
 }

--- a/gateway/src/kernel/app-sessions.ts
+++ b/gateway/src/kernel/app-sessions.ts
@@ -1,9 +1,10 @@
-import type {
-  AppClientSessionContext,
-  AppSessionClientContext,
-  AppSessionContext,
-  AppSessionState,
-  IssuedAppClientSession,
+import {
+  buildAppClientRpcBase,
+  type AppClientSessionContext,
+  type AppSessionClientContext,
+  type AppSessionContext,
+  type AppSessionState,
+  type IssuedAppClientSession,
 } from "../protocol/app-session";
 import { hashToken, verify } from "../auth/shadow";
 
@@ -557,7 +558,7 @@ function toClientContext(input: {
     packageName: input.session.package_name,
     entrypointName: input.session.entrypoint_name,
     routeBase: input.session.route_base,
-    rpcBase: buildAppRpcBase(input.session.session_id),
+    rpcBase: buildAppClientRpcBase(input.session.session_id, input.client.client_id),
     createdAt: input.client.created_at,
     expiresAt: input.client.expires_at,
     lastUsedAt: input.client.last_used_at,
@@ -572,8 +573,4 @@ function sessionState(row: AppSessionRow, clients: AppClientSessionContext[]): A
     return "expired";
   }
   return clients.length > 0 ? "active" : "detached";
-}
-
-function buildAppRpcBase(sessionId: string): string {
-  return `/apps/sessions/${encodeURIComponent(sessionId)}/socket`;
 }

--- a/gateway/src/kernel/app-sessions.ts
+++ b/gateway/src/kernel/app-sessions.ts
@@ -1,6 +1,8 @@
 import type { IssuedAppClientSession, AppClientSessionContext } from "../protocol/app-session";
 import { hashToken, verify } from "../auth/shadow";
 
+export const APP_CLIENT_SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+
 type AppSessionRow = {
   session_id: string;
   uid: number;
@@ -16,6 +18,19 @@ type AppSessionRow = {
   expires_at: number;
   revoked_at: number | null;
 };
+
+type AppSessionKeyRow = {
+  key_id: string;
+  session_id: string;
+  secret_hash: string;
+  created_at: number;
+  expires_at: number;
+  revoked_at: number | null;
+};
+
+type VerifiedSecret =
+  | { ok: true; keyId: string | null }
+  | { ok: false };
 
 export class AppSessionStore {
   constructor(private readonly sql: SqlStorage) {}
@@ -43,6 +58,19 @@ export class AppSessionStore {
     );
     this.sql.exec(
       "CREATE INDEX IF NOT EXISTS idx_app_client_sessions_expires ON app_client_sessions (expires_at)",
+    );
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS app_client_session_keys (
+        key_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        secret_hash TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        revoked_at INTEGER
+      )
+    `);
+    this.sql.exec(
+      "CREATE INDEX IF NOT EXISTS idx_app_client_session_keys_session ON app_client_session_keys (session_id, expires_at)",
     );
   }
 
@@ -113,8 +141,8 @@ export class AppSessionStore {
     if (row.revoked_at != null || row.expires_at <= Date.now()) {
       return null;
     }
-    const ok = await verify(secret, row.secret_hash);
-    if (!ok) {
+    const verified = await this.verifySecret(row, secret);
+    if (!verified.ok) {
       return null;
     }
     const lastUsedAt = Date.now();
@@ -142,8 +170,8 @@ export class AppSessionStore {
     if (row.revoked_at != null || row.expires_at <= Date.now()) {
       return null;
     }
-    const ok = await verify(secret, row.secret_hash);
-    if (!ok) {
+    const verified = await this.verifySecret(row, secret);
+    if (!verified.ok) {
       return null;
     }
     const now = Date.now();
@@ -154,11 +182,100 @@ export class AppSessionStore {
       expiresAt,
       sessionId,
     );
+    if (verified.keyId) {
+      this.sql.exec(
+        "UPDATE app_client_session_keys SET expires_at = ? WHERE key_id = ?",
+        expiresAt,
+        verified.keyId,
+      );
+    }
     return toContext({
       ...row,
       last_used_at: now,
       expires_at: expiresAt,
     });
+  }
+
+  list(uid: number): AppClientSessionContext[] {
+    this.pruneExpired();
+    return this.sql.exec<AppSessionRow>(
+      `SELECT * FROM app_client_sessions
+       WHERE uid = ? AND revoked_at IS NULL AND expires_at > ?
+       ORDER BY last_used_at DESC, created_at DESC`,
+      uid,
+      Date.now(),
+    ).toArray().map(toContext);
+  }
+
+  getActiveForUid(uid: number, sessionId: string): AppClientSessionContext | null {
+    this.pruneExpired();
+    const row = this.getRow(sessionId);
+    if (!row || row.uid !== uid || row.revoked_at != null || row.expires_at <= Date.now()) {
+      return null;
+    }
+    return toContext(row);
+  }
+
+  async mintSecret(uid: number, sessionId: string, ttlMs: number): Promise<IssuedAppClientSession | null> {
+    this.pruneExpired();
+    const row = this.getRow(sessionId);
+    if (!row || row.uid !== uid || row.revoked_at != null || row.expires_at <= Date.now()) {
+      return null;
+    }
+
+    const now = Date.now();
+    const keyId = crypto.randomUUID();
+    const secret = crypto.randomUUID();
+    const expiresAt = now + ttlMs;
+    const secretHash = await hashToken(secret);
+
+    this.sql.exec(
+      `INSERT INTO app_client_session_keys (
+        key_id, session_id, secret_hash, created_at, expires_at, revoked_at
+      ) VALUES (?, ?, ?, ?, ?, ?)`,
+      keyId,
+      sessionId,
+      secretHash,
+      now,
+      expiresAt,
+      null,
+    );
+    this.sql.exec(
+      "UPDATE app_client_sessions SET last_used_at = ?, expires_at = ? WHERE session_id = ?",
+      now,
+      expiresAt,
+      sessionId,
+    );
+
+    return {
+      ...toContext({
+        ...row,
+        last_used_at: now,
+        expires_at: expiresAt,
+      }),
+      secret,
+    };
+  }
+
+  close(uid: number, sessionId: string): boolean {
+    this.pruneExpired();
+    const row = this.getRow(sessionId);
+    if (!row || row.uid !== uid || row.revoked_at != null || row.expires_at <= Date.now()) {
+      return false;
+    }
+
+    const now = Date.now();
+    this.sql.exec(
+      "UPDATE app_client_sessions SET revoked_at = ? WHERE session_id = ?",
+      now,
+      sessionId,
+    );
+    this.sql.exec(
+      "UPDATE app_client_session_keys SET revoked_at = ? WHERE session_id = ? AND revoked_at IS NULL",
+      now,
+      sessionId,
+    );
+    return true;
   }
 
   private getRow(sessionId: string): AppSessionRow | null {
@@ -169,9 +286,36 @@ export class AppSessionStore {
     return rows[0] ?? null;
   }
 
+  private getKeyRows(sessionId: string): AppSessionKeyRow[] {
+    return this.sql.exec<AppSessionKeyRow>(
+      `SELECT * FROM app_client_session_keys
+       WHERE session_id = ? AND revoked_at IS NULL AND expires_at > ?`,
+      sessionId,
+      Date.now(),
+    ).toArray();
+  }
+
+  private async verifySecret(row: AppSessionRow, secret: string): Promise<VerifiedSecret> {
+    if (await verify(secret, row.secret_hash)) {
+      return { ok: true, keyId: null };
+    }
+
+    for (const key of this.getKeyRows(row.session_id)) {
+      if (await verify(secret, key.secret_hash)) {
+        return { ok: true, keyId: key.key_id };
+      }
+    }
+
+    return { ok: false };
+  }
+
   private pruneExpired(): void {
     this.sql.exec(
       "DELETE FROM app_client_sessions WHERE expires_at <= ? OR revoked_at IS NOT NULL",
+      Date.now(),
+    );
+    this.sql.exec(
+      "DELETE FROM app_client_session_keys WHERE expires_at <= ? OR revoked_at IS NOT NULL",
       Date.now(),
     );
   }

--- a/gateway/src/kernel/apps.test.ts
+++ b/gateway/src/kernel/apps.test.ts
@@ -81,7 +81,7 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
         packageName: input.packageName,
         entrypointName: input.entrypointName,
         routeBase: input.routeBase,
-        rpcBase: "/apps/sessions/session-1/socket",
+        rpcBase: `/apps/sessions/session-1/clients/${input.clientId}/socket`,
         createdAt: 1,
         expiresAt: 2,
         lastUsedAt: null,
@@ -96,7 +96,7 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
         packageName: "chat",
         entrypointName: "Chat",
         routeBase: "/apps/chat",
-        rpcBase: "/apps/sessions/session-1/socket",
+        rpcBase: `/apps/sessions/session-1/clients/${input.clientId}/socket`,
         createdAt: 1,
         expiresAt: 3,
         lastUsedAt: 2,
@@ -109,7 +109,7 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
         packageName: "chat",
         entrypointName: "Chat",
         routeBase: "/apps/chat",
-        rpcBase: "/apps/sessions/session-1/socket",
+        rpcBase: "/apps/sessions/session-1/clients/win-1/socket",
         createdAt: 1,
         expiresAt: 2,
         lastUsedAt: null,
@@ -123,7 +123,7 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
           packageName: "chat",
           entrypointName: "Chat",
           routeBase: "/apps/chat",
-          rpcBase: "/apps/sessions/session-1/socket",
+          rpcBase: "/apps/sessions/session-1/clients/win-1/socket",
           createdAt: 1,
           expiresAt: 2,
           lastUsedAt: null,
@@ -138,7 +138,7 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
         packageName: "chat",
         entrypointName: "Chat",
         routeBase: "/apps/chat",
-        rpcBase: "/apps/sessions/session-1/socket",
+        rpcBase: "/apps/sessions/session-1/clients/win-1/socket",
         createdAt: 1,
         expiresAt: 2,
         lastUsedAt: null,
@@ -191,22 +191,25 @@ describe("app syscalls", () => {
     expect(result.window).toMatchObject({ title: "Chat", width: 900 });
 
     const launch = new URL(result.launchUrl, "https://gsv.local");
-    expect(launch.pathname).toBe("/apps/sessions/session-1/launch");
-    expect(launch.searchParams.get("token")).toBe("secret-1");
-    expect(launch.searchParams.get("next")).toBe("/threads/abc?view=compact#bottom");
+    expect(launch.pathname).toBe("/apps/sessions/session-1/clients/win-1/threads/abc");
+    expect(launch.search).toBe("?view=compact");
+    expect(launch.hash).toBe("#bottom");
+    expect(result.launchToken).toBe("secret-1");
   });
 
   it("attaches to an existing app session with a fresh launch secret", async () => {
     const ctx = makeContext();
 
-    const result = await handleAppAttach({ sessionId: "session-1" }, ctx);
+    const result = await handleAppAttach({ sessionId: "session-1", clientId: "win-2" }, ctx);
 
     expect(ctx.appSessions.attach).toHaveBeenCalledWith(expect.objectContaining({
       uid: 1000,
       sessionId: "session-1",
+      clientId: "win-2",
       ttlMs: expect.any(Number),
     }));
-    expect(result.launchUrl).toContain("token=secret-2");
+    expect(result.launchUrl).toBe("/apps/sessions/session-1/clients/win-2/");
+    expect(result.launchToken).toBe("secret-2");
   });
 
   it("detaches one client without closing the app session", async () => {

--- a/gateway/src/kernel/apps.test.ts
+++ b/gateway/src/kernel/apps.test.ts
@@ -85,10 +85,10 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
         expiresAt: 2,
         lastUsedAt: null,
       })),
-      mintSecret: vi.fn(async () => ({
+      attach: vi.fn(async (input) => ({
         sessionId: "session-1",
         secret: "secret-2",
-        clientId: "win-1",
+        clientId: input.clientId,
         uid: 1000,
         username: "alice",
         packageId: "pkg-chat",
@@ -102,7 +102,6 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
       })),
       list: vi.fn(() => [{
         sessionId: "session-1",
-        clientId: "win-1",
         uid: 1000,
         username: "alice",
         packageId: "pkg-chat",
@@ -113,8 +112,36 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
         createdAt: 1,
         expiresAt: 2,
         lastUsedAt: null,
+        state: "active",
+        clients: [{
+          sessionId: "session-1",
+          clientId: "win-1",
+          uid: 1000,
+          username: "alice",
+          packageId: "pkg-chat",
+          packageName: "chat",
+          entrypointName: "Chat",
+          routeBase: "/apps/chat",
+          rpcBase: "/apps/sessions/session-1/socket",
+          createdAt: 1,
+          expiresAt: 2,
+          lastUsedAt: null,
+        }],
       }]),
-      close: vi.fn(() => true),
+      close: vi.fn(() => ({
+        sessionId: "session-1",
+        uid: 1000,
+        username: "alice",
+        packageId: "pkg-chat",
+        packageName: "chat",
+        entrypointName: "Chat",
+        routeBase: "/apps/chat",
+        createdAt: 1,
+        expiresAt: 2,
+        lastUsedAt: null,
+        state: "closed",
+        clients: [],
+      })),
     },
     ...overrides,
   } as unknown as KernelContext;
@@ -155,20 +182,31 @@ describe("app syscalls", () => {
 
     const result = await handleAppAttach({ sessionId: "session-1" }, ctx);
 
-    expect(ctx.appSessions.mintSecret).toHaveBeenCalledWith(1000, "session-1", expect.any(Number));
+    expect(ctx.appSessions.attach).toHaveBeenCalledWith(expect.objectContaining({
+      uid: 1000,
+      sessionId: "session-1",
+      ttlMs: expect.any(Number),
+    }));
     expect(result.launchUrl).toContain("token=secret-2");
   });
 
-  it("lists and closes sessions for the current user", () => {
-    const ctx = makeContext();
+  it("lists and closes sessions for the current user", async () => {
+    const closeAppSession = vi.fn(async () => ({ closed: 1 }));
+    const getAppRunner = vi.fn(() => ({ closeAppSession }));
+    const ctx = makeContext({
+      getAppRunner,
+    });
 
     expect(handleAppList({}, ctx).sessions).toEqual([expect.objectContaining({
       sessionId: "session-1",
       packageName: "chat",
       state: "active",
+      clients: [expect.objectContaining({ clientId: "win-1" })],
     })]);
-    expect(handleAppClose({ sessionId: "session-1" }, ctx)).toEqual({ closed: true });
+    await expect(handleAppClose({ sessionId: "session-1" }, ctx)).resolves.toEqual({ closed: true });
     expect(ctx.appSessions.close).toHaveBeenCalledWith(1000, "session-1");
+    expect(getAppRunner).toHaveBeenCalledWith(1000, "pkg-chat");
+    expect(closeAppSession).toHaveBeenCalledWith("session-1");
   });
 
   it("returns a typed 404 when the package app is missing", async () => {

--- a/gateway/src/kernel/apps.test.ts
+++ b/gateway/src/kernel/apps.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+import type { KernelContext } from "./context";
+import type { InstalledPackageRecord } from "./packages";
+import {
+  AppSyscallError,
+  handleAppAttach,
+  handleAppClose,
+  handleAppList,
+  handleAppOpen,
+} from "./apps";
+
+function makePackageRecord(): InstalledPackageRecord {
+  return {
+    packageId: "pkg-chat",
+    scope: { kind: "global" },
+    manifest: {
+      name: "chat",
+      displayName: "Chat",
+      description: "Chat app",
+      version: "0.1.0",
+      runtime: "web-ui",
+      source: {
+        repo: "root/gsv",
+        ref: "main",
+        subdir: "builtin-packages/chat",
+      },
+      entrypoints: [{
+        name: "Chat",
+        kind: "ui",
+        module: "src/app/main.tsx",
+        route: "/apps/chat",
+        windowDefaults: {
+          width: 900,
+          height: 700,
+          minWidth: 640,
+          minHeight: 480,
+        },
+      }],
+      capabilities: {},
+    },
+    artifact: {
+      hash: "sha256:test",
+      mainModule: "src/app/main.tsx",
+      modulePaths: ["src/app/main.tsx"],
+    },
+    grants: {},
+    enabled: true,
+    reviewRequired: false,
+    reviewedAt: null,
+    installedAt: 1,
+    updatedAt: 2,
+  };
+}
+
+function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
+  return {
+    identity: {
+      role: "user",
+      capabilities: ["app.*"],
+      process: {
+        uid: 1000,
+        gid: 1000,
+        gids: [1000],
+        username: "alice",
+        home: "/home/alice",
+        cwd: "/home/alice",
+      },
+    },
+    packages: {
+      list: vi.fn(() => [makePackageRecord()]),
+    },
+    appSessions: {
+      issue: vi.fn(async (input) => ({
+        sessionId: "session-1",
+        secret: "secret-1",
+        clientId: input.clientId,
+        uid: input.uid,
+        username: input.username,
+        packageId: input.packageId,
+        packageName: input.packageName,
+        entrypointName: input.entrypointName,
+        routeBase: input.routeBase,
+        rpcBase: "/apps/sessions/session-1/socket",
+        createdAt: 1,
+        expiresAt: 2,
+        lastUsedAt: null,
+      })),
+      mintSecret: vi.fn(async () => ({
+        sessionId: "session-1",
+        secret: "secret-2",
+        clientId: "win-1",
+        uid: 1000,
+        username: "alice",
+        packageId: "pkg-chat",
+        packageName: "chat",
+        entrypointName: "Chat",
+        routeBase: "/apps/chat",
+        rpcBase: "/apps/sessions/session-1/socket",
+        createdAt: 1,
+        expiresAt: 3,
+        lastUsedAt: 2,
+      })),
+      list: vi.fn(() => [{
+        sessionId: "session-1",
+        clientId: "win-1",
+        uid: 1000,
+        username: "alice",
+        packageId: "pkg-chat",
+        packageName: "chat",
+        entrypointName: "Chat",
+        routeBase: "/apps/chat",
+        rpcBase: "/apps/sessions/session-1/socket",
+        createdAt: 1,
+        expiresAt: 2,
+        lastUsedAt: null,
+      }]),
+      close: vi.fn(() => true),
+    },
+    ...overrides,
+  } as unknown as KernelContext;
+}
+
+describe("app syscalls", () => {
+  it("opens package apps through a launch URL", async () => {
+    const ctx = makeContext();
+
+    const result = await handleAppOpen({
+      packageName: "chat",
+      clientId: "win-1",
+      suffix: "/threads/abc",
+      search: "?view=compact",
+      hash: "#bottom",
+    }, ctx);
+
+    expect(ctx.appSessions.issue).toHaveBeenCalledWith(expect.objectContaining({
+      uid: 1000,
+      username: "alice",
+      packageId: "pkg-chat",
+      packageName: "chat",
+      entrypointName: "Chat",
+      routeBase: "/apps/chat",
+      clientId: "win-1",
+    }));
+    expect(result.sessionId).toBe("session-1");
+    expect(result.window).toMatchObject({ title: "Chat", width: 900 });
+
+    const launch = new URL(result.launchUrl, "https://gsv.local");
+    expect(launch.pathname).toBe("/apps/sessions/session-1/launch");
+    expect(launch.searchParams.get("token")).toBe("secret-1");
+    expect(launch.searchParams.get("next")).toBe("/threads/abc?view=compact#bottom");
+  });
+
+  it("attaches to an existing app session with a fresh launch secret", async () => {
+    const ctx = makeContext();
+
+    const result = await handleAppAttach({ sessionId: "session-1" }, ctx);
+
+    expect(ctx.appSessions.mintSecret).toHaveBeenCalledWith(1000, "session-1", expect.any(Number));
+    expect(result.launchUrl).toContain("token=secret-2");
+  });
+
+  it("lists and closes sessions for the current user", () => {
+    const ctx = makeContext();
+
+    expect(handleAppList({}, ctx).sessions).toEqual([expect.objectContaining({
+      sessionId: "session-1",
+      packageName: "chat",
+      state: "active",
+    })]);
+    expect(handleAppClose({ sessionId: "session-1" }, ctx)).toEqual({ closed: true });
+    expect(ctx.appSessions.close).toHaveBeenCalledWith(1000, "session-1");
+  });
+
+  it("returns a typed 404 when the package app is missing", async () => {
+    const ctx = makeContext({
+      packages: {
+        list: vi.fn(() => []),
+      } as unknown as KernelContext["packages"],
+    });
+
+    await expect(handleAppOpen({ packageName: "chat" }, ctx)).rejects.toMatchObject({
+      status: 404,
+      message: "Package app not found",
+    } satisfies Partial<AppSyscallError>);
+  });
+});

--- a/gateway/src/kernel/apps.test.ts
+++ b/gateway/src/kernel/apps.test.ts
@@ -5,6 +5,7 @@ import {
   AppSyscallError,
   handleAppAttach,
   handleAppClose,
+  handleAppDetach,
   handleAppList,
   handleAppOpen,
 } from "./apps";
@@ -128,6 +129,20 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
           lastUsedAt: null,
         }],
       }]),
+      detach: vi.fn(() => ({
+        sessionId: "session-1",
+        clientId: "win-1",
+        uid: 1000,
+        username: "alice",
+        packageId: "pkg-chat",
+        packageName: "chat",
+        entrypointName: "Chat",
+        routeBase: "/apps/chat",
+        rpcBase: "/apps/sessions/session-1/socket",
+        createdAt: 1,
+        expiresAt: 2,
+        lastUsedAt: null,
+      })),
       close: vi.fn(() => ({
         sessionId: "session-1",
         uid: 1000,
@@ -144,6 +159,7 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
       })),
     },
     signalWatches: {
+      removeByAppClient: vi.fn(() => 0),
       removeByAppSession: vi.fn(() => 0),
     },
     ...overrides,
@@ -191,6 +207,25 @@ describe("app syscalls", () => {
       ttlMs: expect.any(Number),
     }));
     expect(result.launchUrl).toContain("token=secret-2");
+  });
+
+  it("detaches one client without closing the app session", async () => {
+    const closeAppClient = vi.fn(async () => ({ closed: 1 }));
+    const getAppRunner = vi.fn(() => ({ closeAppClient }));
+    const ctx = makeContext({
+      getAppRunner,
+    });
+
+    await expect(handleAppDetach({
+      sessionId: "session-1",
+      clientId: "win-1",
+    }, ctx)).resolves.toEqual({ detached: true });
+
+    expect(ctx.appSessions.detach).toHaveBeenCalledWith(1000, "session-1", "win-1");
+    expect(ctx.signalWatches.removeByAppClient).toHaveBeenCalledWith(1000, "session-1", "win-1");
+    expect(getAppRunner).toHaveBeenCalledWith(1000, "pkg-chat");
+    expect(closeAppClient).toHaveBeenCalledWith("session-1", "win-1");
+    expect(ctx.appSessions.close).not.toHaveBeenCalled();
   });
 
   it("lists and closes sessions for the current user", async () => {

--- a/gateway/src/kernel/apps.test.ts
+++ b/gateway/src/kernel/apps.test.ts
@@ -143,6 +143,9 @@ function makeContext(overrides: Partial<KernelContext> = {}): KernelContext {
         clients: [],
       })),
     },
+    signalWatches: {
+      removeByAppSession: vi.fn(() => 0),
+    },
     ...overrides,
   } as unknown as KernelContext;
 }
@@ -205,6 +208,7 @@ describe("app syscalls", () => {
     })]);
     await expect(handleAppClose({ sessionId: "session-1" }, ctx)).resolves.toEqual({ closed: true });
     expect(ctx.appSessions.close).toHaveBeenCalledWith(1000, "session-1");
+    expect(ctx.signalWatches.removeByAppSession).toHaveBeenCalledWith(1000, "session-1");
     expect(getAppRunner).toHaveBeenCalledWith(1000, "pkg-chat");
     expect(closeAppSession).toHaveBeenCalledWith("session-1");
   });

--- a/gateway/src/kernel/apps.ts
+++ b/gateway/src/kernel/apps.ts
@@ -8,7 +8,7 @@ import type {
   AppOpenArgs,
   AppSessionSummary,
 } from "@gsv/protocol/syscalls/apps";
-import type { AppClientSessionContext, IssuedAppClientSession } from "../protocol/app-session";
+import type { AppSessionContext, IssuedAppClientSession } from "../protocol/app-session";
 import type { KernelContext } from "./context";
 import {
   type InstalledPackageRecord,
@@ -50,7 +50,12 @@ export async function handleAppOpen(args: AppOpenArgs, ctx: KernelContext): Prom
 export async function handleAppAttach(args: AppAttachArgs, ctx: KernelContext): Promise<AppLaunchResult> {
   const actor = currentActor(ctx);
   const sessionId = normalizeRequiredString(args.sessionId, "sessionId");
-  const clientSession = await ctx.appSessions.mintSecret(actor.uid, sessionId, APP_CLIENT_SESSION_TTL_MS);
+  const clientSession = await ctx.appSessions.attach({
+    uid: actor.uid,
+    sessionId,
+    clientId: normalizeOptionalString(args.clientId) ?? crypto.randomUUID(),
+    ttlMs: APP_CLIENT_SESSION_TTL_MS,
+  });
   if (!clientSession) {
     throw new AppSyscallError(404, "App session not found");
   }
@@ -72,11 +77,15 @@ export function handleAppList(_args: AppListArgs, ctx: KernelContext): AppListRe
   };
 }
 
-export function handleAppClose(args: AppCloseArgs, ctx: KernelContext): AppCloseResult {
+export async function handleAppClose(args: AppCloseArgs, ctx: KernelContext): Promise<AppCloseResult> {
   const actor = currentActor(ctx);
   const sessionId = normalizeRequiredString(args.sessionId, "sessionId");
+  const closedSession = ctx.appSessions.close(actor.uid, sessionId);
+  if (closedSession) {
+    await closeRunnerAppSession(ctx, closedSession);
+  }
   return {
-    closed: ctx.appSessions.close(actor.uid, sessionId),
+    closed: Boolean(closedSession),
   };
 }
 
@@ -138,19 +147,35 @@ function toLaunchResult(
   };
 }
 
-function toSessionSummary(session: AppClientSessionContext): AppSessionSummary {
+function toSessionSummary(session: AppSessionContext): AppSessionSummary {
   return {
     sessionId: session.sessionId,
     packageId: session.packageId,
     packageName: session.packageName,
     entrypointName: session.entrypointName,
     routeBase: session.routeBase,
-    clientId: session.clientId,
     createdAt: session.createdAt,
     lastUsedAt: session.lastUsedAt ?? null,
     expiresAt: session.expiresAt,
-    state: "active",
+    state: session.state,
+    clients: session.clients.map((client) => ({
+      clientId: client.clientId,
+      createdAt: client.createdAt,
+      lastUsedAt: client.lastUsedAt ?? null,
+      expiresAt: client.expiresAt,
+      state: "active",
+    })),
   };
+}
+
+async function closeRunnerAppSession(ctx: KernelContext, session: AppSessionContext): Promise<void> {
+  const runner = ctx.getAppRunner?.(session.uid, session.packageId) as {
+    closeAppSession?: (sessionId: string) => Promise<unknown>;
+  } | undefined;
+  if (!runner?.closeAppSession) {
+    return;
+  }
+  await runner.closeAppSession(session.sessionId);
 }
 
 function buildLaunchUrl(

--- a/gateway/src/kernel/apps.ts
+++ b/gateway/src/kernel/apps.ts
@@ -1,0 +1,215 @@
+import type {
+  AppAttachArgs,
+  AppCloseArgs,
+  AppCloseResult,
+  AppLaunchResult,
+  AppListArgs,
+  AppListResult,
+  AppOpenArgs,
+  AppSessionSummary,
+} from "@gsv/protocol/syscalls/apps";
+import type { AppClientSessionContext, IssuedAppClientSession } from "../protocol/app-session";
+import type { KernelContext } from "./context";
+import {
+  type InstalledPackageRecord,
+  type PackageEntrypoint,
+  packageRouteBase,
+  visiblePackageScopesForActor,
+} from "./packages";
+import { APP_CLIENT_SESSION_TTL_MS } from "./app-sessions";
+
+const APP_LAUNCH_RESERVED_PATHS = new Set(["/launch", "/refresh", "/socket"]);
+
+export class AppSyscallError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+  }
+}
+
+export async function handleAppOpen(args: AppOpenArgs, ctx: KernelContext): Promise<AppLaunchResult> {
+  const actor = currentActor(ctx);
+  const packageName = normalizeRequiredString(args.packageName, "packageName");
+  const entrypointName = normalizeOptionalString(args.entrypointName);
+  const routeBase = packageRouteBase(packageName);
+  const resolved = findLaunchableUiPackage(ctx, actor.uid, packageName, routeBase, entrypointName);
+
+  const clientSession = await ctx.appSessions.issue({
+    uid: actor.uid,
+    username: actor.username,
+    packageId: resolved.record.packageId,
+    packageName: resolved.record.manifest.name,
+    entrypointName: resolved.entrypoint.name,
+    routeBase,
+    clientId: normalizeOptionalString(args.clientId) ?? crypto.randomUUID(),
+    ttlMs: APP_CLIENT_SESSION_TTL_MS,
+  });
+
+  return toLaunchResult(clientSession, resolved.entrypoint, args);
+}
+
+export async function handleAppAttach(args: AppAttachArgs, ctx: KernelContext): Promise<AppLaunchResult> {
+  const actor = currentActor(ctx);
+  const sessionId = normalizeRequiredString(args.sessionId, "sessionId");
+  const clientSession = await ctx.appSessions.mintSecret(actor.uid, sessionId, APP_CLIENT_SESSION_TTL_MS);
+  if (!clientSession) {
+    throw new AppSyscallError(404, "App session not found");
+  }
+
+  const resolved = findLaunchableUiPackage(
+    ctx,
+    actor.uid,
+    clientSession.packageName,
+    clientSession.routeBase,
+    clientSession.entrypointName,
+  );
+  return toLaunchResult(clientSession, resolved.entrypoint, args);
+}
+
+export function handleAppList(_args: AppListArgs, ctx: KernelContext): AppListResult {
+  const actor = currentActor(ctx);
+  return {
+    sessions: ctx.appSessions.list(actor.uid).map(toSessionSummary),
+  };
+}
+
+export function handleAppClose(args: AppCloseArgs, ctx: KernelContext): AppCloseResult {
+  const actor = currentActor(ctx);
+  const sessionId = normalizeRequiredString(args.sessionId, "sessionId");
+  return {
+    closed: ctx.appSessions.close(actor.uid, sessionId),
+  };
+}
+
+function currentActor(ctx: KernelContext): { uid: number; username: string } {
+  const process = ctx.identity?.process;
+  if (!process) {
+    throw new AppSyscallError(401, "Authentication required");
+  }
+  return {
+    uid: process.uid,
+    username: process.username,
+  };
+}
+
+function findLaunchableUiPackage(
+  ctx: KernelContext,
+  uid: number,
+  packageName: string,
+  routeBase: string,
+  entrypointName: string | null,
+): { record: InstalledPackageRecord; entrypoint: PackageEntrypoint } {
+  for (const record of ctx.packages.list({
+    enabled: true,
+    name: packageName,
+    runtime: "web-ui",
+    scopes: visiblePackageScopesForActor({ uid }),
+  })) {
+    const entrypoint = record.manifest.entrypoints.find((candidate) => {
+      return candidate.kind === "ui" &&
+        candidate.route === routeBase &&
+        (!entrypointName || candidate.name === entrypointName);
+    });
+    if (entrypoint) {
+      return { record, entrypoint };
+    }
+  }
+
+  throw new AppSyscallError(404, "Package app not found");
+}
+
+function toLaunchResult(
+  session: IssuedAppClientSession,
+  entrypoint: PackageEntrypoint,
+  args: Pick<AppOpenArgs, "suffix" | "search" | "hash">,
+): AppLaunchResult {
+  return {
+    sessionId: session.sessionId,
+    packageId: session.packageId,
+    packageName: session.packageName,
+    entrypointName: session.entrypointName,
+    routeBase: session.routeBase,
+    clientId: session.clientId,
+    launchUrl: buildLaunchUrl(session, args),
+    expiresAt: session.expiresAt,
+    window: {
+      title: entrypoint.name,
+      ...entrypoint.windowDefaults,
+    },
+  };
+}
+
+function toSessionSummary(session: AppClientSessionContext): AppSessionSummary {
+  return {
+    sessionId: session.sessionId,
+    packageId: session.packageId,
+    packageName: session.packageName,
+    entrypointName: session.entrypointName,
+    routeBase: session.routeBase,
+    clientId: session.clientId,
+    createdAt: session.createdAt,
+    lastUsedAt: session.lastUsedAt ?? null,
+    expiresAt: session.expiresAt,
+    state: "active",
+  };
+}
+
+function buildLaunchUrl(
+  session: IssuedAppClientSession,
+  args: Pick<AppOpenArgs, "suffix" | "search" | "hash">,
+): string {
+  const params = new URLSearchParams({ token: session.secret });
+  const next = buildLaunchNext(args);
+  if (next !== "/") {
+    params.set("next", next);
+  }
+  return `/apps/sessions/${encodeURIComponent(session.sessionId)}/launch?${params.toString()}`;
+}
+
+function buildLaunchNext(args: Pick<AppOpenArgs, "suffix" | "search" | "hash">): string {
+  const suffix = normalizeSuffix(args.suffix);
+  const search = normalizeSearch(args.search);
+  const hash = normalizeHash(args.hash);
+  return `${suffix}${search}${hash}`;
+}
+
+function normalizeRequiredString(value: unknown, name: string): string {
+  if (typeof value !== "string") {
+    throw new AppSyscallError(400, `${name} is required`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new AppSyscallError(400, `${name} is required`);
+  }
+  return trimmed;
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeSuffix(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    return "/";
+  }
+  const trimmed = value.trim();
+  const pathname = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return APP_LAUNCH_RESERVED_PATHS.has(pathname) ? "/" : pathname;
+}
+
+function normalizeSearch(value: unknown): string {
+  if (typeof value !== "string" || !value) {
+    return "";
+  }
+  return value.startsWith("?") ? value : `?${value}`;
+}
+
+function normalizeHash(value: unknown): string {
+  if (typeof value !== "string" || !value) {
+    return "";
+  }
+  return value.startsWith("#") ? value : `#${value}`;
+}

--- a/gateway/src/kernel/apps.ts
+++ b/gateway/src/kernel/apps.ts
@@ -82,6 +82,7 @@ export async function handleAppClose(args: AppCloseArgs, ctx: KernelContext): Pr
   const sessionId = normalizeRequiredString(args.sessionId, "sessionId");
   const closedSession = ctx.appSessions.close(actor.uid, sessionId);
   if (closedSession) {
+    ctx.signalWatches.removeByAppSession(actor.uid, closedSession.sessionId);
     await closeRunnerAppSession(ctx, closedSession);
   }
   return {

--- a/gateway/src/kernel/apps.ts
+++ b/gateway/src/kernel/apps.ts
@@ -2,6 +2,8 @@ import type {
   AppAttachArgs,
   AppCloseArgs,
   AppCloseResult,
+  AppDetachArgs,
+  AppDetachResult,
   AppLaunchResult,
   AppListArgs,
   AppListResult,
@@ -74,6 +76,20 @@ export function handleAppList(_args: AppListArgs, ctx: KernelContext): AppListRe
   const actor = currentActor(ctx);
   return {
     sessions: ctx.appSessions.list(actor.uid).map(toSessionSummary),
+  };
+}
+
+export async function handleAppDetach(args: AppDetachArgs, ctx: KernelContext): Promise<AppDetachResult> {
+  const actor = currentActor(ctx);
+  const sessionId = normalizeRequiredString(args.sessionId, "sessionId");
+  const clientId = normalizeRequiredString(args.clientId, "clientId");
+  const detachedClient = ctx.appSessions.detach(actor.uid, sessionId, clientId);
+  if (detachedClient) {
+    ctx.signalWatches.removeByAppClient(actor.uid, detachedClient.sessionId, detachedClient.clientId);
+    await closeRunnerAppClient(ctx, detachedClient);
+  }
+  return {
+    detached: Boolean(detachedClient),
   };
 }
 
@@ -177,6 +193,19 @@ async function closeRunnerAppSession(ctx: KernelContext, session: AppSessionCont
     return;
   }
   await runner.closeAppSession(session.sessionId);
+}
+
+async function closeRunnerAppClient(
+  ctx: KernelContext,
+  client: Pick<IssuedAppClientSession, "uid" | "packageId" | "sessionId" | "clientId">,
+): Promise<void> {
+  const runner = ctx.getAppRunner?.(client.uid, client.packageId) as {
+    closeAppClient?: (sessionId: string, clientId: string) => Promise<unknown>;
+  } | undefined;
+  if (!runner?.closeAppClient) {
+    return;
+  }
+  await runner.closeAppClient(client.sessionId, client.clientId);
 }
 
 function buildLaunchUrl(

--- a/gateway/src/kernel/apps.ts
+++ b/gateway/src/kernel/apps.ts
@@ -10,7 +10,11 @@ import type {
   AppOpenArgs,
   AppSessionSummary,
 } from "@gsv/protocol/syscalls/apps";
-import type { AppSessionContext, IssuedAppClientSession } from "../protocol/app-session";
+import {
+  buildAppClientRouteBase,
+  type AppSessionContext,
+  type IssuedAppClientSession,
+} from "../protocol/app-session";
 import type { KernelContext } from "./context";
 import {
   type InstalledPackageRecord,
@@ -156,6 +160,7 @@ function toLaunchResult(
     routeBase: session.routeBase,
     clientId: session.clientId,
     launchUrl: buildLaunchUrl(session, args),
+    launchToken: session.secret,
     expiresAt: session.expiresAt,
     window: {
       title: entrypoint.name,
@@ -212,12 +217,11 @@ function buildLaunchUrl(
   session: IssuedAppClientSession,
   args: Pick<AppOpenArgs, "suffix" | "search" | "hash">,
 ): string {
-  const params = new URLSearchParams({ token: session.secret });
   const next = buildLaunchNext(args);
   if (next !== "/") {
-    params.set("next", next);
+    return `${buildAppClientRouteBase(session.sessionId, session.clientId)}${next}`;
   }
-  return `/apps/sessions/${encodeURIComponent(session.sessionId)}/launch?${params.toString()}`;
+  return `${buildAppClientRouteBase(session.sessionId, session.clientId)}/`;
 }
 
 function buildLaunchNext(args: Pick<AppOpenArgs, "suffix" | "search" | "hash">): string {

--- a/gateway/src/kernel/capabilities.test.ts
+++ b/gateway/src/kernel/capabilities.test.ts
@@ -188,6 +188,7 @@ describe("CapabilityStore", () => {
       "adapter.status",
       "ai.speech.create",
       "ai.transcription.create",
+      "app.*",
       "codemode.*",
       "fs.*",
       "notification.*",

--- a/gateway/src/kernel/capabilities.ts
+++ b/gateway/src/kernel/capabilities.ts
@@ -17,6 +17,7 @@ const DEFAULT_CAPABILITIES: [number, string[]][] = [
   [0,   ["*"]],                                           // root
   [100, [
     "codemode.*",
+    "app.*",
     "fs.*",
     "shell.*",
     "notification.*",

--- a/gateway/src/kernel/context.ts
+++ b/gateway/src/kernel/context.ts
@@ -23,6 +23,7 @@ import type { SignalWatchStore } from "./signal-watches";
 import type { NotificationStore } from "./notifications";
 import type { IpcCallStore } from "./ipc-calls";
 import type { ScheduleStore } from "./scheduler";
+import type { AppSessionStore } from "./app-sessions";
 import type { AppFrameContext } from "../protocol/app-frame";
 import type { SchedulerRunArgs, SchedulerRunResult } from "../syscalls/scheduler";
 import type { McpAddConnectionInput, McpAddConnectionResult } from "./sys/mcp";
@@ -41,6 +42,7 @@ export type KernelContext = {
   adapters: AdapterStore;
   runRoutes: RunRouteStore;
   shellSessions: ShellSessionStore;
+  appSessions: AppSessionStore;
   signalWatches: SignalWatchStore;
   ipcCalls?: IpcCallStore;
   notifications?: NotificationStore;

--- a/gateway/src/kernel/dispatch.ts
+++ b/gateway/src/kernel/dispatch.ts
@@ -118,6 +118,7 @@ import {
   AppSyscallError,
   handleAppAttach,
   handleAppClose,
+  handleAppDetach,
   handleAppList,
   handleAppOpen,
 } from "./apps";
@@ -326,6 +327,9 @@ async function dispatchNative(
         break;
       case "app.list":
         data = handleAppList(frame.args, ctx);
+        break;
+      case "app.detach":
+        data = await handleAppDetach(frame.args, ctx);
         break;
       case "app.close":
         data = await handleAppClose(frame.args, ctx);

--- a/gateway/src/kernel/dispatch.ts
+++ b/gateway/src/kernel/dispatch.ts
@@ -115,6 +115,13 @@ import {
   handleSchedulerUpdate,
 } from "./scheduler";
 import {
+  AppSyscallError,
+  handleAppAttach,
+  handleAppClose,
+  handleAppList,
+  handleAppOpen,
+} from "./apps";
+import {
   getVisibleTarget,
   targetCanHandle,
   type TargetDescriptor,
@@ -309,6 +316,19 @@ async function dispatchNative(
             sendDeviceBinaryFrame: deps.sendDeviceBinaryFrame,
           },
         });
+        break;
+
+      case "app.open":
+        data = await handleAppOpen(frame.args, ctx);
+        break;
+      case "app.attach":
+        data = await handleAppAttach(frame.args, ctx);
+        break;
+      case "app.list":
+        data = handleAppList(frame.args, ctx);
+        break;
+      case "app.close":
+        data = handleAppClose(frame.args, ctx);
         break;
 
       case "codemode.run":
@@ -582,6 +602,9 @@ async function dispatchNative(
 
     return { type: "res", id: frame.id, ok: true, data } as ResponseFrame;
   } catch (err) {
+    if (err instanceof AppSyscallError) {
+      return errFrame(frame.id, err.status, err.message);
+    }
     const message = err instanceof Error ? err.message : String(err);
     return errFrame(frame.id, 500, message);
   }

--- a/gateway/src/kernel/dispatch.ts
+++ b/gateway/src/kernel/dispatch.ts
@@ -328,7 +328,7 @@ async function dispatchNative(
         data = handleAppList(frame.args, ctx);
         break;
       case "app.close":
-        data = handleAppClose(frame.args, ctx);
+        data = await handleAppClose(frame.args, ctx);
         break;
 
       case "codemode.run":

--- a/gateway/src/kernel/do.ts
+++ b/gateway/src/kernel/do.ts
@@ -49,7 +49,7 @@ import {
   ScheduleStore,
   skippedScheduleResult,
 } from "./scheduler";
-import { AppSessionStore } from "./app-sessions";
+import { APP_CLIENT_SESSION_TTL_MS, AppSessionStore } from "./app-sessions";
 import {
   ensureKernelBootstrapped,
   handleConnect,
@@ -103,7 +103,6 @@ import type {
 } from "../syscalls/scheduler";
 
 const SERVER_VERSION = "0.2.1";
-const APP_CLIENT_SESSION_TTL_MS = 12 * 60 * 60 * 1000;
 const KERNEL_BINARY_DEVICE_ID = "__gsv_kernel__";
 
 type ConnectionState = {
@@ -1202,6 +1201,7 @@ export class Kernel extends Host<Env> {
       adapters: this.adapters,
       runRoutes: this.runRoutes,
       shellSessions: this.shellSessions,
+      appSessions: this.appSessions,
       signalWatches: this.signalWatches,
       ipcCalls: this.ipcCalls,
       notifications: this.notifications,
@@ -1277,6 +1277,7 @@ export class Kernel extends Host<Env> {
       adapters: this.adapters,
       runRoutes: this.runRoutes,
       shellSessions: this.shellSessions,
+      appSessions: this.appSessions,
       signalWatches: this.signalWatches,
       ipcCalls: this.ipcCalls,
       notifications: this.notifications,
@@ -1314,6 +1315,7 @@ export class Kernel extends Host<Env> {
       adapters: this.adapters,
       runRoutes: this.runRoutes,
       shellSessions: this.shellSessions,
+      appSessions: this.appSessions,
       signalWatches: this.signalWatches,
       ipcCalls: this.ipcCalls,
       notifications: this.notifications,
@@ -2747,6 +2749,7 @@ export class Kernel extends Host<Env> {
       adapters: this.adapters,
       runRoutes: this.runRoutes,
       shellSessions: this.shellSessions,
+      appSessions: this.appSessions,
       signalWatches: this.signalWatches,
       ipcCalls: this.ipcCalls,
       notifications: this.notifications,

--- a/gateway/src/kernel/do.ts
+++ b/gateway/src/kernel/do.ts
@@ -1938,12 +1938,13 @@ export class Kernel extends Host<Env> {
           this.signalWatches.deleteHandled(watch.watchId);
           continue;
         }
-        if (watch.targetKind === "app" && !this.isActiveAppSignalWatchOwner(watch)) {
-          this.signalWatches.deleteHandled(watch.watchId);
-          continue;
-        }
         if (watch.targetKind === "app") {
-          await this.invokePackageAppSignalHandler(watch, processId, frame);
+          const appClientSession = this.getActiveAppSignalWatchClient(watch);
+          if (watch.appSessionId && watch.appClientId && !appClientSession) {
+            this.signalWatches.deleteHandled(watch.watchId);
+            continue;
+          }
+          await this.invokePackageAppSignalHandler(watch, processId, frame, appClientSession);
         } else {
           await this.invokeProcessSignalWatch(watch, processId, frame);
         }
@@ -1962,25 +1963,28 @@ export class Kernel extends Host<Env> {
     return typeof key === "string" && (key.startsWith("live:") || key.startsWith("__gsv_live__:"));
   }
 
-  private isActiveAppSignalWatchOwner(watch: SignalWatchRecord): boolean {
+  private getActiveAppSignalWatchClient(watch: SignalWatchRecord): AppClientSessionContext | null {
     if (!watch.appSessionId || !watch.appClientId) {
-      return true;
+      return null;
     }
     const session = this.appSessions.getActiveForUid(watch.uid, watch.appSessionId);
-    if (!session) {
-      return false;
+    if (
+      !session ||
+      session.packageId !== watch.packageId ||
+      session.packageName !== watch.packageName ||
+      session.entrypointName !== watch.entrypointName ||
+      session.routeBase !== watch.routeBase
+    ) {
+      return null;
     }
-    return session.packageId === watch.packageId &&
-      session.packageName === watch.packageName &&
-      session.entrypointName === watch.entrypointName &&
-      session.routeBase === watch.routeBase &&
-      session.clients.some((client) => client.clientId === watch.appClientId);
+    return session.clients.find((client) => client.clientId === watch.appClientId) ?? null;
   }
 
   private async invokePackageAppSignalHandler(
     watch: SignalWatchRecord,
     processId: string,
     frame: SignalFrame,
+    appClientSession: AppClientSessionContext | null,
   ): Promise<void> {
     if (!watch.packageId || !watch.packageName || !watch.entrypointName || !watch.routeBase) {
       throw new Error(`App signal watch ${watch.watchId} is missing package metadata`);
@@ -2018,7 +2022,6 @@ export class Kernel extends Host<Env> {
       issuedAt: now,
       expiresAt: now + DEFAULT_APP_FRAME_TTL_MS,
     };
-
     const runner = this.ctx.exports.AppRunner.getByName(buildAppRunnerName(user.uid, record.packageId));
     await runner.ensureRuntime({
       packageId: record.packageId,
@@ -2039,6 +2042,16 @@ export class Kernel extends Host<Env> {
         ...(watch.state === undefined ? {} : { state: watch.state }),
         createdAt: watch.createdAt,
       },
+      ...(appClientSession
+        ? {
+            appSession: {
+              sessionId: appClientSession.sessionId,
+              clientId: appClientSession.clientId,
+              rpcBase: appClientSession.rpcBase,
+              expiresAt: appClientSession.expiresAt,
+            },
+          }
+        : {}),
     });
   }
 

--- a/gateway/src/kernel/do.ts
+++ b/gateway/src/kernel/do.ts
@@ -169,15 +169,9 @@ type ResolvePackageHttpResult =
     };
 
 type ResolvePackageAppRpcInput = {
-  packageName: string;
+  packageName?: string;
   sessionId: string;
   secret: string;
-};
-
-type ResolvePackageAppRpcRouteInput = {
-  packageName: string;
-  sessionId: string;
-  routeToken: string;
 };
 
 type ResolvePackageAppRpcResult =
@@ -195,20 +189,6 @@ type ResolvePackageAppRpcResult =
         capabilities: string[];
       };
       hasRpc: boolean;
-    }
-  | {
-      ok: false;
-      status: number;
-      message: string;
-    };
-
-type ResolvePackageAppRpcRouteResult =
-  | {
-      ok: true;
-      uid: number;
-      packageId: string;
-      packageName: string;
-      sessionId: string;
     }
   | {
       ok: false;
@@ -657,11 +637,11 @@ export class Kernel extends Host<Env> {
 
   async resolvePackageAppRpcSession(input: ResolvePackageAppRpcInput): Promise<ResolvePackageAppRpcResult> {
     await this.ready;
-    const packageName = input.packageName.trim();
+    const packageName = input.packageName?.trim() ?? "";
     const sessionId = input.sessionId.trim();
     const secret = input.secret.trim();
 
-    if (!packageName || !sessionId || !secret) {
+    if (!sessionId || !secret) {
       return { ok: false, status: 401, message: "Authentication required" };
     }
 
@@ -669,10 +649,35 @@ export class Kernel extends Host<Env> {
     if (!clientSession) {
       return { ok: false, status: 401, message: "Authentication failed" };
     }
-    if (clientSession.packageName !== packageName) {
+    if (packageName && clientSession.packageName !== packageName) {
       return { ok: false, status: 404, message: "Package app session not found" };
     }
 
+    return this.resolvePackageAppSessionContext(clientSession);
+  }
+
+  async refreshPackageAppRpcSession(input: ResolvePackageAppRpcInput): Promise<ResolvePackageAppRpcResult> {
+    await this.ready;
+    const packageName = input.packageName?.trim() ?? "";
+    const sessionId = input.sessionId.trim();
+    const secret = input.secret.trim();
+
+    if (!sessionId || !secret) {
+      return { ok: false, status: 401, message: "Authentication required" };
+    }
+
+    const clientSession = await this.appSessions.refresh(sessionId, secret, APP_CLIENT_SESSION_TTL_MS);
+    if (!clientSession) {
+      return { ok: false, status: 401, message: "Authentication failed" };
+    }
+    if (packageName && clientSession.packageName !== packageName) {
+      return { ok: false, status: 404, message: "Package app session not found" };
+    }
+
+    return this.resolvePackageAppSessionContext(clientSession);
+  }
+
+  private resolvePackageAppSessionContext(clientSession: AppClientSessionContext): ResolvePackageAppRpcResult {
     const authUser = this.auth.getPasswdByUid(clientSession.uid);
     if (!authUser || authUser.username !== clientSession.username) {
       return { ok: false, status: 401, message: "Authentication failed" };
@@ -710,46 +715,6 @@ export class Kernel extends Host<Env> {
         capabilities,
       },
       hasRpc: record.manifest.entrypoints.some((candidateEntrypoint) => candidateEntrypoint.kind === "rpc"),
-    };
-  }
-
-  async resolvePackageAppRpcRoute(input: ResolvePackageAppRpcRouteInput): Promise<ResolvePackageAppRpcRouteResult> {
-    await this.ready;
-    const packageName = input.packageName.trim();
-    const sessionId = input.sessionId.trim();
-    const routeToken = input.routeToken.trim();
-
-    if (!packageName || !sessionId || !routeToken) {
-      return { ok: false, status: 401, message: "Authentication required" };
-    }
-
-    const clientSession = this.appSessions.resolveRoute(sessionId, routeToken);
-    if (!clientSession || clientSession.packageName !== packageName) {
-      return { ok: false, status: 404, message: "Package app session not found" };
-    }
-
-    const authUser = this.auth.getPasswdByUid(clientSession.uid);
-    if (!authUser || authUser.username !== clientSession.username) {
-      return { ok: false, status: 401, message: "Authentication failed" };
-    }
-
-    const record = this.packages.resolve(
-      clientSession.packageId,
-      visiblePackageScopesForActor({ uid: clientSession.uid }),
-    );
-    if (!record || !record.enabled || record.manifest.name !== clientSession.packageName) {
-      return { ok: false, status: 404, message: "Package app not found" };
-    }
-    if (!record.manifest.entrypoints.some((candidateEntrypoint) => candidateEntrypoint.kind === "rpc")) {
-      return { ok: false, status: 404, message: "Package app has no backend rpc" };
-    }
-
-    return {
-      ok: true,
-      uid: clientSession.uid,
-      packageId: record.packageId,
-      packageName: record.manifest.name,
-      sessionId: clientSession.sessionId,
     };
   }
 

--- a/gateway/src/kernel/do.ts
+++ b/gateway/src/kernel/do.ts
@@ -79,10 +79,8 @@ import {
   setAdapterActivityForKernel,
 } from "./adapter-handlers";
 import {
-  type InstalledPackageRecord,
   PackageStore,
   type PackageEntrypoint,
-  packageRouteBase,
   type PackageArtifactMetadata,
   visiblePackageScopesForActor,
 } from "./packages";
@@ -137,35 +135,6 @@ type ProcSendData = {
   runId?: string;
   queued?: boolean;
 };
-
-type ResolvePackageHttpInput = {
-  packageName: string;
-  username: string;
-  token: string;
-  clientId?: string;
-};
-
-type ResolvePackageHttpResult =
-  | {
-      ok: true;
-      packageId: string;
-      packageName: string;
-      routeBase: string;
-      artifact: PackageArtifactMetadata;
-      appFrame: AppFrameContext;
-      clientSession: AppClientSessionContext & { secret: string };
-      auth: {
-        uid: number;
-        username: string;
-        capabilities: string[];
-      };
-      hasRpc: boolean;
-    }
-  | {
-      ok: false;
-      status: number;
-      message: string;
-    };
 
 type ResolvePackageAppRpcInput = {
   packageName?: string;
@@ -552,86 +521,6 @@ export class Kernel extends Host<Env> {
     pending.cleanup();
     this.applyPostDispatchEffects(frame, result.response);
     return result.response;
-  }
-
-  async resolvePackageHttpRoute(input: ResolvePackageHttpInput): Promise<ResolvePackageHttpResult> {
-    await this.ready;
-    const packageName = input.packageName.trim();
-    const username = input.username.trim();
-    const token = input.token.trim();
-
-    if (!packageName) {
-      return { ok: false, status: 400, message: "Package name is required" };
-    }
-    if (!username || !token) {
-      return { ok: false, status: 401, message: "Authentication required" };
-    }
-
-    const auth = await this.auth.authenticateToken(username, token, { role: "user" });
-    if (!auth.ok) {
-      return { ok: false, status: 401, message: "Authentication failed" };
-    }
-
-    const routeBase = packageRouteBase(packageName);
-    let record: InstalledPackageRecord | null = null;
-    let entrypoint: PackageEntrypoint | null = null;
-
-    for (const candidate of this.packages.list({
-      enabled: true,
-      name: packageName,
-      runtime: "web-ui",
-      scopes: visiblePackageScopesForActor({ uid: auth.identity.uid }),
-    })) {
-      const matched = candidate.manifest.entrypoints.find((candidateEntrypoint) => {
-        return candidateEntrypoint.kind === "ui" && candidateEntrypoint.route === routeBase;
-      });
-      if (matched) {
-        record = candidate;
-        entrypoint = matched;
-        break;
-      }
-    }
-
-    if (!record || !entrypoint) {
-      return { ok: false, status: 404, message: "Package app not found" };
-    }
-
-    const now = Date.now();
-    const clientSession = await this.appSessions.issue({
-      uid: auth.identity.uid,
-      username: auth.identity.username,
-      packageId: record.packageId,
-      packageName: record.manifest.name,
-      entrypointName: entrypoint.name,
-      routeBase,
-      clientId: input.clientId?.trim() || crypto.randomUUID(),
-      ttlMs: APP_CLIENT_SESSION_TTL_MS,
-    });
-
-    return {
-      ok: true,
-      packageId: record.packageId,
-      packageName: record.manifest.name,
-      routeBase,
-      artifact: record.artifact,
-      appFrame: {
-        uid: auth.identity.uid,
-        username: auth.identity.username,
-        packageId: record.packageId,
-        packageName: record.manifest.name,
-        entrypointName: entrypoint.name,
-        routeBase,
-        issuedAt: now,
-        expiresAt: now + DEFAULT_APP_FRAME_TTL_MS,
-      },
-      clientSession,
-      auth: {
-        uid: auth.identity.uid,
-        username: auth.identity.username,
-        capabilities: this.caps.resolve(auth.identity.gids),
-      },
-      hasRpc: record.manifest.entrypoints.some((candidateEntrypoint) => candidateEntrypoint.kind === "rpc"),
-    };
   }
 
   async resolvePackageAppRpcSession(input: ResolvePackageAppRpcInput): Promise<ResolvePackageAppRpcResult> {

--- a/gateway/src/kernel/do.ts
+++ b/gateway/src/kernel/do.ts
@@ -1938,6 +1938,10 @@ export class Kernel extends Host<Env> {
           this.signalWatches.deleteHandled(watch.watchId);
           continue;
         }
+        if (watch.targetKind === "app" && !this.isActiveAppSignalWatchOwner(watch)) {
+          this.signalWatches.deleteHandled(watch.watchId);
+          continue;
+        }
         if (watch.targetKind === "app") {
           await this.invokePackageAppSignalHandler(watch, processId, frame);
         } else {
@@ -1956,6 +1960,21 @@ export class Kernel extends Host<Env> {
 
   private isLegacySignalWatchKey(key: string | null | undefined): boolean {
     return typeof key === "string" && (key.startsWith("live:") || key.startsWith("__gsv_live__:"));
+  }
+
+  private isActiveAppSignalWatchOwner(watch: SignalWatchRecord): boolean {
+    if (!watch.appSessionId || !watch.appClientId) {
+      return true;
+    }
+    const session = this.appSessions.getActiveForUid(watch.uid, watch.appSessionId);
+    if (!session) {
+      return false;
+    }
+    return session.packageId === watch.packageId &&
+      session.packageName === watch.packageName &&
+      session.entrypointName === watch.entrypointName &&
+      session.routeBase === watch.routeBase &&
+      session.clients.some((client) => client.clientId === watch.appClientId);
   }
 
   private async invokePackageAppSignalHandler(

--- a/gateway/src/kernel/do.ts
+++ b/gateway/src/kernel/do.ts
@@ -174,6 +174,12 @@ type ResolvePackageAppRpcInput = {
   secret: string;
 };
 
+type ResolvePackageAppRpcRouteInput = {
+  packageName: string;
+  sessionId: string;
+  routeToken: string;
+};
+
 type ResolvePackageAppRpcResult =
   | {
       ok: true;
@@ -189,6 +195,20 @@ type ResolvePackageAppRpcResult =
         capabilities: string[];
       };
       hasRpc: boolean;
+    }
+  | {
+      ok: false;
+      status: number;
+      message: string;
+    };
+
+type ResolvePackageAppRpcRouteResult =
+  | {
+      ok: true;
+      uid: number;
+      packageId: string;
+      packageName: string;
+      sessionId: string;
     }
   | {
       ok: false;
@@ -690,6 +710,46 @@ export class Kernel extends Host<Env> {
         capabilities,
       },
       hasRpc: record.manifest.entrypoints.some((candidateEntrypoint) => candidateEntrypoint.kind === "rpc"),
+    };
+  }
+
+  async resolvePackageAppRpcRoute(input: ResolvePackageAppRpcRouteInput): Promise<ResolvePackageAppRpcRouteResult> {
+    await this.ready;
+    const packageName = input.packageName.trim();
+    const sessionId = input.sessionId.trim();
+    const routeToken = input.routeToken.trim();
+
+    if (!packageName || !sessionId || !routeToken) {
+      return { ok: false, status: 401, message: "Authentication required" };
+    }
+
+    const clientSession = this.appSessions.resolveRoute(sessionId, routeToken);
+    if (!clientSession || clientSession.packageName !== packageName) {
+      return { ok: false, status: 404, message: "Package app session not found" };
+    }
+
+    const authUser = this.auth.getPasswdByUid(clientSession.uid);
+    if (!authUser || authUser.username !== clientSession.username) {
+      return { ok: false, status: 401, message: "Authentication failed" };
+    }
+
+    const record = this.packages.resolve(
+      clientSession.packageId,
+      visiblePackageScopesForActor({ uid: clientSession.uid }),
+    );
+    if (!record || !record.enabled || record.manifest.name !== clientSession.packageName) {
+      return { ok: false, status: 404, message: "Package app not found" };
+    }
+    if (!record.manifest.entrypoints.some((candidateEntrypoint) => candidateEntrypoint.kind === "rpc")) {
+      return { ok: false, status: 404, message: "Package app has no backend rpc" };
+    }
+
+    return {
+      ok: true,
+      uid: clientSession.uid,
+      packageId: record.packageId,
+      packageName: record.manifest.name,
+      sessionId: clientSession.sessionId,
     };
   }
 

--- a/gateway/src/kernel/signal-watches.ts
+++ b/gateway/src/kernel/signal-watches.ts
@@ -8,6 +8,8 @@ export type SignalWatchTargetInput =
       packageName: string;
       entrypointName: string;
       routeBase: string;
+      appSessionId?: string | null;
+      appClientId?: string | null;
     }
   | {
       kind: "process";
@@ -23,6 +25,8 @@ export type SignalWatchRecord = {
   packageName: string | null;
   entrypointName: string | null;
   routeBase: string | null;
+  appSessionId: string | null;
+  appClientId: string | null;
   signal: string;
   processId: string | null;
   key: string | null;
@@ -70,6 +74,16 @@ export class SignalWatchStore {
       "target_process_id",
       "ALTER TABLE signal_watches ADD COLUMN target_process_id TEXT",
     );
+    this.ensureColumn(
+      "signal_watches",
+      "app_session_id",
+      "ALTER TABLE signal_watches ADD COLUMN app_session_id TEXT",
+    );
+    this.ensureColumn(
+      "signal_watches",
+      "app_client_id",
+      "ALTER TABLE signal_watches ADD COLUMN app_client_id TEXT",
+    );
     this.sql.exec(
       "UPDATE signal_watches SET target_type = 'app' WHERE target_type IS NULL OR target_type = ''",
     );
@@ -82,6 +96,9 @@ export class SignalWatchStore {
     );
     this.sql.exec(
       "CREATE INDEX IF NOT EXISTS idx_signal_watches_target_key ON signal_watches (uid, target_type, target_process_id, package_id, entrypoint_name, dedupe_key, status)",
+    );
+    this.sql.exec(
+      "CREATE INDEX IF NOT EXISTS idx_signal_watches_app_owner ON signal_watches (uid, app_session_id, app_client_id, status)",
     );
   }
 
@@ -104,7 +121,8 @@ export class SignalWatchStore {
       this.sql.exec(
         `UPDATE signal_watches
            SET target_type = ?, target_process_id = ?, package_id = ?, package_name = ?, entrypoint_name = ?, route_base = ?,
-               signal = ?, process_id = ?, state_json = ?, once_only = ?, error = NULL, updated_at = ?, expires_at = ?
+               app_session_id = ?, app_client_id = ?, signal = ?, process_id = ?, state_json = ?, once_only = ?, error = NULL,
+               updated_at = ?, expires_at = ?
          WHERE watch_id = ?`,
         input.target.kind,
         input.target.kind === "process" ? input.target.processId : null,
@@ -112,6 +130,8 @@ export class SignalWatchStore {
         input.target.kind === "app" ? input.target.packageName : "",
         input.target.kind === "app" ? input.target.entrypointName : "",
         input.target.kind === "app" ? input.target.routeBase : "",
+        input.target.kind === "app" ? input.target.appSessionId ?? null : null,
+        input.target.kind === "app" ? input.target.appClientId ?? null : null,
         input.signal,
         input.processId ?? null,
         JSON.stringify(input.state ?? null),
@@ -129,6 +149,8 @@ export class SignalWatchStore {
           packageName: input.target.kind === "app" ? input.target.packageName : null,
           entrypointName: input.target.kind === "app" ? input.target.entrypointName : null,
           routeBase: input.target.kind === "app" ? input.target.routeBase : null,
+          appSessionId: input.target.kind === "app" ? input.target.appSessionId ?? null : null,
+          appClientId: input.target.kind === "app" ? input.target.appClientId ?? null : null,
           signal: input.signal,
           processId: input.processId ?? null,
           state: input.state ?? null,
@@ -150,6 +172,8 @@ export class SignalWatchStore {
       packageName: input.target.kind === "app" ? input.target.packageName : null,
       entrypointName: input.target.kind === "app" ? input.target.entrypointName : null,
       routeBase: input.target.kind === "app" ? input.target.routeBase : null,
+      appSessionId: input.target.kind === "app" ? input.target.appSessionId ?? null : null,
+      appClientId: input.target.kind === "app" ? input.target.appClientId ?? null : null,
       signal: input.signal,
       processId: input.processId ?? null,
       key: input.key ?? null,
@@ -164,9 +188,10 @@ export class SignalWatchStore {
 
     this.sql.exec(
       `INSERT INTO signal_watches (
-        watch_id, uid, target_type, target_process_id, package_id, package_name, entrypoint_name, route_base, signal,
-        process_id, dedupe_key, state_json, once_only, status, error, created_at, updated_at, expires_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        watch_id, uid, target_type, target_process_id, package_id, package_name, entrypoint_name, route_base,
+        app_session_id, app_client_id, signal, process_id, dedupe_key, state_json, once_only, status, error,
+        created_at, updated_at, expires_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       watch.watchId,
       watch.uid,
       watch.targetKind,
@@ -175,6 +200,8 @@ export class SignalWatchStore {
       watch.packageName ?? "",
       watch.entrypointName ?? "",
       watch.routeBase ?? "",
+      watch.appSessionId,
+      watch.appClientId,
       watch.signal,
       watch.processId,
       watch.key,
@@ -231,18 +258,25 @@ export class SignalWatchStore {
     if (target.kind === "app") {
       const count = [...this.sql.exec<{ count: number }>(
         `SELECT COUNT(*) as count FROM signal_watches
-         WHERE uid = ? AND target_type = 'app' AND package_id = ? AND entrypoint_name = ? AND watch_id = ?`,
+         WHERE uid = ? AND target_type = 'app' AND package_id = ? AND entrypoint_name = ?
+           AND app_session_id IS ? AND app_client_id IS ? AND watch_id = ?`,
         uid,
         target.packageId,
         target.entrypointName,
+        target.appSessionId ?? null,
+        target.appClientId ?? null,
         watchId,
       )][0]?.count ?? 0;
       if (count > 0) {
         this.sql.exec(
-          "DELETE FROM signal_watches WHERE uid = ? AND target_type = 'app' AND package_id = ? AND entrypoint_name = ? AND watch_id = ?",
+          `DELETE FROM signal_watches
+           WHERE uid = ? AND target_type = 'app' AND package_id = ? AND entrypoint_name = ?
+             AND app_session_id IS ? AND app_client_id IS ? AND watch_id = ?`,
           uid,
           target.packageId,
           target.entrypointName,
+          target.appSessionId ?? null,
+          target.appClientId ?? null,
           watchId,
         );
       }
@@ -271,18 +305,25 @@ export class SignalWatchStore {
     if (target.kind === "app") {
       const count = [...this.sql.exec<{ count: number }>(
         `SELECT COUNT(*) as count FROM signal_watches
-         WHERE uid = ? AND target_type = 'app' AND package_id = ? AND entrypoint_name = ? AND dedupe_key = ?`,
+         WHERE uid = ? AND target_type = 'app' AND package_id = ? AND entrypoint_name = ?
+           AND app_session_id IS ? AND app_client_id IS ? AND dedupe_key = ?`,
         uid,
         target.packageId,
         target.entrypointName,
+        target.appSessionId ?? null,
+        target.appClientId ?? null,
         key,
       )][0]?.count ?? 0;
       if (count > 0) {
         this.sql.exec(
-          "DELETE FROM signal_watches WHERE uid = ? AND target_type = 'app' AND package_id = ? AND entrypoint_name = ? AND dedupe_key = ?",
+          `DELETE FROM signal_watches
+           WHERE uid = ? AND target_type = 'app' AND package_id = ? AND entrypoint_name = ?
+             AND app_session_id IS ? AND app_client_id IS ? AND dedupe_key = ?`,
           uid,
           target.packageId,
           target.entrypointName,
+          target.appSessionId ?? null,
+          target.appClientId ?? null,
           key,
         );
       }
@@ -307,6 +348,42 @@ export class SignalWatchStore {
     return count;
   }
 
+  removeByAppSession(uid: number, appSessionId: string): number {
+    const count = [...this.sql.exec<{ count: number }>(
+      `SELECT COUNT(*) as count FROM signal_watches
+       WHERE uid = ? AND target_type = 'app' AND app_session_id = ?`,
+      uid,
+      appSessionId,
+    )][0]?.count ?? 0;
+    if (count > 0) {
+      this.sql.exec(
+        "DELETE FROM signal_watches WHERE uid = ? AND target_type = 'app' AND app_session_id = ?",
+        uid,
+        appSessionId,
+      );
+    }
+    return count;
+  }
+
+  removeByAppClient(uid: number, appSessionId: string, appClientId: string): number {
+    const count = [...this.sql.exec<{ count: number }>(
+      `SELECT COUNT(*) as count FROM signal_watches
+       WHERE uid = ? AND target_type = 'app' AND app_session_id = ? AND app_client_id = ?`,
+      uid,
+      appSessionId,
+      appClientId,
+    )][0]?.count ?? 0;
+    if (count > 0) {
+      this.sql.exec(
+        "DELETE FROM signal_watches WHERE uid = ? AND target_type = 'app' AND app_session_id = ? AND app_client_id = ?",
+        uid,
+        appSessionId,
+        appClientId,
+      );
+    }
+    return count;
+  }
+
   private findActiveByKey(
     uid: number,
     target: SignalWatchTargetInput,
@@ -319,6 +396,8 @@ export class SignalWatchStore {
            AND target_type = 'app'
            AND package_id = ?
            AND entrypoint_name = ?
+           AND app_session_id IS ?
+           AND app_client_id IS ?
            AND dedupe_key = ?
            AND status = 'active'
          ORDER BY created_at DESC
@@ -326,6 +405,8 @@ export class SignalWatchStore {
         uid,
         target.packageId,
         target.entrypointName,
+        target.appSessionId ?? null,
+        target.appClientId ?? null,
         key,
       )]
       : [...this.sql.exec<RowShape>(
@@ -361,6 +442,8 @@ type RowShape = {
   package_name: string;
   entrypoint_name: string;
   route_base: string;
+  app_session_id: string | null;
+  app_client_id: string | null;
   signal: string;
   process_id: string | null;
   dedupe_key: string | null;
@@ -384,6 +467,8 @@ function toSignalWatchRecord(row: RowShape): SignalWatchRecord {
     packageName: row.package_name ? row.package_name : null,
     entrypointName: row.entrypoint_name ? row.entrypoint_name : null,
     routeBase: row.route_base ? row.route_base : null,
+    appSessionId: row.app_session_id,
+    appClientId: row.app_client_id,
     signal: row.signal,
     processId: row.process_id,
     key: row.dedupe_key,

--- a/gateway/src/kernel/signals.test.ts
+++ b/gateway/src/kernel/signals.test.ts
@@ -108,7 +108,7 @@ describe("signal watch handlers", () => {
             packageName: "chat",
             entrypointName: "Chat",
             routeBase: "/apps/chat",
-            rpcBase: "/apps/sessions/session-1/socket",
+            rpcBase: "/apps/sessions/session-1/clients/client-1/socket",
             createdAt: 1,
             lastUsedAt: null,
             expiresAt: Date.now() + 60_000,

--- a/gateway/src/kernel/signals.test.ts
+++ b/gateway/src/kernel/signals.test.ts
@@ -74,6 +74,69 @@ describe("signal watch handlers", () => {
     }));
   });
 
+  it("scopes app-owned watches to the active app session client", () => {
+    const ctx = makeContext({
+      appFrame: {
+        packageId: "pkg-chat",
+        packageName: "chat",
+        entrypointName: "Chat",
+        routeBase: "/apps/chat",
+        uid: 1000,
+        username: "hank",
+        issuedAt: 1,
+        expiresAt: Date.now() + 60_000,
+      },
+      appSessions: {
+        getActiveForUid: vi.fn(() => ({
+          sessionId: "session-1",
+          uid: 1000,
+          username: "hank",
+          packageId: "pkg-chat",
+          packageName: "chat",
+          entrypointName: "Chat",
+          routeBase: "/apps/chat",
+          createdAt: 1,
+          lastUsedAt: null,
+          expiresAt: Date.now() + 60_000,
+          state: "active",
+          clients: [{
+            sessionId: "session-1",
+            clientId: "client-1",
+            uid: 1000,
+            username: "hank",
+            packageId: "pkg-chat",
+            packageName: "chat",
+            entrypointName: "Chat",
+            routeBase: "/apps/chat",
+            rpcBase: "/apps/sessions/session-1/socket",
+            createdAt: 1,
+            lastUsedAt: null,
+            expiresAt: Date.now() + 60_000,
+          }],
+        })),
+      },
+    });
+
+    handleSignalWatch({
+      signal: "proc.run.stream",
+      processId: "proc-child",
+      key: "chat:session-1:client-1:proc-child:proc.run.stream",
+      owner: { appSessionId: "session-1", clientId: "client-1" },
+      state: { clientId: "client-1", pid: "proc-child" },
+      once: false,
+    }, ctx);
+
+    expect(ctx.appSessions.getActiveForUid).toHaveBeenCalledWith(1000, "session-1");
+    expect(ctx.signalWatches.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      expiresAt: null,
+      target: expect.objectContaining({
+        kind: "app",
+        appSessionId: "session-1",
+        appClientId: "client-1",
+      }),
+    }));
+  });
+
   it("requires process runtimes to watch an explicit other process", () => {
     const ctx = makeContext({
       processId: "proc-parent",

--- a/gateway/src/kernel/signals.ts
+++ b/gateway/src/kernel/signals.ts
@@ -9,7 +9,7 @@ export function handleSignalWatch(
   args: SignalWatchArgs,
   ctx: KernelContext,
 ): SignalWatchResult {
-  const target = resolveSignalWatchTarget(ctx);
+  const target = resolveSignalWatchTarget(ctx, args);
 
   const signal = args.signal.trim();
   if (!signal) {
@@ -34,8 +34,10 @@ export function handleSignalWatch(
     }
   }
 
-  const ttlMs = clampSignalWatchTtl(args.ttlMs);
-  const expiresAt = ttlMs > 0 ? Date.now() + ttlMs : null;
+  const ttlMs = target.kind === "app" && target.appSessionId && args.ttlMs === undefined
+    ? null
+    : clampSignalWatchTtl(args.ttlMs);
+  const expiresAt = ttlMs == null ? null : Date.now() + ttlMs;
   const key = typeof args.key === "string" && args.key.trim().length > 0
     ? args.key.trim()
     : null;
@@ -63,7 +65,7 @@ export function handleSignalUnwatch(
   args: SignalUnwatchArgs,
   ctx: KernelContext,
 ): SignalUnwatchResult {
-  const target = resolveSignalWatchTarget(ctx);
+  const target = resolveSignalWatchTarget(ctx, args);
   const uid = ctx.identity!.process.uid;
 
   if ("watchId" in args) {
@@ -84,15 +86,28 @@ export function handleSignalUnwatch(
   };
 }
 
-function resolveSignalWatchTarget(ctx: KernelContext): SignalWatchTargetInput {
+function resolveSignalWatchTarget(
+  ctx: KernelContext,
+  args: Pick<SignalWatchArgs, "owner">,
+): SignalWatchTargetInput {
   if (ctx.appFrame) {
+    const owner = resolveAppWatchOwner(ctx, args.owner);
     return {
       kind: "app",
       packageId: ctx.appFrame.packageId,
       packageName: ctx.appFrame.packageName,
       entrypointName: ctx.appFrame.entrypointName,
       routeBase: ctx.appFrame.routeBase,
+      ...(owner
+        ? {
+            appSessionId: owner.appSessionId,
+            appClientId: owner.clientId,
+          }
+        : {}),
     };
+  }
+  if (args.owner !== undefined) {
+    throw new Error("signal.watch owner is only available to app runtimes");
   }
   if (ctx.processId) {
     return {
@@ -101,6 +116,45 @@ function resolveSignalWatchTarget(ctx: KernelContext): SignalWatchTargetInput {
     };
   }
   throw new Error("signal.watch is only available to app and process runtimes");
+}
+
+function resolveAppWatchOwner(
+  ctx: KernelContext,
+  rawOwner: SignalWatchArgs["owner"],
+): { appSessionId: string; clientId: string } | null {
+  if (rawOwner === undefined) {
+    return null;
+  }
+  if (!rawOwner || typeof rawOwner !== "object") {
+    throw new Error("signal.watch owner must be an object");
+  }
+
+  const appSessionId = typeof rawOwner.appSessionId === "string" ? rawOwner.appSessionId.trim() : "";
+  const clientId = typeof rawOwner.clientId === "string" ? rawOwner.clientId.trim() : "";
+  if (!appSessionId || !clientId) {
+    throw new Error("signal.watch owner requires appSessionId and clientId");
+  }
+
+  const appFrame = ctx.appFrame;
+  const uid = ctx.identity!.process.uid;
+  const session = ctx.appSessions.getActiveForUid(uid, appSessionId);
+  if (!session) {
+    throw new Error("Unknown app session");
+  }
+  if (
+    !appFrame ||
+    session.packageId !== appFrame.packageId ||
+    session.packageName !== appFrame.packageName ||
+    session.entrypointName !== appFrame.entrypointName ||
+    session.routeBase !== appFrame.routeBase
+  ) {
+    throw new Error("signal.watch owner does not match current app");
+  }
+  if (!session.clients.some((client) => client.clientId === clientId)) {
+    throw new Error("Unknown app client");
+  }
+
+  return { appSessionId, clientId };
 }
 
 function clampSignalWatchTtl(value: number | undefined): number {

--- a/gateway/src/protocol/app-session.ts
+++ b/gateway/src/protocol/app-session.ts
@@ -1,4 +1,6 @@
-export type AppClientSessionContext = {
+export type AppSessionState = "active" | "detached" | "closing" | "closed" | "expired";
+
+export type AppSessionClientContext = {
   sessionId: string;
   clientId: string;
   uid: number;
@@ -12,6 +14,23 @@ export type AppClientSessionContext = {
   expiresAt: number;
   lastUsedAt?: number | null;
 };
+
+export type AppSessionContext = {
+  sessionId: string;
+  uid: number;
+  username: string;
+  packageId: string;
+  packageName: string;
+  entrypointName: string;
+  routeBase: string;
+  createdAt: number;
+  expiresAt: number;
+  lastUsedAt?: number | null;
+  state: AppSessionState;
+  clients: AppSessionClientContext[];
+};
+
+export type AppClientSessionContext = AppSessionClientContext;
 
 export type IssuedAppClientSession = AppClientSessionContext & {
   secret: string;

--- a/gateway/src/protocol/app-session.ts
+++ b/gateway/src/protocol/app-session.ts
@@ -36,6 +36,14 @@ export type IssuedAppClientSession = AppClientSessionContext & {
   secret: string;
 };
 
+export function buildAppClientRouteBase(sessionId: string, clientId: string): string {
+  return `/apps/sessions/${encodeURIComponent(sessionId)}/clients/${encodeURIComponent(clientId)}`;
+}
+
+export function buildAppClientRpcBase(sessionId: string, clientId: string): string {
+  return `${buildAppClientRouteBase(sessionId, clientId)}/socket`;
+}
+
 export function buildAppRunnerName(uid: number, packageId: string): string {
   return `app:${uid}:${packageId}`;
 }

--- a/gateway/src/syscalls/index.ts
+++ b/gateway/src/syscalls/index.ts
@@ -238,6 +238,8 @@ import type {
   AppAttachArgs,
   AppCloseArgs,
   AppCloseResult,
+  AppDetachArgs,
+  AppDetachResult,
   AppLaunchResult,
   AppListArgs,
   AppListResult,
@@ -268,6 +270,7 @@ export type SyscallDomains = {
   "app.open": { args: AppOpenArgs; result: AppLaunchResult };
   "app.attach": { args: AppAttachArgs; result: AppLaunchResult };
   "app.list": { args: AppListArgs; result: AppListResult };
+  "app.detach": { args: AppDetachArgs; result: AppDetachResult };
   "app.close": { args: AppCloseArgs; result: AppCloseResult };
 
   // CodeMode (process-local programmable tool use)

--- a/gateway/src/syscalls/index.ts
+++ b/gateway/src/syscalls/index.ts
@@ -234,6 +234,15 @@ import type {
   NotificationMarkReadArgs,
   NotificationMarkReadResult,
 } from "@gsv/protocol/syscalls/notification";
+import type {
+  AppAttachArgs,
+  AppCloseArgs,
+  AppCloseResult,
+  AppLaunchResult,
+  AppListArgs,
+  AppListResult,
+  AppOpenArgs,
+} from "@gsv/protocol/syscalls/apps";
 export type ToolDefinition = {
   name: string;
   description: string;
@@ -254,6 +263,12 @@ export type SyscallDomains = {
 
   // Shell (device commands)
   "shell.exec": { args: ShellExecArgs; result: ShellExecResult };
+
+  // App sessions
+  "app.open": { args: AppOpenArgs; result: AppLaunchResult };
+  "app.attach": { args: AppAttachArgs; result: AppLaunchResult };
+  "app.list": { args: AppListArgs; result: AppListResult };
+  "app.close": { args: AppCloseArgs; result: AppCloseResult };
 
   // CodeMode (process-local programmable tool use)
   "codemode.exec": { args: CodeModeExecArgs; result: CodeModeExecResult };
@@ -385,6 +400,7 @@ export type ResultOf<S extends SyscallName> = SyscallDomains[S]["result"];
 type SyscallDomain =
   | "fs"
   | "shell"
+  | "app"
   | "codemode"
   | "proc"
   | "pkg"

--- a/gateway/src/syscalls/signal.ts
+++ b/gateway/src/syscalls/signal.ts
@@ -1,8 +1,14 @@
+export type SignalWatchOwner = {
+  appSessionId: string;
+  clientId: string;
+};
+
 export type SignalWatchArgs = {
   signal: string;
   processId?: string;
   key?: string;
   state?: unknown;
+  owner?: SignalWatchOwner;
   once?: boolean;
   ttlMs?: number;
 };
@@ -15,8 +21,8 @@ export type SignalWatchResult = {
 };
 
 export type SignalUnwatchArgs =
-  | { watchId: string; key?: never }
-  | { watchId?: never; key: string };
+  | { watchId: string; key?: never; owner?: SignalWatchOwner }
+  | { watchId?: never; key: string; owner?: SignalWatchOwner };
 
 export type SignalUnwatchResult = {
   removed: number;

--- a/gateway/wrangler.jsonc
+++ b/gateway/wrangler.jsonc
@@ -52,7 +52,7 @@
 		"directory": "../web/dist/",
 		"binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/ws", "/apps/*", "/app-rpc/*", "/git/*", "/public/*", "/runtime/*", "/downloads/*", "/oauth/*", "/.well-known/*"]
+    "run_worker_first": ["/ws", "/apps/*", "/git/*", "/public/*", "/runtime/*", "/downloads/*", "/oauth/*", "/.well-known/*"]
 	},
 	// Channel service bindings (Gateway → Channel RPC)
 	"services": [

--- a/gateway/wrangler.test.jsonc
+++ b/gateway/wrangler.test.jsonc
@@ -55,7 +55,7 @@
 		"directory": "./test-assets/",
 		"binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/ws", "/apps/*", "/app-rpc/*", "/git/*", "/runtime/*", "/downloads/*"]
+    "run_worker_first": ["/ws", "/apps/*", "/git/*", "/runtime/*", "/downloads/*"]
 	}
 	// Note: No AI binding, no service bindings for channels
 	// Tests should mock these dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@earendil-works/pi-ai": "^0.74.0",
         "@gsv/protocol": "file:../shared/protocol",
         "agents": "^0.10.2",
-        "capnweb": "^0.6.1",
         "just-bash": "^2.12.6",
         "marked": "^16.4.2"
       },
@@ -1820,10 +1819,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "gateway/node_modules/capnweb": {
-      "version": "0.6.1",
-      "license": "MIT"
     },
     "gateway/node_modules/color-convert": {
       "version": "2.0.1",

--- a/shared/package/src/browser.ts
+++ b/shared/package/src/browser.ts
@@ -10,20 +10,62 @@ export type PackageAppBoot = {
   hasBackend: boolean;
 };
 
-type CapnwebGlobal = {
-  newWebSocketRpcSession<T = unknown>(socket: string | WebSocket, localMain?: unknown): T;
-  RpcTarget?: abstract new (...args: unknown[]) => object;
+type AppRequestFrame = {
+  type: "req";
+  id: string;
+  call: string;
+  args?: unknown;
+};
+
+type AppResponseFrame =
+  | {
+      type: "res";
+      id: string;
+      ok: true;
+      data?: unknown;
+    }
+  | {
+      type: "res";
+      id: string;
+      ok: false;
+      error: {
+        code: number;
+        message: string;
+        details?: unknown;
+      };
+    };
+
+type AppSignalFrame = {
+  type: "sig";
+  signal: string;
+  payload?: unknown;
+};
+
+type AppSocketFrame = AppResponseFrame | AppSignalFrame;
+
+type AppConnectResult = {
+  protocol: number;
+  packageId: string;
+  packageName: string;
+  clientId: string;
+  expiresAt: number;
+};
+
+type PendingBackendRequest = {
+  resolve(value: unknown): void;
+  reject(error: unknown): void;
 };
 
 type RemoteBackend = {
   invoke(method: string, args?: unknown): Promise<unknown>;
-  onRpcBroken?: (callback: (error: unknown) => void) => void;
 } & Record<string | symbol, unknown>;
 
 type BackendConnection = {
   backend: RemoteBackend;
   socket: WebSocket;
   broken: boolean;
+  pending: Map<string, PendingBackendRequest>;
+  request<T = unknown>(call: string, args?: unknown): Promise<T>;
 };
 
 type BackendProxyControl = {
@@ -47,7 +89,6 @@ declare global {
     __GSV_BACKEND_READY__?: Promise<unknown>;
     __GSV_APP_RUNTIME__?: PackageAppRuntimeChrome;
     backend?: unknown;
-    capnweb?: CapnwebGlobal;
   }
 }
 
@@ -63,23 +104,16 @@ export function hasAppBoot(): boolean {
   return Boolean(globalThis.window?.__GSV_APP_BOOT__);
 }
 
-function getCapnweb(): CapnwebGlobal {
-  const capnweb = globalThis.window?.capnweb;
-  if (!capnweb || typeof capnweb.newWebSocketRpcSession !== "function") {
-    throw new Error("capnweb runtime is unavailable");
-  }
-  return capnweb;
-}
-
 let backendConnectionPromise: Promise<BackendConnection> | null = null;
 let backendProxy: unknown = null;
-let appClientTarget: unknown = null;
 let appSessionRefreshPromise: Promise<PackageAppBoot> | null = null;
 let appRuntimeReady = false;
 let connectedReadyFallback: ReturnType<typeof setTimeout> | null = null;
+let backendRequestSeq = 0;
 const appEventListeners = new Set<AppEventListener>();
 const APP_SESSION_REFRESH_LEEWAY_MS = 60_000;
 const CONNECTED_READY_FALLBACK_MS = 650;
+const APP_SOCKET_PROTOCOL_VERSION = 1;
 
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -198,6 +232,17 @@ class BackendTransportClosedError extends Error {
   }
 }
 
+class BackendRpcError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "BackendRpcError";
+  }
+}
+
 function resetBackendConnection(): void {
   const previousConnection = backendConnectionPromise;
   backendConnectionPromise = null;
@@ -205,7 +250,11 @@ function resetBackendConnection(): void {
     globalThis.window.__GSV_BACKEND_READY__ = undefined;
   }
   void previousConnection
-    ?.then((connection) => closeBackendSocket(connection.socket))
+    ?.then((connection) => {
+      connection.broken = true;
+      rejectPendingBackendRequests(connection, new BackendTransportClosedError("client reconnect"));
+      closeBackendSocket(connection.socket);
+    })
     .catch(() => {});
 }
 
@@ -219,6 +268,161 @@ function shouldRetryBackendCall(connection: BackendConnection | null, error: unk
   return error instanceof BackendTransportClosedError
     || Boolean(connection?.broken)
     || Boolean(connection && connection.socket.readyState !== WebSocket.OPEN);
+}
+
+function createRequestId(): string {
+  backendRequestSeq += 1;
+  return `app:${Date.now().toString(36)}:${backendRequestSeq.toString(36)}`;
+}
+
+function rejectPendingBackendRequests(connection: BackendConnection, error: unknown): void {
+  for (const pending of connection.pending.values()) {
+    pending.reject(error);
+  }
+  connection.pending.clear();
+}
+
+function waitForSocketOpen(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.OPEN) {
+    return Promise.resolve();
+  }
+  if (socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED) {
+    return Promise.reject(new BackendTransportClosedError("package backend socket closed"));
+  }
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      socket.removeEventListener("open", onOpen);
+      socket.removeEventListener("error", onError);
+      socket.removeEventListener("close", onClose);
+    };
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (event: Event) => {
+      cleanup();
+      reject(new BackendTransportClosedError(event));
+    };
+    const onClose = (event: CloseEvent) => {
+      cleanup();
+      reject(new BackendTransportClosedError(`package backend socket closed (${event.code})`));
+    };
+    socket.addEventListener("open", onOpen);
+    socket.addEventListener("error", onError);
+    socket.addEventListener("close", onClose);
+  });
+}
+
+function sendBackendRequest<T = unknown>(
+  connection: BackendConnection,
+  call: string,
+  args?: unknown,
+): Promise<T> {
+  if (connection.broken || connection.socket.readyState !== WebSocket.OPEN) {
+    return Promise.reject(new BackendTransportClosedError("package backend socket is closed"));
+  }
+
+  const id = createRequestId();
+  const frame: AppRequestFrame = {
+    type: "req",
+    id,
+    call,
+    ...(args === undefined ? {} : { args }),
+  };
+
+  return new Promise((resolve, reject) => {
+    connection.pending.set(id, {
+      resolve: (value) => resolve(value as T),
+      reject,
+    });
+    try {
+      connection.socket.send(JSON.stringify(frame));
+    } catch (error) {
+      connection.pending.delete(id);
+      reject(new BackendTransportClosedError(error));
+    }
+  });
+}
+
+function handleBackendFrame(connection: BackendConnection, raw: unknown): void {
+  if (typeof raw !== "string") {
+    console.warn("[gsv-package] ignored non-text app frame");
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.warn("[gsv-package] ignored invalid app frame", error);
+    return;
+  }
+
+  if (!isAppSocketFrame(parsed)) {
+    console.warn("[gsv-package] ignored unknown app frame", parsed);
+    return;
+  }
+
+  if (parsed.type === "sig") {
+    emitAppEvent(parsed.signal, parsed.payload);
+    return;
+  }
+
+  const pending = connection.pending.get(parsed.id);
+  if (!pending) {
+    return;
+  }
+  connection.pending.delete(parsed.id);
+  if (parsed.ok) {
+    pending.resolve(parsed.data);
+    return;
+  }
+  pending.reject(new BackendRpcError(
+    parsed.error.code,
+    parsed.error.message,
+    parsed.error.details,
+  ));
+}
+
+function isAppSocketFrame(value: unknown): value is AppSocketFrame {
+  return isAppResponseFrame(value) || isAppSignalFrame(value);
+}
+
+function isAppResponseFrame(value: unknown): value is AppResponseFrame {
+  const record = asRecord(value);
+  if (record?.type !== "res" || typeof record.id !== "string" || typeof record.ok !== "boolean") {
+    return false;
+  }
+  if (record.ok) {
+    return true;
+  }
+  const error = asRecord(record.error);
+  return Boolean(
+    error &&
+    typeof error.code === "number" &&
+    typeof error.message === "string",
+  );
+}
+
+function isAppSignalFrame(value: unknown): value is AppSignalFrame {
+  const record = asRecord(value);
+  return record?.type === "sig" && typeof record.signal === "string";
+}
+
+function isAppConnectResult(value: unknown): value is AppConnectResult {
+  const record = asRecord(value);
+  return Boolean(
+    record &&
+    typeof record.protocol === "number" &&
+    typeof record.packageId === "string" &&
+    typeof record.packageName === "string" &&
+    typeof record.clientId === "string" &&
+    typeof record.expiresAt === "number",
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? value as Record<string, unknown> : null;
 }
 
 function isPackageAppBoot(value: unknown): value is PackageAppBoot {
@@ -294,23 +498,6 @@ function emitAppEvent(event: string, payload: unknown): void {
   }
 }
 
-function getOrCreateAppClientTarget(): unknown {
-  if (appClientTarget) {
-    return appClientTarget;
-  }
-  const RpcTargetCtor = getCapnweb().RpcTarget;
-  if (typeof RpcTargetCtor !== "function") {
-    throw new Error("capnweb RpcTarget is unavailable");
-  }
-  appClientTarget = new class extends RpcTargetCtor {
-    async onAppEvent(event: unknown, payload: unknown) {
-      const normalizedEvent = typeof event === "string" ? event : String(event ?? "");
-      emitAppEvent(normalizedEvent, payload);
-    }
-  }();
-  return appClientTarget;
-}
-
 async function connectBackendTransport(): Promise<BackendConnection> {
   if (backendConnectionPromise) {
     return backendConnectionPromise;
@@ -325,42 +512,54 @@ async function connectBackendTransport(): Promise<BackendConnection> {
   if (shouldRefreshAppSession(boot)) {
     boot = await refreshAppSession(boot);
   }
-  const capnweb = getCapnweb();
   const socket = new WebSocket(buildRpcWebSocketUrl(boot.rpcBase));
-  let connection: BackendConnection | null = null;
+  const connection: BackendConnection = {
+    backend: {
+      invoke(method: string, args?: unknown) {
+        return connection.request("backend.invoke", { method, args });
+      },
+    },
+    socket,
+    broken: socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED,
+    pending: new Map(),
+    request<T = unknown>(call: string, args?: unknown): Promise<T> {
+      return sendBackendRequest<T>(connection, call, args);
+    },
+  };
   let ready: Promise<BackendConnection>;
-  let transportBroken = socket.readyState === WebSocket.CLOSING || socket.readyState === WebSocket.CLOSED;
-  const markTransportBroken = () => {
-    transportBroken = true;
-    if (connection) {
-      connection.broken = true;
-    }
+  const markTransportBroken = (cause: unknown) => {
+    connection.broken = true;
+    rejectPendingBackendRequests(connection, new BackendTransportClosedError(cause));
     if (backendConnectionPromise === ready) {
       resetBackendConnection();
     }
   };
-  socket.addEventListener("close", markTransportBroken);
+  socket.addEventListener("message", (event) => {
+    handleBackendFrame(connection, event.data);
+  });
+  socket.addEventListener("close", (event) => {
+    markTransportBroken(`package backend socket closed (${event.code})`);
+  });
   socket.addEventListener("error", markTransportBroken);
 
   ready = (async () => {
-    const session = capnweb.newWebSocketRpcSession<{
-      authenticate(secret: string, clientTarget?: unknown): unknown;
-    }>(socket);
-    const backend = await session.authenticate(boot.sessionSecret, getOrCreateAppClientTarget());
-    if (!backend || (typeof backend !== "object" && typeof backend !== "function")) {
-      throw new Error("package backend rpc returned an invalid target");
+    await waitForSocketOpen(socket);
+    const connected = await connection.request("app.connect", {
+      secret: boot.sessionSecret,
+      clientId: boot.clientId,
+    });
+    if (!isAppConnectResult(connected)) {
+      throw new Error("package backend returned an invalid connect response");
     }
-    const target = backend as RemoteBackend;
-    if (typeof target.invoke !== "function") {
-      throw new Error("package backend rpc target is missing invoke()");
+    if (connected.protocol !== APP_SOCKET_PROTOCOL_VERSION) {
+      throw new Error(`unsupported package backend protocol ${connected.protocol}`);
     }
-    connection = {
-      backend: target,
-      socket,
-      broken: transportBroken || socket.readyState !== WebSocket.OPEN,
-    };
-    if (typeof target.onRpcBroken === "function") {
-      target.onRpcBroken(markTransportBroken);
+    if (
+      connected.packageId !== boot.packageId ||
+      connected.packageName !== boot.packageName ||
+      connected.clientId !== boot.clientId
+    ) {
+      throw new Error("package backend connected to the wrong app session");
     }
     setRuntimeStatus("connected");
     if (!appRuntimeReady) {
@@ -371,7 +570,7 @@ async function connectBackendTransport(): Promise<BackendConnection> {
     if (backendConnectionPromise === ready) {
       resetBackendConnection();
     }
-    const nextError = transportBroken ? new BackendTransportClosedError(error) : error;
+    const nextError = connection.broken ? new BackendTransportClosedError(error) : error;
     setAppError(nextError);
     throw nextError;
   });

--- a/shared/package/src/browser.ts
+++ b/shared/package/src/browser.ts
@@ -4,7 +4,6 @@ export type PackageAppBoot = {
   routeBase: string;
   rpcBase: string;
   sessionId: string;
-  sessionSecret: string;
   clientId: string;
   expiresAt: number;
   hasBackend: boolean;
@@ -42,14 +41,6 @@ type AppSignalFrame = {
 };
 
 type AppSocketFrame = AppResponseFrame | AppSignalFrame;
-
-type AppConnectResult = {
-  protocol: number;
-  packageId: string;
-  packageName: string;
-  clientId: string;
-  expiresAt: number;
-};
 
 type PendingBackendRequest = {
   resolve(value: unknown): void;
@@ -113,7 +104,6 @@ let backendRequestSeq = 0;
 const appEventListeners = new Set<AppEventListener>();
 const APP_SESSION_REFRESH_LEEWAY_MS = 60_000;
 const CONNECTED_READY_FALLBACK_MS = 650;
-const APP_SOCKET_PROTOCOL_VERSION = 1;
 
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -409,18 +399,6 @@ function isAppSignalFrame(value: unknown): value is AppSignalFrame {
   return record?.type === "sig" && typeof record.signal === "string";
 }
 
-function isAppConnectResult(value: unknown): value is AppConnectResult {
-  const record = asRecord(value);
-  return Boolean(
-    record &&
-    typeof record.protocol === "number" &&
-    typeof record.packageId === "string" &&
-    typeof record.packageName === "string" &&
-    typeof record.clientId === "string" &&
-    typeof record.expiresAt === "number",
-  );
-}
-
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" ? value as Record<string, unknown> : null;
 }
@@ -435,7 +413,6 @@ function isPackageAppBoot(value: unknown): value is PackageAppBoot {
     && typeof candidate.routeBase === "string"
     && typeof candidate.rpcBase === "string"
     && typeof candidate.sessionId === "string"
-    && typeof candidate.sessionSecret === "string"
     && typeof candidate.clientId === "string"
     && typeof candidate.expiresAt === "number"
     && typeof candidate.hasBackend === "boolean";
@@ -455,10 +432,8 @@ async function refreshAppSession(boot: PackageAppBoot): Promise<PackageAppBoot> 
       method: "POST",
       credentials: "same-origin",
       headers: {
-        "content-type": "application/json",
         "accept": "application/json",
       },
-      body: JSON.stringify({ clientId: boot.clientId }),
     });
 
     if (!response.ok) {
@@ -544,23 +519,6 @@ async function connectBackendTransport(): Promise<BackendConnection> {
 
   ready = (async () => {
     await waitForSocketOpen(socket);
-    const connected = await connection.request("app.connect", {
-      secret: boot.sessionSecret,
-      clientId: boot.clientId,
-    });
-    if (!isAppConnectResult(connected)) {
-      throw new Error("package backend returned an invalid connect response");
-    }
-    if (connected.protocol !== APP_SOCKET_PROTOCOL_VERSION) {
-      throw new Error(`unsupported package backend protocol ${connected.protocol}`);
-    }
-    if (
-      connected.packageId !== boot.packageId ||
-      connected.packageName !== boot.packageName ||
-      connected.clientId !== boot.clientId
-    ) {
-      throw new Error("package backend connected to the wrong app session");
-    }
     setRuntimeStatus("connected");
     if (!appRuntimeReady) {
       scheduleConnectedReadyFallback();
@@ -636,7 +594,7 @@ function buildRpcWebSocketUrl(rpcBase: string): string {
 
 function buildRpcSessionRefreshUrl(boot: PackageAppBoot): string {
   return new URL(
-    `/app-rpc/${encodeURIComponent(boot.packageName)}/sessions/${encodeURIComponent(boot.sessionId)}/refresh`,
+    `/apps/sessions/${encodeURIComponent(boot.sessionId)}/refresh`,
     globalThis.window?.location?.href ?? "http://localhost",
   ).toString();
 }

--- a/shared/package/src/browser.ts
+++ b/shared/package/src/browser.ts
@@ -639,8 +639,9 @@ function buildRpcWebSocketUrl(rpcBase: string): string {
 }
 
 function buildRpcSessionRefreshUrl(boot: PackageAppBoot): string {
+  const routeBase = boot.routeBase.endsWith("/") ? boot.routeBase.slice(0, -1) : boot.routeBase;
   return new URL(
-    `/apps/sessions/${encodeURIComponent(boot.sessionId)}/refresh`,
+    `${routeBase}/refresh`,
     globalThis.window?.location?.href ?? "http://localhost",
   ).toString();
 }

--- a/shared/package/src/browser.ts
+++ b/shared/package/src/browser.ts
@@ -100,9 +100,11 @@ let backendProxy: unknown = null;
 let appSessionRefreshPromise: Promise<PackageAppBoot> | null = null;
 let appRuntimeReady = false;
 let connectedReadyFallback: ReturnType<typeof setTimeout> | null = null;
+let appSessionRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 let backendRequestSeq = 0;
 const appEventListeners = new Set<AppEventListener>();
 const APP_SESSION_REFRESH_LEEWAY_MS = 60_000;
+const APP_SESSION_REFRESH_RETRY_MS = 30_000;
 const CONNECTED_READY_FALLBACK_MS = 650;
 
 function formatErrorMessage(error: unknown): string {
@@ -133,6 +135,13 @@ function clearConnectedReadyFallback(): void {
   if (connectedReadyFallback !== null) {
     clearTimeout(connectedReadyFallback);
     connectedReadyFallback = null;
+  }
+}
+
+function clearAppSessionRefreshTimer(): void {
+  if (appSessionRefreshTimer !== null) {
+    clearTimeout(appSessionRefreshTimer);
+    appSessionRefreshTimer = null;
   }
 }
 
@@ -236,6 +245,7 @@ class BackendRpcError extends Error {
 function resetBackendConnection(): void {
   const previousConnection = backendConnectionPromise;
   backendConnectionPromise = null;
+  clearAppSessionRefreshTimer();
   if (globalThis.window) {
     globalThis.window.__GSV_BACKEND_READY__ = undefined;
   }
@@ -463,6 +473,37 @@ async function refreshAppSession(boot: PackageAppBoot): Promise<PackageAppBoot> 
   return refresh;
 }
 
+function scheduleAppSessionRefresh(
+  connection: BackendConnection,
+  boot: PackageAppBoot,
+  isCurrentConnection: () => boolean,
+): void {
+  clearAppSessionRefreshTimer();
+  if (connection.broken || !isCurrentConnection()) {
+    return;
+  }
+  const delayMs = Math.max(0, boot.expiresAt - Date.now() - APP_SESSION_REFRESH_LEEWAY_MS);
+  appSessionRefreshTimer = setTimeout(() => {
+    appSessionRefreshTimer = null;
+    if (connection.broken || !isCurrentConnection()) {
+      return;
+    }
+    void refreshAppSession(getAppBoot())
+      .then((nextBoot) => {
+        scheduleAppSessionRefresh(connection, nextBoot, isCurrentConnection);
+      })
+      .catch((error) => {
+        console.warn("[gsv-package] app session refresh failed", error);
+        if (!connection.broken && isCurrentConnection()) {
+          appSessionRefreshTimer = setTimeout(() => {
+            appSessionRefreshTimer = null;
+            scheduleAppSessionRefresh(connection, getAppBoot(), isCurrentConnection);
+          }, APP_SESSION_REFRESH_RETRY_MS);
+        }
+      });
+  }, delayMs);
+}
+
 function emitAppEvent(event: string, payload: unknown): void {
   for (const listener of appEventListeners) {
     try {
@@ -502,8 +543,12 @@ async function connectBackendTransport(): Promise<BackendConnection> {
     },
   };
   let ready: Promise<BackendConnection>;
+  const isCurrentConnection = () => backendConnectionPromise === ready;
   const markTransportBroken = (cause: unknown) => {
     connection.broken = true;
+    if (isCurrentConnection()) {
+      clearAppSessionRefreshTimer();
+    }
     rejectPendingBackendRequests(connection, new BackendTransportClosedError(cause));
     if (backendConnectionPromise === ready) {
       resetBackendConnection();
@@ -520,6 +565,7 @@ async function connectBackendTransport(): Promise<BackendConnection> {
   ready = (async () => {
     await waitForSocketOpen(socket);
     setRuntimeStatus("connected");
+    scheduleAppSessionRefresh(connection, boot, isCurrentConnection);
     if (!appRuntimeReady) {
       scheduleConnectedReadyFallback();
     }

--- a/shared/package/src/host.ts
+++ b/shared/package/src/host.ts
@@ -83,14 +83,9 @@ export function getAppClientId(): string {
       return getAppBoot().clientId.trim();
     }
   } catch {
-    // Fall back to the legacy query param below.
-  }
-
-  try {
-    return new URL(window.location.href).searchParams.get("windowId")?.trim() || "";
-  } catch {
     return "";
   }
+  return "";
 }
 
 export function openApp(request: OpenAppRequest): void {

--- a/shared/package/src/host.ts
+++ b/shared/package/src/host.ts
@@ -3,6 +3,7 @@ import {
   buildOpenAppRoute,
   type OpenAppRequest,
 } from "@gsv/app-link";
+import { getAppBoot, hasAppBoot } from "./browser";
 
 export type HostStatus = {
   connected: boolean;
@@ -55,8 +56,7 @@ declare global {
 }
 
 export function consumePendingAppOpen(windowId?: string): OpenAppRequest | null {
-  const fallbackWindowId = new URL(window.location.href).searchParams.get("windowId")?.trim() || "";
-  const normalizedWindowId = windowId?.trim() || fallbackWindowId;
+  const normalizedWindowId = windowId?.trim() || getAppClientId();
   if (!normalizedWindowId) {
     return null;
   }
@@ -75,6 +75,22 @@ export function consumePendingAppOpen(windowId?: string): OpenAppRequest | null 
   }
 
   return null;
+}
+
+export function getAppClientId(): string {
+  try {
+    if (hasAppBoot()) {
+      return getAppBoot().clientId.trim();
+    }
+  } catch {
+    // Fall back to the legacy query param below.
+  }
+
+  try {
+    return new URL(window.location.href).searchParams.get("windowId")?.trim() || "";
+  } catch {
+    return "";
+  }
 }
 
 export function openApp(request: OpenAppRequest): void {

--- a/shared/protocol/package.json
+++ b/shared/protocol/package.json
@@ -12,6 +12,7 @@
     "./syscalls/proc": "./src/syscalls/proc.ts",
     "./syscalls/notification": "./src/syscalls/notification.ts",
     "./syscalls/ai": "./src/syscalls/ai.ts",
+    "./syscalls/apps": "./src/syscalls/apps.ts",
     "./binary-frame": "./src/binary-frame.ts",
     "./speech-text": "./src/speech-text.ts"
   },

--- a/shared/protocol/src/index.ts
+++ b/shared/protocol/src/index.ts
@@ -4,5 +4,6 @@ export type * from "./syscalls/repositories";
 export type * from "./syscalls/proc";
 export type * from "./syscalls/notification";
 export type * from "./syscalls/ai";
+export type * from "./syscalls/apps";
 export type * from "./package-assembly";
 export * from "./binary-frame";

--- a/shared/protocol/src/syscalls/apps.ts
+++ b/shared/protocol/src/syscalls/apps.ts
@@ -1,0 +1,62 @@
+export type AppLaunchWindowHint = {
+  title: string;
+  width?: number;
+  height?: number;
+  minWidth?: number;
+  minHeight?: number;
+};
+
+export type AppOpenArgs = {
+  packageName: string;
+  entrypointName?: string;
+  clientId?: string;
+  suffix?: string;
+  search?: string;
+  hash?: string;
+};
+
+export type AppAttachArgs = {
+  sessionId: string;
+  suffix?: string;
+  search?: string;
+  hash?: string;
+};
+
+export type AppLaunchResult = {
+  sessionId: string;
+  packageId: string;
+  packageName: string;
+  entrypointName: string;
+  routeBase: string;
+  clientId: string;
+  launchUrl: string;
+  expiresAt: number;
+  window: AppLaunchWindowHint;
+};
+
+export type AppListArgs = Record<string, never>;
+
+export type AppSessionSummary = {
+  sessionId: string;
+  packageId: string;
+  packageName: string;
+  entrypointName: string;
+  routeBase: string;
+  clientId: string;
+  createdAt: number;
+  lastUsedAt: number | null;
+  expiresAt: number;
+  state: "active";
+};
+
+export type AppListResult = {
+  sessions: AppSessionSummary[];
+};
+
+export type AppCloseArgs = {
+  sessionId: string;
+};
+
+export type AppCloseResult = {
+  closed: boolean;
+};

--- a/shared/protocol/src/syscalls/apps.ts
+++ b/shared/protocol/src/syscalls/apps.ts
@@ -17,6 +17,7 @@ export type AppOpenArgs = {
 
 export type AppAttachArgs = {
   sessionId: string;
+  clientId?: string;
   suffix?: string;
   search?: string;
   hash?: string;
@@ -36,17 +37,28 @@ export type AppLaunchResult = {
 
 export type AppListArgs = Record<string, never>;
 
+export type AppSessionState = "active" | "detached" | "closing" | "closed" | "expired";
+export type AppSessionClientState = "active" | "closed" | "expired";
+
+export type AppSessionClientSummary = {
+  clientId: string;
+  createdAt: number;
+  lastUsedAt: number | null;
+  expiresAt: number;
+  state: AppSessionClientState;
+};
+
 export type AppSessionSummary = {
   sessionId: string;
   packageId: string;
   packageName: string;
   entrypointName: string;
   routeBase: string;
-  clientId: string;
   createdAt: number;
   lastUsedAt: number | null;
   expiresAt: number;
-  state: "active";
+  state: AppSessionState;
+  clients: AppSessionClientSummary[];
 };
 
 export type AppListResult = {

--- a/shared/protocol/src/syscalls/apps.ts
+++ b/shared/protocol/src/syscalls/apps.ts
@@ -31,6 +31,7 @@ export type AppLaunchResult = {
   routeBase: string;
   clientId: string;
   launchUrl: string;
+  launchToken: string;
   expiresAt: number;
   window: AppLaunchWindowHint;
 };

--- a/shared/protocol/src/syscalls/apps.ts
+++ b/shared/protocol/src/syscalls/apps.ts
@@ -65,6 +65,15 @@ export type AppListResult = {
   sessions: AppSessionSummary[];
 };
 
+export type AppDetachArgs = {
+  sessionId: string;
+  clientId: string;
+};
+
+export type AppDetachResult = {
+  detached: boolean;
+};
+
 export type AppCloseArgs = {
   sessionId: string;
 };

--- a/web/src/apps-runtime.ts
+++ b/web/src/apps-runtime.ts
@@ -2,6 +2,7 @@ import type { AppManifest } from "./apps";
 import type { AppInstance, AppRuntimeRegistry } from "./app-runtime";
 import type { GatewayClientLike } from "./gateway-client";
 import { attachHostBridge } from "./host-bridge";
+import type { AppLaunchResult, AppOpenArgs } from "@gsv/protocol/syscalls/apps";
 
 function escapeHtml(value: string): string {
   return value
@@ -39,6 +40,23 @@ function canonicalizeAppRoute(route: string): string {
     url.pathname = `${url.pathname}/`;
   }
   return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function appOpenArgsFromRoute(route: string, windowId: string): AppOpenArgs {
+  const url = new URL(canonicalizeAppRoute(route), window.location.origin);
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length < 2 || parts[0] !== "apps" || parts[1] === "sessions") {
+    throw new Error(`Unsupported app route: ${route}`);
+  }
+
+  const suffixParts = parts.slice(2);
+  return {
+    packageName: parts[1],
+    clientId: windowId,
+    suffix: suffixParts.length > 0 ? `/${suffixParts.join("/")}` : "/",
+    search: url.search,
+    hash: url.hash,
+  };
 }
 
 function attachIframeInteractionFocus(iframe: HTMLIFrameElement, requestFocus: () => void): { destroy: () => void } {
@@ -91,13 +109,21 @@ function attachIframeInteractionFocus(iframe: HTMLIFrameElement, requestFocus: (
 function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClientLike): AppInstance {
   let bridge: ReturnType<typeof attachHostBridge> | null = null;
   let focusController: ReturnType<typeof attachIframeInteractionFocus> | null = null;
+  let mountGeneration = 0;
 
   return {
-    mount: (container, context) => {
+    mount: async (container, context) => {
+      const generation = ++mountGeneration;
+      const launch = await gatewayClient.call<AppLaunchResult>(
+        "app.open",
+        appOpenArgsFromRoute(context.route, context.windowId),
+      );
+      if (generation !== mountGeneration) {
+        return;
+      }
+
       const iframe = document.createElement("iframe");
-      const iframeUrl = new URL(canonicalizeAppRoute(context.route), window.location.origin);
-      iframeUrl.searchParams.set("windowId", context.windowId);
-      iframe.src = iframeUrl.pathname + iframeUrl.search + iframeUrl.hash;
+      iframe.src = launch.launchUrl;
       iframe.title = manifest.name;
       iframe.loading = "eager";
       iframe.style.width = "100%";
@@ -118,6 +144,7 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
       container.replaceChildren(iframe);
     },
     terminate: () => {
+      mountGeneration += 1;
       focusController?.destroy();
       focusController = null;
       bridge?.destroy();

--- a/web/src/apps-runtime.ts
+++ b/web/src/apps-runtime.ts
@@ -111,6 +111,7 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
   let focusController: ReturnType<typeof attachIframeInteractionFocus> | null = null;
   let mountGeneration = 0;
   let activeSessionId: string | null = null;
+  let activeClientId: string | null = null;
 
   const closeSession = (sessionId: string): void => {
     void gatewayClient.call("app.close", { sessionId }).catch(() => {
@@ -118,11 +119,19 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
     });
   };
 
-  const closeActiveSession = (): void => {
+  const detachClient = (sessionId: string, clientId: string): void => {
+    void gatewayClient.call("app.detach", { sessionId, clientId }).catch(() => {
+      // The server may already have expired the session or the host may be disconnecting.
+    });
+  };
+
+  const detachActiveClient = (): void => {
     const sessionId = activeSessionId;
+    const clientId = activeClientId;
     activeSessionId = null;
-    if (sessionId) {
-      closeSession(sessionId);
+    activeClientId = null;
+    if (sessionId && clientId) {
+      detachClient(sessionId, clientId);
     }
   };
 
@@ -138,8 +147,9 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
         return;
       }
 
-      closeActiveSession();
+      detachActiveClient();
       activeSessionId = launch.sessionId;
+      activeClientId = launch.clientId;
 
       const iframe = document.createElement("iframe");
       iframe.src = launch.launchUrl;
@@ -164,7 +174,7 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
     },
     terminate: () => {
       mountGeneration += 1;
-      closeActiveSession();
+      detachActiveClient();
       focusController?.destroy();
       focusController = null;
       bridge?.destroy();

--- a/web/src/apps-runtime.ts
+++ b/web/src/apps-runtime.ts
@@ -106,6 +106,27 @@ function attachIframeInteractionFocus(iframe: HTMLIFrameElement, requestFocus: (
   };
 }
 
+function appSessionLaunchEndpoint(sessionId: string): string {
+  return `/apps/sessions/${encodeURIComponent(sessionId)}/launch`;
+}
+
+async function establishAppLaunchSession(launch: AppLaunchResult): Promise<void> {
+  const response = await fetch(appSessionLaunchEndpoint(launch.sessionId), {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      "accept": "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ token: launch.launchToken }),
+  });
+  if (response.ok) {
+    return;
+  }
+  const message = await response.text().catch(() => "");
+  throw new Error(message || `Failed to launch app session (${response.status})`);
+}
+
 function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClientLike): AppInstance {
   let bridge: ReturnType<typeof attachHostBridge> | null = null;
   let focusController: ReturnType<typeof attachIframeInteractionFocus> | null = null;
@@ -142,6 +163,16 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
         "app.open",
         appOpenArgsFromRoute(context.route, context.windowId),
       );
+      if (generation !== mountGeneration) {
+        closeSession(launch.sessionId);
+        return;
+      }
+      try {
+        await establishAppLaunchSession(launch);
+      } catch (error) {
+        closeSession(launch.sessionId);
+        throw error;
+      }
       if (generation !== mountGeneration) {
         closeSession(launch.sessionId);
         return;

--- a/web/src/apps-runtime.ts
+++ b/web/src/apps-runtime.ts
@@ -110,6 +110,21 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
   let bridge: ReturnType<typeof attachHostBridge> | null = null;
   let focusController: ReturnType<typeof attachIframeInteractionFocus> | null = null;
   let mountGeneration = 0;
+  let activeSessionId: string | null = null;
+
+  const closeSession = (sessionId: string): void => {
+    void gatewayClient.call("app.close", { sessionId }).catch(() => {
+      // The server may already have expired the session or the host may be disconnecting.
+    });
+  };
+
+  const closeActiveSession = (): void => {
+    const sessionId = activeSessionId;
+    activeSessionId = null;
+    if (sessionId) {
+      closeSession(sessionId);
+    }
+  };
 
   return {
     mount: async (container, context) => {
@@ -119,8 +134,12 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
         appOpenArgsFromRoute(context.route, context.windowId),
       );
       if (generation !== mountGeneration) {
+        closeSession(launch.sessionId);
         return;
       }
+
+      closeActiveSession();
+      activeSessionId = launch.sessionId;
 
       const iframe = document.createElement("iframe");
       iframe.src = launch.launchUrl;
@@ -145,6 +164,7 @@ function createWebAppInstance(manifest: AppManifest, gatewayClient: GatewayClien
     },
     terminate: () => {
       mountGeneration += 1;
+      closeActiveSession();
       focusController?.destroy();
       focusController = null;
       bridge?.destroy();

--- a/web/src/session-service.ts
+++ b/web/src/session-service.ts
@@ -14,8 +14,6 @@ import type {
 const STORAGE_USERNAME = "gsv.ui.gateway.username";
 const STORAGE_SESSION_TOKEN = "gsv.ui.session.token.v1";
 const STORAGE_PENDING_REVOKES = "gsv.ui.session.pending-revokes.v1";
-const APP_SESSION_USER_COOKIE = "gsv_app_user";
-const APP_SESSION_TOKEN_COOKIE = "gsv_app_token";
 const SESSION_TOKEN_TTL_MS = 12 * 60 * 60 * 1000;
 const SESSION_TOKEN_REFRESH_LEEWAY_MS = 10 * 60 * 1000;
 const LOCK_REVOKE_WAIT_MS = 1_500;
@@ -132,8 +130,6 @@ function storePersistedToken(token: PersistedSessionToken): void {
   } catch {
     // Ignore storage failures.
   }
-
-  syncAppSessionCookies(token);
 }
 
 function deriveGatewayUrlFromOrigin(): string {
@@ -184,46 +180,6 @@ function waitFor(ms: number): Promise<void> {
   });
 }
 
-function writeCookie(name: string, value: string, expiresAt: number | null): void {
-  const parts = [
-    `${name}=${encodeURIComponent(value)}`,
-    "Path=/",
-    "SameSite=Strict",
-  ];
-
-  if (window.location.protocol === "https:") {
-    parts.push("Secure");
-  }
-  if (typeof expiresAt === "number") {
-    parts.push(`Expires=${new Date(expiresAt).toUTCString()}`);
-  }
-
-  document.cookie = parts.join("; ");
-}
-
-function clearCookie(name: string): void {
-  const parts = [
-    `${name}=`,
-    "Path=/",
-    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
-    "SameSite=Strict",
-  ];
-  if (window.location.protocol === "https:") {
-    parts.push("Secure");
-  }
-  document.cookie = parts.join("; ");
-}
-
-function syncAppSessionCookies(token: PersistedSessionToken): void {
-  writeCookie(APP_SESSION_USER_COOKIE, token.username, token.expiresAt);
-  writeCookie(APP_SESSION_TOKEN_COOKIE, token.token, token.expiresAt);
-}
-
-function clearAppSessionCookies(): void {
-  clearCookie(APP_SESSION_USER_COOKIE);
-  clearCookie(APP_SESSION_TOKEN_COOKIE);
-}
-
 export function createSessionService(client: GatewayClient): SessionService {
   const listeners = new Set<(snapshot: SessionSnapshot) => void>();
 
@@ -241,12 +197,6 @@ export function createSessionService(client: GatewayClient): SessionService {
   let refreshTimerId: number | null = null;
   let pendingSetupLogin: SessionLoginInput | null = null;
   let holdReadyUntilBootstrap = false;
-
-  if (currentSessionToken) {
-    syncAppSessionCookies(currentSessionToken);
-  } else {
-    clearAppSessionCookies();
-  }
 
   const emit = (): void => {
     for (const listener of listeners) {
@@ -269,7 +219,6 @@ export function createSessionService(client: GatewayClient): SessionService {
   const clearStoredSessionToken = (): void => {
     currentSessionToken = null;
     removeValue(STORAGE_SESSION_TOKEN);
-    clearAppSessionCookies();
     clearRefreshTimer();
   };
 


### PR DESCRIPTION
- Replaced app-client capnweb transport with AppRunner-owned hibernatable WebSocket transport.
- Added session-scoped app runtime URLs under /apps/sessions/<sid>/.
- Added short-lived app launch URLs that set scoped HttpOnly app session cookies.
- Added app.open, app.attach, app.list, app.close, and app.detach syscalls.
- Removed JS-visible app session secrets from browser boot.
- Removed legacy /app-rpc/* routing.
- Removed legacy direct /apps/<pkg> app launch path.
- Changed web shell app launches to use app.open.
- Split Kernel app sessions from attached app clients/windows.
- Updated app.list to return attached clients per app session.
- Added AppRunner socket closure for whole app sessions.
- Added AppRunner socket closure for individual detached app clients.
- Changed web shell window teardown to call app.detach instead of closing the whole session.
- Scoped app signal watches to { appSessionId, clientId }.
- Removed Chat’s hourly signal watch renewal workaround.
- Cleaned app-owned signal watches when clients detach or sessions close.
- Added stale app watch pruning during Kernel signal dispatch.
- Updated Chat process live-update watches to use app session/client ownership.
- Updated syscall and storage docs for app sessions, app clients, launch URLs, and signal watch ownership.
- Added tests for app session/client split, client detach, app close cleanup, and app-owned signal watch scoping.