### PR TITLE
fix compaction for workers ai reasoning models

### DIFF
--- a/gateway/src/inference/service.test.ts
+++ b/gateway/src/inference/service.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { resolveGenerationOptions, resolveGenerationTimeoutMs } from "./service";
+import { extractGeneratedText, resolveGenerationOptions, resolveGenerationTimeoutMs } from "./service";
 import type { AiConfigResult } from "../syscalls/ai";
-import type { Context } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
+
+function assistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: "test",
+    provider: "test",
+    model: "test-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
 
 const CONFIG: AiConfigResult = {
   provider: "anthropic",
@@ -41,6 +61,32 @@ describe("resolveGenerationOptions", () => {
 
     expect(result.reasoning).toBeUndefined();
     expect(result.maxTokens).toBe(768);
+  });
+});
+
+describe("extractGeneratedText", () => {
+  it("returns the joined text blocks when present", () => {
+    const message = assistantMessage([
+      { type: "thinking", thinking: "weighing options" },
+      { type: "text", text: "Hello " },
+      { type: "text", text: "world" },
+    ]);
+
+    expect(extractGeneratedText(message)).toBe("Hello world");
+  });
+
+  it("falls back to reasoning when a reasoning model emits no text block", () => {
+    const message = assistantMessage([
+      { type: "thinking", thinking: "  Summary of the conversation.  " },
+    ]);
+    message.stopReason = "error";
+    message.errorMessage = "Workers AI returned an empty response";
+
+    expect(extractGeneratedText(message)).toBe("Summary of the conversation.");
+  });
+
+  it("returns empty string when there is neither text nor reasoning", () => {
+    expect(extractGeneratedText(assistantMessage([]))).toBe("");
   });
 });
 

--- a/gateway/src/inference/service.ts
+++ b/gateway/src/inference/service.ts
@@ -3,6 +3,8 @@ import type {
   AssistantMessageEventStream,
   Context,
   KnownProvider,
+  TextContent,
+  ThinkingContent,
   ThinkingLevel,
 } from "@earendil-works/pi-ai";
 import { completeSimple, getModels, getProviders, streamSimple } from "@earendil-works/pi-ai";
@@ -114,17 +116,39 @@ export function createGenerationService(): GenerationService {
     stream,
     async generateText(request: GenerateRequest): Promise<string> {
       const response = await generate(request);
-      const text = response.content
-        .filter((block): block is { type: "text"; text: string } => block.type === "text")
-        .map((block) => block.text)
-        .join("")
-        .trim();
-      if (!text) {
-        throw new Error(`Generation for ${request.purpose} returned no text`);
+      const text = extractGeneratedText(response);
+      if (text) {
+        return text;
       }
-      return text;
+      throw new Error(`Generation for ${request.purpose} returned no text`);
     },
   };
+}
+
+/**
+ * Extract usable text from a generation for non-conversational purposes such as
+ * compaction summaries and thread titles.
+ *
+ * Reasoning models (notably Workers AI ones such as kimi-k2.6) sometimes emit
+ * their answer in a reasoning/thinking channel and produce no separate text
+ * block when thinking is disabled. Falling back to that reasoning text keeps the
+ * run alive instead of hard-failing with "returned no text".
+ */
+export function extractGeneratedText(response: AssistantMessage): string {
+  const text = response.content
+    .filter((block): block is TextContent => block.type === "text")
+    .map((block) => block.text)
+    .join("")
+    .trim();
+  if (text) {
+    return text;
+  }
+
+  return response.content
+    .filter((block): block is ThinkingContent => block.type === "thinking")
+    .map((block) => block.thinking)
+    .join("")
+    .trim();
 }
 
 export function resolveGenerationOptions(


### PR DESCRIPTION
Reasoning models such as Workers AI kimi-k2.6 return their answer in the reasoning/thinking channel and emit no separate text block when thinking is disabled (as it is for compaction summaries and thread titles). The old generateText filtered for text only and threw "returned no text", breaking compaction for those models. Fall back to the reasoning text via a tested extractGeneratedText helper when no text block is present.