### PR TITLE
Design system: page templates + Templates tab

### DIFF
--- a/web/src/app/components/ui/ObjectCard.css
+++ b/web/src/app/components/ui/ObjectCard.css
@@ -1,0 +1,6 @@
+/* ObjectCard — hover state ported from ObjectCard.dc.html <helmet><style>. */
+.gsv-objcard:hover {
+  border-color: #9a94ff !important;
+  box-shadow: 0 0 18px rgba(150, 140, 255, 0.3), 0 12px 30px rgba(0, 0, 0, 0.55) !important;
+  background: linear-gradient(180deg, var(--hover), var(--panel)) !important;
+}

--- a/web/src/app/components/ui/ObjectCard.tsx
+++ b/web/src/app/components/ui/ObjectCard.tsx
@@ -1,0 +1,101 @@
+import type { ComponentChildren } from "preact";
+import type { JSX } from "preact";
+import { Icon } from "./Icon";
+import "./ObjectCard.css";
+
+export type ObjectCardGlyph = "machines" | "messengers" | "integrations" | "applications";
+export type ObjectCardStatus = "online" | "error" | "idle" | "warn" | "live";
+
+export interface ObjectCardProps {
+  /** Object name (the source calls this `label`, NOT `name`). */
+  label?: string;
+  type?: string;
+  blurb?: string;
+  glyph?: ObjectCardGlyph;
+  /** Pre-built icon node; falls back to an Icon for `glyph`. */
+  icon?: ComponentChildren;
+  status?: ObjectCardStatus;
+  width?: number;
+  onClick?: () => void;
+}
+
+const STATUS_VAR: Record<ObjectCardStatus, string> = {
+  online: "var(--online)",
+  error: "var(--error)",
+  idle: "var(--idle)",
+  warn: "var(--warn)",
+  live: "var(--live)",
+};
+
+// glyph key → Icon name (fallback when no `icon` node is passed).
+const GLYPH_ICON: Record<ObjectCardGlyph, string> = {
+  machines: "computer",
+  messengers: "chat",
+  integrations: "weblink",
+  applications: "stars",
+};
+
+/** ObjectCard — ported from ObjectCard.dc.html. Object dialog card: header
+ *  (icon + name + status dot), a type micro-label and a blurb. */
+export function ObjectCard({
+  label = "<HANK-LINUX>",
+  type = "COMPUTE HOST",
+  blurb = "Primary Linux box. Runs heavy jobs and background tasks for the crew.",
+  glyph = "machines",
+  icon,
+  status = "online",
+  width = 238,
+  onClick,
+}: ObjectCardProps) {
+  const dc = STATUS_VAR[status] ?? STATUS_VAR.online;
+  const hasIcon = icon !== undefined && icon !== null && icon !== "";
+  const iconEl = hasIcon ? icon : <Icon name={GLYPH_ICON[glyph] ?? GLYPH_ICON.machines} size={20} color="var(--accent-bright)" />;
+
+  const dotStyle: JSX.CSSProperties = {
+    width: "7px",
+    height: "7px",
+    borderRadius: "50%",
+    flex: "none",
+    background: dc,
+    ...(status === "idle" ? {} : { boxShadow: `0 0 7px ${dc}` }),
+  };
+
+  return (
+    <div
+      onClick={onClick}
+      class="gsv-objcard"
+      style={{
+        width: `${width}px`,
+        position: "relative",
+        background: "linear-gradient(180deg,#100e2a,var(--node-bg))",
+        border: "1px solid var(--border)",
+        overflow: "hidden",
+        boxShadow: "0 12px 30px rgba(0,0,0,.55)",
+        cursor: "pointer",
+        transition: "border-color .15s,box-shadow .15s,background .15s",
+        fontFamily: "var(--gsv-font-mono)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "9px",
+          padding: "10px 13px",
+          background: "var(--header-bar)",
+          borderBottom: "1px solid var(--border)",
+        }}
+      >
+        <span style={{ display: "flex", flex: "none", color: "var(--accent-bright)" }}>{iconEl}</span>
+        <span style={{ fontSize: "11px", letterSpacing: ".1em", color: "var(--accent-bright)", fontWeight: 500, flex: 1, minWidth: 0 }}>
+          {label}
+        </span>
+        <span style={dotStyle} />
+      </div>
+      <div style={{ padding: "12px 13px" }}>
+        <div style={{ fontSize: "8px", letterSpacing: ".22em", color: "var(--text-dim)", marginBottom: "8px" }}>{type}</div>
+        <div style={{ fontSize: "10px", lineHeight: 1.55, color: "#9089d4", textWrap: "pretty" }}>{blurb}</div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/components/ui/Tile.css
+++ b/web/src/app/components/ui/Tile.css
@@ -1,0 +1,13 @@
+/* Tile — hover states ported from Tile.dc.html <helmet><style>.
+   .tl is the object tile; .ga is the anchor (GSV) circle. */
+.gsv-tile:hover {
+  border-color: #a9a4ff !important;
+  transform: translateY(-2px);
+}
+
+.gsv-tile-anchor:hover {
+  transform: scale(1.07);
+  border-color: var(--accent-bright) !important;
+  background: rgba(150, 140, 255, 0.12) !important;
+  box-shadow: 0 0 40px rgba(150, 140, 255, 0.6) !important;
+}

--- a/web/src/app/components/ui/Tile.tsx
+++ b/web/src/app/components/ui/Tile.tsx
@@ -1,0 +1,147 @@
+import type { JSX } from "preact";
+import { Icon } from "./Icon";
+import "./Tile.css";
+
+export type TileGlyph = "machines" | "messengers" | "integrations" | "applications";
+export type TileStatus = "online" | "error" | "idle" | "warn" | "live" | "update";
+
+export interface TileProps {
+  label?: string;
+  glyph?: TileGlyph;
+  status?: TileStatus;
+  selected?: boolean;
+  anchor?: boolean;
+  onClick?: () => void;
+}
+
+// status tone → token (verbatim from Tile.dc.html)
+const STATUS_VAR: Record<TileStatus, string> = {
+  online: "var(--online)",
+  error: "var(--error)",
+  idle: "var(--idle)",
+  warn: "var(--warn)",
+  live: "var(--live)",
+  update: "var(--update)",
+};
+
+// glyph key → Icon name (the source drew a dot glyph per key; we use the
+// shared Icon set for the same object categories).
+const GLYPH_ICON: Record<TileGlyph, string> = {
+  machines: "computer",
+  messengers: "chat",
+  integrations: "weblink",
+  applications: "stars",
+};
+
+/** Tile — ported from Tile.dc.html. 96px object tile with a glyph icon and a
+ *  corner status dot, plus an "anchor" (GSV) circular variant. */
+export function Tile({
+  label,
+  glyph = "machines",
+  status = "online",
+  selected = false,
+  anchor = false,
+  onClick,
+}: TileProps) {
+  const dc = STATUS_VAR[status] ?? STATUS_VAR.online;
+  const labelText = label ?? (anchor ? "GSV" : "MACHINES");
+  const labelColor = anchor ? "var(--text-hi)" : selected ? "var(--text-hi)" : "#cdd2e0";
+
+  const wrapperStyle: JSX.CSSProperties = {
+    display: "inline-flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "11px",
+    fontFamily: "var(--gsv-font-mono)",
+  };
+
+  const dotStyle: JSX.CSSProperties = {
+    position: "absolute",
+    top: "8px",
+    right: "8px",
+    width: "8px",
+    height: "8px",
+    borderRadius: "50%",
+    background: dc,
+    ...(status === "idle" ? {} : { boxShadow: `0 0 7px ${dc}` }),
+  };
+
+  if (anchor) {
+    return (
+      <div style={wrapperStyle}>
+        <div
+          onClick={onClick}
+          class="gsv-tile-anchor"
+          style={{
+            position: "relative",
+            width: "92px",
+            height: "92px",
+            borderRadius: "50%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "var(--node-bg)",
+            border: "1.4px solid var(--accent-bright)",
+            boxShadow: "0 0 16px rgba(150,140,255,.45)",
+            cursor: "pointer",
+            transition: "transform .2s,background .2s,border-color .2s,box-shadow .2s",
+          }}
+        >
+          <span style={{ position: "absolute", top: "-7px", left: "50%", width: "1.5px", height: "8px", background: "#e4e8f2", transform: "translateX(-50%)" }} />
+          <span style={{ position: "absolute", bottom: "-7px", left: "50%", width: "1.5px", height: "8px", background: "#e4e8f2", transform: "translateX(-50%)" }} />
+          <span style={{ position: "absolute", left: "-7px", top: "50%", height: "1.5px", width: "8px", background: "#e4e8f2", transform: "translateY(-50%)" }} />
+          <span style={{ position: "absolute", right: "-7px", top: "50%", height: "1.5px", width: "8px", background: "#e4e8f2", transform: "translateY(-50%)" }} />
+          <svg width="42" height="42" viewBox="0 0 16 16">
+            <g fill="var(--text-hi)" shape-rendering="crispEdges">
+              <rect x="7" y="1" width="2" height="2" />
+              <rect x="6" y="3" width="4" height="6" />
+              <rect x="4" y="6" width="2" height="3" />
+              <rect x="10" y="6" width="2" height="3" />
+              <rect x="7" y="11" width="2" height="3" fill="#a9a4ff" />
+            </g>
+          </svg>
+        </div>
+        <span style={{ fontSize: "11px", letterSpacing: ".16em", color: labelColor }}>{labelText}</span>
+      </div>
+    );
+  }
+
+  const iconColor = selected ? "var(--text-hi)" : "var(--node-label)";
+  const tileSkin: JSX.CSSProperties = selected
+    ? {
+        background: "rgba(150,140,255,.15)",
+        border: "1px solid var(--accent-bright)",
+        boxShadow: "0 0 24px rgba(150,140,255,.45)",
+      }
+    : {
+        background: "var(--panel)",
+        border: "1px solid var(--border)",
+        boxShadow: "0 6px 18px rgba(0,0,0,.45)",
+      };
+
+  return (
+    <div style={wrapperStyle}>
+      <div
+        onClick={onClick}
+        class="gsv-tile"
+        style={{
+          position: "relative",
+          width: "96px",
+          height: "96px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          cursor: "pointer",
+          transition: "transform .2s,background .2s,border-color .2s,box-shadow .2s",
+          ...tileSkin,
+        }}
+      >
+        <span style={dotStyle} />
+        <span style={{ display: "flex", color: iconColor }}>
+          <Icon name={GLYPH_ICON[glyph] ?? GLYPH_ICON.machines} size={30} />
+        </span>
+      </div>
+      <span style={{ fontSize: "11px", letterSpacing: ".16em", color: labelColor }}>{labelText}</span>
+    </div>
+  );
+}

--- a/web/src/design-system/catalog.css
+++ b/web/src/design-system/catalog.css
@@ -43,6 +43,37 @@
   color: var(--text-hi);
   text-transform: uppercase;
 }
+
+.ds-tabs {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0;
+  border: 1px solid var(--border);
+}
+.ds-tab {
+  font-family: var(--gsv-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  padding: 8px 18px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.ds-tab:last-child {
+  border-right: none;
+}
+.ds-tab:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+.ds-tab.is-active {
+  background: var(--selected);
+  color: var(--accent-bright);
+}
 .ds-topbar .ds-sub {
   font-size: 10px;
   letter-spacing: 0.18em;
@@ -157,6 +188,17 @@
 }
 .ds-story-body {
   padding: 24px 18px;
+}
+
+/* Page-template viewport — frames a full screen inside the catalog so the long
+   page can be reviewed without blowing up overall page height. */
+.ds-template-frame {
+  height: 720px;
+  overflow: auto;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--void);
 }
 
 /* Layout helpers for stories */

--- a/web/src/design-system/catalog.tsx
+++ b/web/src/design-system/catalog.tsx
@@ -27,9 +27,16 @@ import tooltip from "./stories/Tooltip.story";
 import listRow from "./stories/ListRow.story";
 import agentImage from "./stories/AgentImage.story";
 import avatar from "./stories/Avatar.story";
+import tile from "./stories/Tile.story";
+import objectCard from "./stories/ObjectCard.story";
 import iconButton from "./stories/IconButton.story";
 import sectionHeader from "./stories/SectionHeader.story";
 import addAction from "./stories/AddAction.story";
+import settingsDashboard from "./stories/SettingsDashboard.story";
+import crewPage from "./stories/CrewPage.story";
+import agentDetail from "./stories/AgentDetail.story";
+import settingsList from "./stories/SettingsList.story";
+import objectDetail from "./stories/ObjectDetail.story";
 import iconMenu from "./stories/IconMenu.story";
 import consoleHeader from "./stories/ConsoleHeader.story";
 import statusBar from "./stories/StatusBar.story";
@@ -65,6 +72,8 @@ const STORIES: Story[] = [
   tooltip,
   // Data Display
   listRow,
+  tile,
+  objectCard,
   agentImage,
   avatar,
   // Chrome
@@ -81,6 +90,12 @@ const STORIES: Story[] = [
   confirmModal,
   agentCard,
   agentEditor,
+  // Templates
+  settingsDashboard,
+  crewPage,
+  agentDetail,
+  settingsList,
+  objectDetail,
 ];
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -127,21 +142,51 @@ function useScrollSpy(slugs: string[]): string {
   return active;
 }
 
+type Tab = "components" | "templates";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "components", label: "Components" },
+  { id: "templates", label: "Templates" },
+];
+
 export function Catalog() {
+  const [tab, setTab] = useState<Tab>("components");
+
+  // Templates live in their own tab; everything else is the Components tab.
+  const tabStories = STORIES.filter((s) =>
+    tab === "templates" ? s.group === "Templates" : s.group !== "Templates",
+  );
+
   const byGroup = new Map<StoryGroup, Story[]>();
-  for (const story of STORIES) {
+  for (const story of tabStories) {
     const list = byGroup.get(story.group) ?? [];
     list.push(story);
     byGroup.set(story.group, list);
   }
   const groups = STORY_GROUP_ORDER.filter((g) => byGroup.has(g));
-  const active = useScrollSpy(STORIES.map((s) => slugify(s.title)));
+  const active = useScrollSpy(tabStories.map((s) => slugify(s.title)));
+
+  const selectTab = (id: Tab) => {
+    setTab(id);
+    window.scrollTo(0, 0);
+  };
 
   return (
     <div class="ds-root">
       <header class="ds-topbar">
         <h1>GSV Design System</h1>
         <span class="ds-sub">migration preview · web/ port</span>
+        <div class="ds-tabs">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              class={`ds-tab${tab === t.id ? " is-active" : ""}`}
+              onClick={() => selectTab(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
       </header>
       <div class="ds-layout">
         <nav class="ds-nav">

--- a/web/src/design-system/stories/AgentDetail.story.tsx
+++ b/web/src/design-system/stories/AgentDetail.story.tsx
@@ -1,0 +1,15 @@
+import { AgentDetail } from "../templates/AgentDetail";
+import type { Story } from "../story";
+
+const story: Story = {
+  title: "Detail page (agent)",
+  group: "Templates",
+  blurb: "canonical detail-page template · breadcrumb header + framed AgentEditor (General/Files/Tasks)",
+  render: () => (
+    <div class="ds-template-frame">
+      <AgentDetail />
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/design-system/stories/CrewPage.story.tsx
+++ b/web/src/design-system/stories/CrewPage.story.tsx
@@ -1,0 +1,15 @@
+import { CrewPage } from "../templates/CrewPage";
+import type { Story } from "../story";
+
+const story: Story = {
+  title: "Crew page",
+  group: "Templates",
+  blurb: "console crew roster · breadcrumb bar · responsive AgentCard grid + NEW AGENT tile",
+  render: () => (
+    <div class="ds-template-frame">
+      <CrewPage />
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/design-system/stories/ObjectCard.story.tsx
+++ b/web/src/design-system/stories/ObjectCard.story.tsx
@@ -1,0 +1,53 @@
+import { ObjectCard } from "../../app/components/ui/ObjectCard";
+import { Icon } from "../../app/components/ui/Icon";
+import type { Story } from "../story";
+
+const story: Story = {
+  title: "ObjectCard",
+  group: "Data Display",
+  blurb: "object dialog card · header icon + name + status · type · blurb",
+  render: () => (
+    <div class="ds-col">
+      <div class="ds-cell">
+        <div class="ds-label">Glyph fallback</div>
+        <div class="ds-row">
+          <ObjectCard
+            label="<HANK-LINUX>"
+            type="COMPUTE HOST"
+            glyph="machines"
+            status="online"
+            blurb="Primary Linux box. Runs heavy jobs and background tasks for the crew."
+          />
+          <ObjectCard
+            label="DISCORD"
+            type="MESSENGER"
+            glyph="messengers"
+            status="live"
+            blurb="Bridges crew chat into the GSV. Relays mentions and DMs."
+          />
+        </div>
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Status</div>
+        <div class="ds-row">
+          <ObjectCard label="<DELL-TOWER>" type="COMPUTE HOST" status="error" blurb="Lost contact 4m ago. Last heartbeat failed." />
+          <ObjectCard label="<RPI-EDGE>" type="EDGE NODE" status="idle" blurb="Powered down overnight. Wakes on schedule." />
+        </div>
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Pre-built icon node</div>
+        <div class="ds-row">
+          <ObjectCard
+            label="GMAIL"
+            type="INTEGRATION"
+            status="online"
+            icon={<Icon name="gmail" size={20} color="var(--accent-bright)" />}
+            blurb="Reads and sends mail on behalf of the crew. OAuth scope: send + read."
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/design-system/stories/ObjectDetail.story.tsx
+++ b/web/src/design-system/stories/ObjectDetail.story.tsx
@@ -1,0 +1,15 @@
+import { ObjectDetail } from "../templates/ObjectDetail";
+import type { Story } from "../story";
+
+const story: Story = {
+  title: "Object detail",
+  group: "Templates",
+  blurb: "console page · breadcrumb · object header · details + activity",
+  render: () => (
+    <div class="ds-template-frame">
+      <ObjectDetail />
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/design-system/stories/SettingsDashboard.story.tsx
+++ b/web/src/design-system/stories/SettingsDashboard.story.tsx
@@ -1,0 +1,15 @@
+import { SettingsDashboard } from "../templates/SettingsDashboard";
+import type { Story } from "../story";
+
+const story: Story = {
+  title: "Settings dashboard",
+  group: "Templates",
+  blurb: "The Ship · console page · object categories · status rows",
+  render: () => (
+    <div class="ds-template-frame">
+      <SettingsDashboard />
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/design-system/stories/SettingsList.story.tsx
+++ b/web/src/design-system/stories/SettingsList.story.tsx
@@ -1,0 +1,15 @@
+import { SettingsList } from "../templates/SettingsList";
+import type { Story } from "../story";
+
+const story: Story = {
+  title: "List page",
+  group: "Templates",
+  blurb: "single-category object list · MACHINES · console page",
+  render: () => (
+    <div class="ds-template-frame">
+      <SettingsList />
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/design-system/stories/Tile.story.tsx
+++ b/web/src/design-system/stories/Tile.story.tsx
@@ -1,0 +1,47 @@
+import { Tile } from "../../app/components/ui/Tile";
+import type { Story } from "../story";
+
+const story: Story = {
+  title: "Tile",
+  group: "Data Display",
+  blurb: "96px object tile · glyph · corner status dot · selected · anchor",
+  render: () => (
+    <div class="ds-col">
+      <div class="ds-cell">
+        <div class="ds-label">Glyphs</div>
+        <div class="ds-row">
+          <Tile label="MACHINES" glyph="machines" />
+          <Tile label="MESSENGERS" glyph="messengers" />
+          <Tile label="INTEGRATIONS" glyph="integrations" />
+          <Tile label="APPLICATIONS" glyph="applications" />
+        </div>
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Status</div>
+        <div class="ds-row">
+          <Tile label="ONLINE" status="online" />
+          <Tile label="ERROR" status="error" />
+          <Tile label="IDLE" status="idle" />
+          <Tile label="WARN" status="warn" />
+          <Tile label="LIVE" status="live" />
+          <Tile label="UPDATE" status="update" />
+        </div>
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Selected</div>
+        <div class="ds-row">
+          <Tile label="MACHINES" glyph="machines" selected />
+          <Tile label="INTEGRATIONS" glyph="integrations" selected status="live" />
+        </div>
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Anchor</div>
+        <div class="ds-row">
+          <Tile label="GSV" anchor />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/design-system/story.ts
+++ b/web/src/design-system/story.ts
@@ -22,7 +22,8 @@ export type StoryGroup =
   | "Feedback"
   | "Data Display"
   | "Chrome"
-  | "Composite";
+  | "Composite"
+  | "Templates";
 
 export const STORY_GROUP_ORDER: StoryGroup[] = [
   "Foundations",
@@ -31,4 +32,5 @@ export const STORY_GROUP_ORDER: StoryGroup[] = [
   "Data Display",
   "Chrome",
   "Composite",
+  "Templates",
 ];

--- a/web/src/design-system/templates/AgentDetail.tsx
+++ b/web/src/design-system/templates/AgentDetail.tsx
@@ -1,0 +1,48 @@
+import { AgentEditor } from "../../app/components/ui/AgentEditor";
+import { ConsoleHeader } from "../../app/components/ui/ConsoleHeader";
+
+/** AgentDetail — the canonical GSV detail-page template. A console page on
+ *  `var(--void)`: a breadcrumb ConsoleHeader (with its live pulsing dot + a
+ *  right-aligned ship tag) sits atop a glyph-grid background texture, and the
+ *  ported AgentEditor (manage mode, with its GENERAL / FILES / TASKS tabs and
+ *  form atoms) is composed verbatim inside a framed, softly glowing panel as
+ *  the page body. This is the reusable pattern for all other detail pages. */
+export function AgentDetail() {
+  return (
+    <div
+      style="position:relative;min-height:100%;background:var(--void);font-family:var(--gsv-font-mono);color:#cdd2e0;overflow:hidden;"
+    >
+      {/* glyph universe grid texture */}
+      <div style="position:absolute;inset:0;pointer-events:none;z-index:0;background-image:linear-gradient(rgba(150,140,255,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(150,140,255,.04) 1px,transparent 1px);background-size:46px 46px;" />
+      <div style="position:absolute;inset:0;pointer-events:none;z-index:0;font-family:var(--gsv-font-mono);">
+        <span style="position:absolute;left:18%;top:14%;font-size:13px;color:#b6b1ff;opacity:.16;">✦</span>
+        <span style="position:absolute;left:64%;top:9%;font-size:15px;color:#cdd5e6;opacity:.18;">∗</span>
+        <span style="position:absolute;left:83%;top:33%;font-size:11px;color:#b6b1ff;opacity:.16;">·</span>
+        <span style="position:absolute;left:43%;top:50%;font-size:10px;color:#cdd5e6;opacity:.2;">◦</span>
+        <span style="position:absolute;left:23%;top:74%;font-size:12px;color:#b6b1ff;opacity:.14;">✦</span>
+        <span style="position:absolute;left:72%;top:80%;font-size:13px;color:#cdd5e6;opacity:.16;">∗</span>
+        <span style="position:absolute;left:91%;top:64%;font-size:9px;color:#cdd5e6;opacity:.22;">◦</span>
+      </div>
+
+      {/* ===== breadcrumb console header: GSV › SETTINGS › CREW › Xanadu ===== */}
+      <div style="position:relative;z-index:2;">
+        <ConsoleHeader
+          crumbs={[
+            { label: "GSV", onClick: () => {} },
+            { label: "SETTINGS", onClick: () => {} },
+            { label: "CREW", onClick: () => {} },
+            { label: "Xanadu" },
+          ]}
+          tail="GSV · XANADU"
+        />
+      </div>
+
+      {/* ===== framed panel — the AgentEditor as the page body ===== */}
+      <div style="position:relative;z-index:2;padding:26px;">
+        <div style="border:1px solid var(--border);background:var(--void);box-shadow:0 0 0 1px #060414,0 0 26px rgba(150,140,255,.12);">
+          <AgentEditor mode="manage" containerWidth={1100} avatarSrc="img/agent-0.png" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/design-system/templates/CrewPage.tsx
+++ b/web/src/design-system/templates/CrewPage.tsx
@@ -1,0 +1,318 @@
+import { useLayoutEffect, useRef, useState } from "preact/hooks";
+import { AgentCard } from "../../app/components/ui/AgentCard";
+
+const MONO = "var(--gsv-font-mono)";
+
+export interface CrewPageProps {
+  /** Override the measured container width (drives the narrow < 720px layout). */
+  containerWidth?: number;
+  onNew?: () => void;
+  onManage?: (name: string) => void;
+  onBack?: () => void;
+}
+
+interface SeedAgent {
+  name: string;
+  role: string;
+  desc: string;
+  img: string;
+  modelDefault: boolean;
+  tasksTotal: number;
+  active: boolean;
+  running: boolean;
+}
+
+// Verbatim from the source DATA0.
+const DATA0: SeedAgent[] = [
+  {
+    name: "Xanadu",
+    role: "PERSONAL AGENT",
+    desc: "Default agent — first crew of GSV. Your right hand, here for whatever you need.",
+    img: "img/agent-0.png",
+    modelDefault: true,
+    tasksTotal: 23,
+    active: true,
+    running: true,
+  },
+  {
+    name: "Liger",
+    role: "RESEARCH AGENT",
+    desc: "Digs through the library and the web. Summarises, cross-references, keeps the index warm.",
+    img: "img/agent-1.png",
+    modelDefault: true,
+    tasksTotal: 0,
+    active: false,
+    running: false,
+  },
+  {
+    name: "Bob",
+    role: "OPS AGENT",
+    desc: "Watches the machines and runs the heavy jobs. Currently recovering from a crashed task.",
+    img: "img/agent-2.png",
+    modelDefault: false,
+    tasksTotal: 4,
+    active: false,
+    running: false,
+  },
+];
+
+/** CrewPage — ported from "Crew Page.dc.html". Console page on var(--void) with
+ *  a glyph-grid background texture, a back + breadcrumb top bar, and a panel
+ *  whose section-header bar caps a responsive grid of AgentCards closed by a
+ *  dashed NEW AGENT tile. Below 720px the layout collapses to a single column. */
+export function CrewPage({ containerWidth, onNew, onManage, onBack }: CrewPageProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [measured, setMeasured] = useState(0);
+
+  useLayoutEffect(() => {
+    if (containerWidth != null) return;
+    const el = rootRef.current;
+    if (!el) return;
+    const update = () => setMeasured(el.clientWidth);
+    update();
+    if (typeof ResizeObserver !== "undefined") {
+      const ro = new ResizeObserver(update);
+      ro.observe(el);
+      return () => ro.disconnect();
+    }
+    return undefined;
+  }, [containerWidth]);
+
+  const W = containerWidth != null ? containerWidth : measured || 1100;
+  const narrow = W < 720;
+
+  const goManage = (name: string) => onManage?.(name);
+  const goNew = () => onNew?.();
+  const goBack = () => onBack?.();
+
+  const crewCount = DATA0.length;
+  const runningCount = DATA0.filter((a) => a.running).length;
+
+  return (
+    <div
+      ref={rootRef}
+      style={{
+        position: "relative",
+        minHeight: "100%",
+        background: "var(--void)",
+        fontFamily: MONO,
+        color: "#cdd2e0",
+        padding: 0,
+        overflow: "hidden",
+      }}
+    >
+      {/* glyph universe texture */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          pointerEvents: "none",
+          zIndex: 0,
+          backgroundImage:
+            "linear-gradient(rgba(150,140,255,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(150,140,255,.04) 1px,transparent 1px)",
+          backgroundSize: "46px 46px",
+        }}
+      />
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none", zIndex: 0, fontFamily: MONO }}>
+        <span style={{ position: "absolute", left: "16%", top: "13%", fontSize: "13px", color: "#b6b1ff", opacity: 0.16 }}>
+          {"✦"}
+        </span>
+        <span style={{ position: "absolute", left: "62%", top: "8%", fontSize: "15px", color: "#cdd5e6", opacity: 0.18 }}>
+          {"∗"}
+        </span>
+        <span style={{ position: "absolute", left: "85%", top: "30%", fontSize: "11px", color: "#b6b1ff", opacity: 0.16 }}>
+          {"·"}
+        </span>
+        <span style={{ position: "absolute", left: "40%", top: "52%", fontSize: "10px", color: "#cdd5e6", opacity: 0.2 }}>
+          {"◦"}
+        </span>
+        <span style={{ position: "absolute", left: "22%", top: "78%", fontSize: "12px", color: "#b6b1ff", opacity: 0.14 }}>
+          {"✦"}
+        </span>
+        <span style={{ position: "absolute", left: "74%", top: "82%", fontSize: "13px", color: "#cdd5e6", opacity: 0.16 }}>
+          {"∗"}
+        </span>
+        <span style={{ position: "absolute", left: "92%", top: "66%", fontSize: "9px", color: "#cdd5e6", opacity: 0.22 }}>
+          {"◦"}
+        </span>
+      </div>
+
+      <div style={{ position: "relative", zIndex: 2 }}>
+        {/* top bar */}
+        <div
+          style={{
+            position: "relative",
+            zIndex: 2,
+            display: "flex",
+            alignItems: "center",
+            ...(narrow
+              ? { gap: "12px", padding: "16px 16px" }
+              : { gap: "18px", padding: "22px 30px" }),
+          }}
+        >
+          <span
+            onClick={goBack}
+            class="gsv-crew-back"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "38px",
+              height: "38px",
+              flex: "none",
+              cursor: "pointer",
+              color: "var(--accent)",
+              border: "1px solid var(--border)",
+              background: "var(--panel-2)",
+              transition: "background .12s",
+            }}
+          >
+            <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
+              <path d="M9.5 3.5 L5 8 L9.5 12.5" />
+              <path d="M5 8 H13" />
+            </svg>
+          </span>
+          <div style={{ display: "flex", alignItems: "center", gap: "10px", fontSize: "12.5px", letterSpacing: ".18em" }}>
+            <span class="gsv-crew-crumb" style={{ color: "var(--text-dim)", cursor: "pointer" }}>
+              GSV
+            </span>
+            <span style={{ color: "var(--rule-section)" }}>{"›"}</span>
+            <span class="gsv-crew-crumb" style={{ color: "var(--text-dim)", cursor: "pointer" }}>
+              SETTINGS
+            </span>
+            <span style={{ color: "var(--rule-section)" }}>{"›"}</span>
+            <span style={{ color: "var(--text-hi)", textShadow: "0 0 7px rgba(150,140,255,.45)" }}>CREW</span>
+          </div>
+        </div>
+
+        {/* panel */}
+        <div
+          style={{
+            position: "relative",
+            zIndex: 2,
+            borderTop: "1px solid var(--border)",
+            minHeight: narrow ? "480px" : "560px",
+          }}
+        >
+          {/* section header bar */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "11px",
+              padding: "14px 20px",
+              borderBottom: "1px solid var(--border)",
+              background: "var(--header-bar)",
+            }}
+          >
+            <span
+              style={{
+                width: "7px",
+                height: "7px",
+                flex: "none",
+                borderRadius: "1px",
+                background: "var(--accent)",
+                boxShadow: "0 0 8px var(--accent)",
+              }}
+            />
+            <span
+              style={{
+                fontWeight: 600,
+                fontSize: "13.5px",
+                letterSpacing: ".2em",
+                color: "var(--text-title)",
+                textShadow: "0 0 5px rgba(150,140,255,.3)",
+              }}
+            >
+              CREW
+            </span>
+            <span style={{ marginLeft: "auto", fontSize: "10px", letterSpacing: ".16em", color: "#7d78b8" }}>
+              {crewCount} AGENTS {"·"} {runningCount} RUNNING
+            </span>
+          </div>
+
+          {/* agent card grid */}
+          <div
+            style={
+              narrow
+                ? { padding: "16px", display: "grid", gridTemplateColumns: "1fr", gap: "16px", alignItems: "start" }
+                : {
+                    padding: "26px",
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fill,minmax(312px,1fr))",
+                    gap: "22px",
+                    alignItems: "start",
+                  }
+            }
+          >
+            {DATA0.map((a) => (
+              <div key={a.name} style={{ border: "1px solid var(--border)", boxShadow: "0 0 22px rgba(60,52,150,.12)" }}>
+                <AgentCard
+                  agentName={a.name}
+                  agentRole={a.role}
+                  description={a.desc}
+                  imgSrc={a.img}
+                  modelIsDefault={a.modelDefault}
+                  tasksTotal={a.tasksTotal}
+                  active={true}
+                  showActions={false}
+                  onManage={() => goManage(a.name)}
+                />
+              </div>
+            ))}
+
+            {/* NEW AGENT tile */}
+            <div
+              onClick={goNew}
+              class="gsv-crew-newtile"
+              style={{
+                minHeight: "430px",
+                border: "1px dashed var(--border-raised)",
+                background: "var(--panel)",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "18px",
+                cursor: "pointer",
+                transition: "background .15s,border-color .15s",
+              }}
+            >
+              <div
+                style={{
+                  width: "54px",
+                  height: "54px",
+                  border: "1px dashed var(--dashed)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "var(--accent)",
+                }}
+              >
+                <svg width="26" height="26" viewBox="0 0 16 16" shape-rendering="crispEdges">
+                  <g fill="currentColor">
+                    <rect x="7" y="2" width="2" height="12" />
+                    <rect x="2" y="7" width="12" height="2" />
+                  </g>
+                </svg>
+              </div>
+              <div style={{ fontSize: "11px", letterSpacing: ".2em", color: "var(--text-title)" }}>NEW AGENT</div>
+              <div
+                style={{
+                  fontSize: "9.5px",
+                  letterSpacing: ".1em",
+                  color: "#7d78b8",
+                  maxWidth: "200px",
+                  textAlign: "center",
+                  lineHeight: 1.5,
+                }}
+              >
+                Spin up a new crew member with its own persona &amp; files
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/design-system/templates/ObjectDetail.tsx
+++ b/web/src/design-system/templates/ObjectDetail.tsx
@@ -1,0 +1,127 @@
+import type { JSX } from "preact";
+import { ConsoleHeader } from "../../app/components/ui/ConsoleHeader";
+import { SectionHeader } from "../../app/components/ui/SectionHeader";
+import { ListRow } from "../../app/components/ui/ListRow";
+import { Icon } from "../../app/components/ui/Icon";
+import { StatusDot } from "../../app/components/ui/StatusDot";
+
+/**
+ * ObjectDetail — console page template showing a single object (the Gmail
+ * integration). Composes the ported atoms: ConsoleHeader breadcrumb, an
+ * ObjectCard-style detail header (icon + name + status), a type micro-label, a
+ * prose blurb, and SectionHeader + ListRow sections.
+ *
+ * Backdrop is `var(--void)` with the periwinkle glyph-grid texture (verbatim
+ * from GSV Live.dc.html).
+ */
+export function ObjectDetail() {
+  const pageStyle: JSX.CSSProperties = {
+    position: "relative",
+    minHeight: "100%",
+    background: "radial-gradient(1100px 720px at 50% -4%,rgba(150,140,255,.07),transparent 58%),var(--void)",
+    fontFamily: "var(--gsv-font-mono)",
+    color: "var(--text)",
+  };
+
+  const gridStyle: JSX.CSSProperties = {
+    position: "absolute",
+    inset: 0,
+    pointerEvents: "none",
+    backgroundImage:
+      "linear-gradient(rgba(150,140,255,.035) 1px,transparent 1px),linear-gradient(90deg,rgba(150,140,255,.035) 1px,transparent 1px)",
+    backgroundSize: "46px 46px",
+  };
+
+  return (
+    <div style={pageStyle}>
+      <div style={gridStyle} />
+
+      <div style={{ position: "relative" }}>
+        <ConsoleHeader
+          crumbs={[{ label: "GSV" }, { label: "INTEGRATIONS" }, { label: "Gmail" }]}
+          tail="GSV · INTEGRATIONS"
+        />
+
+        <div style={{ maxWidth: "760px", margin: "0 auto", padding: "30px 26px 48px" }}>
+          {/* Detail header — icon + name + status dot */}
+          <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+            <span
+              style={{
+                display: "flex",
+                flex: "none",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "52px",
+                height: "52px",
+                background: "linear-gradient(180deg,#100e2a,var(--node-bg))",
+                border: "1px solid var(--border)",
+                color: "var(--accent-bright)",
+                boxShadow: "0 6px 18px rgba(0,0,0,.45)",
+              }}
+            >
+              <Icon name="gmail" size={26} color="var(--accent-bright)" />
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+                <span
+                  style={{
+                    fontSize: "20px",
+                    letterSpacing: ".08em",
+                    fontWeight: 500,
+                    color: "var(--text-hi)",
+                    textShadow: "0 0 6px rgba(150,140,255,.4)",
+                  }}
+                >
+                  Gmail
+                </span>
+                <StatusDot tone="online" size={8} />
+                <span style={{ fontSize: "9px", letterSpacing: ".14em", color: "var(--online)" }}>ONLINE</span>
+              </div>
+              <div style={{ fontSize: "8px", letterSpacing: ".22em", color: "var(--text-dim)", marginTop: "8px" }}>
+                INTEGRATION · MESSENGER
+              </div>
+            </div>
+          </div>
+
+          {/* Prose blurb */}
+          <p
+            style={{
+              fontFamily: "var(--gsv-font-prose)",
+              fontSize: "14px",
+              lineHeight: 1.65,
+              color: "#9089d4",
+              margin: "20px 0 32px",
+              textWrap: "pretty",
+            }}
+          >
+            Reads and sends mail on behalf of the crew. The GSV uses this integration to triage the
+            inbox, draft replies, and surface anything that needs a human. OAuth is scoped to send and
+            read; the token refreshes silently and is revocable from this page.
+          </p>
+
+          {/* DETAILS section */}
+          <div style={{ marginBottom: "26px" }}>
+            <SectionHeader title="DETAILS" meta="OAUTH · v3" divider />
+            <div style={{ border: "1px solid var(--border)", borderTop: "none" }}>
+              <ListRow label="Account" status="none" sub="crew@gsv.example.com" />
+              <ListRow label="Scopes" status="none" sub="gmail.send · gmail.readonly" />
+              <ListRow label="Token" status="online" statusLabel="VALID" sub="Refreshed 12m ago" />
+              <ListRow label="Connected" status="none" sub="2026-04-02 · 81 days ago" />
+            </div>
+          </div>
+
+          {/* RECENT ACTIVITY section */}
+          <div>
+            <SectionHeader title="RECENT ACTIVITY" meta="LAST 24H" divider />
+            <div style={{ border: "1px solid var(--border)", borderTop: "none" }}>
+              <ListRow label="Sent reply to <re: Q2 budget>" status="online" statusLabel="OK" chevron />
+              <ListRow label="Drafted 3 replies for review" status="online" statusLabel="OK" chevron />
+              <ListRow label="Token refresh" status="online" statusLabel="OK" />
+              <ListRow label="Rate limit hit · backed off" status="error" statusLabel="WARN" chevron />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/design-system/templates/SettingsDashboard.tsx
+++ b/web/src/design-system/templates/SettingsDashboard.tsx
@@ -1,0 +1,249 @@
+import { ConsoleHeader } from "../../app/components/ui/ConsoleHeader";
+import { SectionHeader } from "../../app/components/ui/SectionHeader";
+import { StatusDot } from "../../app/components/ui/StatusDot";
+import type { StatusTone } from "../../app/components/ui/StatusDot";
+import { Tag } from "../../app/components/ui/Tag";
+import type { TagTone } from "../../app/components/ui/Tag";
+import { Icon } from "../../app/components/ui/Icon";
+
+/* ---------------------------------------------------------------------------
+ * Seed data — transcribed from the GSV Live PAGE_DEFS object and the
+ * settings-pa-full.png reference. Each category becomes a SectionHeader bar
+ * followed by ListRows. No backend; this is a static, self-contained page.
+ * ------------------------------------------------------------------------- */
+
+interface Item {
+  /** Dot-matrix icon name (file in web/public/icons/, no extension). */
+  icon: string;
+  label: string;
+  /** Status tone used for the StatusDot. */
+  tone: StatusTone;
+  /** Short status word (ONLINE / IDLE / SYNCED / RUNNING / …); omit to use a tag. */
+  statusLabel?: string;
+  /** Optional boxed tag (e.g. UPDATE / DEFAULT) shown before the status. */
+  tag?: { label: string; tone: TagTone };
+}
+
+interface Category {
+  title: string;
+  /** Count shown after the title, e.g. "2". */
+  count: number;
+  /** Small sub-meta word under the count, e.g. HOSTS / CHANNELS / LINKED. */
+  noun: string;
+  items: Item[];
+}
+
+const CATEGORIES: Category[] = [
+  {
+    title: "MACHINES",
+    count: 2,
+    noun: "HOSTS",
+    items: [
+      { icon: "computer", label: "<HANK-LINUX>", tone: "online", statusLabel: "ONLINE" },
+      { icon: "computer", label: "<KAWAH-OILMACHINE>", tone: "idle", statusLabel: "IDLE" },
+    ],
+  },
+  {
+    title: "MESSENGERS",
+    count: 2,
+    noun: "CHANNELS",
+    items: [
+      { icon: "telegram", label: "Telegram", tone: "online", statusLabel: "ONLINE" },
+      { icon: "discord", label: "Discord", tone: "online", statusLabel: "ONLINE" },
+    ],
+  },
+  {
+    title: "INTEGRATIONS",
+    count: 2,
+    noun: "LINKED",
+    items: [
+      { icon: "gmail", label: "Gmail", tone: "online", statusLabel: "SYNCED" },
+      { icon: "list", label: "Linear", tone: "online", statusLabel: "SYNCED" },
+    ],
+  },
+  {
+    title: "APPLICATIONS",
+    count: 2,
+    noun: "APPS",
+    items: [
+      {
+        icon: "weblink",
+        label: "<CONTACT-LIST>",
+        tone: "online",
+        statusLabel: "HAM-INC",
+        tag: { label: "UPDATE", tone: "update" },
+      },
+      { icon: "stars", label: "<SPACE-SIMULATION>", tone: "online", statusLabel: "ESTEVO" },
+    ],
+  },
+  {
+    title: "CREW",
+    count: 3,
+    noun: "AGENTS",
+    items: [
+      { icon: "chat", label: "XANADU", tone: "online", statusLabel: "ONLINE" },
+      { icon: "chat", label: "LIGER", tone: "online", statusLabel: "ONLINE" },
+      { icon: "chat", label: "BOB", tone: "idle", statusLabel: "IDLE" },
+    ],
+  },
+  {
+    title: "MODELS",
+    count: 4,
+    noun: "1 DEFAULT",
+    items: [
+      {
+        icon: "cog",
+        label: "Nemotron 3",
+        tone: "online",
+        statusLabel: "DEFAULT",
+        tag: { label: "DEFAULT", tone: "accent" },
+      },
+      { icon: "cog", label: "Nemotron 2", tone: "idle", statusLabel: "LEGACY" },
+      { icon: "cog", label: "Model 2", tone: "online", statusLabel: "READY" },
+      { icon: "cog", label: "Model 3", tone: "online", statusLabel: "READY" },
+    ],
+  },
+  {
+    title: "TASKS",
+    count: 35,
+    noun: "23 RUNNING",
+    items: [
+      { icon: "list", label: "Polishing silverware", tone: "online", statusLabel: "RUNNING" },
+      { icon: "list", label: "Indexing the library", tone: "online", statusLabel: "RUNNING" },
+      { icon: "list", label: "Instagram events of the week", tone: "error", statusLabel: "ERROR" },
+      { icon: "list", label: "Email vet", tone: "idle", statusLabel: "DONE" },
+      { icon: "list", label: "Archiving old logs", tone: "idle", statusLabel: "IDLE" },
+    ],
+  },
+];
+
+/** Map a StatusDot tone to the ListRow status union (for the dot baked into
+ *  ListRow we instead render our own dot + word in the row's status slot). */
+const TONE_STATUS_TEXT: Record<StatusTone, string> = {
+  online: "var(--online)",
+  error: "var(--error)",
+  idle: "#9a95cf",
+  update: "var(--update)",
+  live: "var(--live)",
+  warn: "var(--warn)",
+};
+
+/** A single category: the SectionHeader bar (square dot + title + count meta +
+ *  chevron) followed by its ListRows. */
+function CategorySection({ cat }: { cat: Category }) {
+  return (
+    <div>
+      {/* SectionHeader bar with a right-aligned chevron overlaid via a flex wrapper. */}
+      <div style={{ position: "relative" }}>
+        <SectionHeader title={cat.title} meta={`· ${cat.count}`} divider />
+        <span
+          style={{
+            position: "absolute",
+            right: "20px",
+            top: "0",
+            bottom: "0",
+            display: "inline-flex",
+            alignItems: "center",
+            pointerEvents: "none",
+          }}
+        >
+          <svg width="9" height="12" viewBox="0 0 9 12" style={{ filter: "drop-shadow(0 0 3px rgba(150,140,255,.5))" }}>
+            <path d="M0 0 L9 6 L0 12 Z" fill="var(--accent)" />
+          </svg>
+        </span>
+        {/* Small sub-meta word (HOSTS / CHANNELS / LINKED …), under the count. */}
+        <span
+          style={{
+            position: "absolute",
+            right: "44px",
+            top: "50%",
+            transform: "translateY(6px)",
+            fontFamily: "var(--gsv-font-mono)",
+            fontSize: "9px",
+            letterSpacing: ".16em",
+            color: "var(--text-dim)",
+            pointerEvents: "none",
+          }}
+        >
+          {cat.noun}
+        </span>
+      </div>
+
+      {cat.items.map((it, i) => (
+        <div
+          key={i}
+          class="ds-settings-row"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "14px",
+            padding: "15px 20px",
+            borderBottom: "1px solid var(--border)",
+            cursor: "pointer",
+            transition: "background .12s",
+            fontFamily: "var(--gsv-font-mono)",
+          }}
+        >
+          <span style={{ display: "flex", flex: "none", color: "var(--accent-bright)" }}>
+            <Icon name={it.icon} size={18} />
+          </span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: "12.5px", letterSpacing: ".04em", color: "var(--text)" }}>{it.label}</div>
+          </div>
+          {it.tag ? <Tag tone={it.tag.tone} label={it.tag.label} boxed /> : null}
+          {it.statusLabel ? (
+            <span
+              style={{
+                flex: "none",
+                fontSize: "9px",
+                letterSpacing: ".12em",
+                color: TONE_STATUS_TEXT[it.tone],
+              }}
+            >
+              {it.statusLabel}
+            </span>
+          ) : null}
+          <StatusDot tone={it.tone} size={8} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** SettingsDashboard — the GSV "Settings Dashboard" ("The Ship") page. A console
+ *  page on var(--void): a breadcrumb ConsoleHeader, then one raised panel holding
+ *  every object category (MACHINES, MESSENGERS, INTEGRATIONS, APPLICATIONS, CREW,
+ *  MODELS, TASKS) as a SectionHeader bar + ListRow-style rows. */
+export function SettingsDashboard() {
+  return (
+    <div
+      style={{
+        minHeight: "100%",
+        background: "var(--void)",
+        fontFamily: "var(--gsv-font-mono)",
+        color: "#cdd2e0",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <ConsoleHeader
+        crumbs={[{ label: "GSV", onClick: () => {} }, { label: "CONTROL" }]}
+        tail="GSV // CONTROL"
+      />
+
+      <div style={{ flex: 1, padding: "20px" }}>
+        <div
+          style={{
+            border: "1px solid var(--border-raised)",
+            background: "var(--panel)",
+            boxShadow: "inset 0 0 0 1px #060414, 0 0 30px rgba(80,70,180,.1)",
+          }}
+        >
+          {CATEGORIES.map((cat) => (
+            <CategorySection key={cat.title} cat={cat} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/design-system/templates/SettingsList.tsx
+++ b/web/src/design-system/templates/SettingsList.tsx
@@ -1,0 +1,152 @@
+import type { JSX } from "preact";
+import { ConsoleHeader } from "../../app/components/ui/ConsoleHeader";
+import { SectionHeader } from "../../app/components/ui/SectionHeader";
+import { ListRow } from "../../app/components/ui/ListRow";
+import type { ListRowStatus } from "../../app/components/ui/ListRow";
+import { StatusDot } from "../../app/components/ui/StatusDot";
+import type { StatusTone } from "../../app/components/ui/StatusDot";
+import { Tag } from "../../app/components/ui/Tag";
+import type { TagTone } from "../../app/components/ui/Tag";
+import { Icon } from "../../app/components/ui/Icon";
+import { AddAction } from "../../app/components/ui/AddAction";
+
+interface MachineRow {
+  name: string;
+  sub: string;
+  status: ListRowStatus;
+  statusLabel: string;
+  /** Right-aligned status dot tone. */
+  tone: StatusTone;
+  tag?: string;
+  tagTone?: TagTone;
+}
+
+// Self-contained seed data — modeled on PAGE_DEFS.machines in GSV Live.dc.html,
+// extended to ~6 realistic hosts for the list page.
+const MACHINES: MachineRow[] = [
+  {
+    name: "<HANK-LINUX>",
+    sub: "linux · x86_64 · last seen 2m ago",
+    status: "online",
+    statusLabel: "ONLINE",
+    tone: "online",
+  },
+  {
+    name: "<KAWAH-OILMACHINE>",
+    sub: "linux · aarch64 · last seen 41m ago",
+    status: "idle",
+    statusLabel: "IDLE",
+    tone: "idle",
+  },
+  {
+    name: "<LIGER-RENDER>",
+    sub: "linux · x86_64 · 64 cores · last seen 12s ago",
+    status: "online",
+    statusLabel: "ONLINE",
+    tone: "online",
+  },
+  {
+    name: "<BOB-MACMINI>",
+    sub: "darwin · arm64 · update available",
+    status: "online",
+    statusLabel: "ONLINE",
+    tone: "online",
+    tag: "UPDATE",
+    tagTone: "update",
+  },
+  {
+    name: "<ESTEVO-EDGE>",
+    sub: "linux · armv7 · last seen 3h ago",
+    status: "idle",
+    statusLabel: "IDLE",
+    tone: "idle",
+  },
+  {
+    name: "<XANADU-GPU>",
+    sub: "linux · x86_64 · connection lost",
+    status: "error",
+    statusLabel: "OFFLINE",
+    tone: "error",
+  },
+];
+
+const rootStyle: JSX.CSSProperties = {
+  minHeight: "100%",
+  background: "var(--void)",
+  fontFamily: "var(--gsv-font-mono)",
+};
+
+/** SettingsList — GSV "Settings List" page template. A single-category object
+ *  list (MACHINES) composed of already-ported console atoms: a breadcrumb
+ *  ConsoleHeader, a SectionHeader bar, a full-width list of ListRows (each with
+ *  a dot-matrix Icon, name, sub-label, a right-aligned Tag/StatusDot and a
+ *  trailing chevron), capped with an AddAction row. */
+export function SettingsList() {
+  return (
+    <div style={rootStyle}>
+      <ConsoleHeader
+        crumbs={[
+          { label: "GSV", notLast: true },
+          { label: "SETTINGS", notLast: true },
+          { label: "MACHINES" },
+        ]}
+        tail="GSV · CONTROL"
+      />
+
+      <SectionHeader title="MACHINES · 2 HOSTS" />
+
+      <div>
+        {MACHINES.map((m, i) => (
+          <div
+            key={i}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              borderBottom: "1px solid var(--border)",
+            }}
+          >
+            <span
+              style={{
+                display: "inline-flex",
+                flex: "none",
+                color: "var(--accent)",
+                paddingLeft: "20px",
+              }}
+            >
+              <Icon name="computer" size={18} title="machine" />
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <ListRow label={m.name} sub={m.sub} status="none" />
+            </div>
+            {m.tag ? (
+              <span style={{ flex: "none", paddingRight: "12px" }}>
+                <Tag tone={m.tagTone ?? "update"} label={m.tag} boxed />
+              </span>
+            ) : null}
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "9px",
+                flex: "none",
+                paddingRight: "20px",
+              }}
+            >
+              <span style={{ fontSize: "9px", letterSpacing: ".12em", color: "var(--text-dim)" }}>{m.statusLabel}</span>
+              <StatusDot tone={m.tone} size={8} />
+              <span style={{ display: "inline-flex", alignItems: "center" }}>
+                <svg width="9" height="12" viewBox="0 0 9 12" style={{ filter: "drop-shadow(0 0 3px rgba(150,140,255,.5))" }}>
+                  <path d="M0 0 L9 6 L0 12 Z" fill="var(--accent)" />
+                </svg>
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ padding: "16px 20px" }}>
+        <AddAction variant="row" label="CONNECT NEW MACHINE" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Continues the design-system migration (stacks on the merged composites work). Showcase-only — `/design.html`; the real app and built-in packages are untouched.

## What's new

**Page templates** (Control Panel; composed from the ported components), each in a resizable framed viewport:
- **Settings dashboard** ("The Ship") — object categories (Machines/Messengers/Integrations/Applications/Crew/Models/Tasks) as status rows.
- **Crew page** — ported from `Crew Page.dc.html`: breadcrumb + section header + responsive AgentCard grid + dashed NEW AGENT tile.
- **Detail page (agent)** — the canonical detail pattern (ConsoleHeader breadcrumb + AgentEditor's General/Files/Tasks).
- **List page** — single-category object list.
- **Object detail** — object header + details/activity sections.

**Two remaining atoms** ported: **Tile** (96px object tile + GSV anchor) and **ObjectCard**.

**Catalog** — split into **Components / Templates tabs**, each with its own left-nav index; switching tabs resets scroll.

## ⚠️ Known issues / follow-ups (being worked on in parallel)
- **The Settings dashboard/page is broken** and needs tweaks — tracked as a parallel follow-up, not addressed in this PR.
- Minor: `ListRow` has no icon slot, so dashboard/list rows compose `Icon + ListRow + cluster`; `AgentEditor`'s `min-height:100vh` makes the Detail frame ≥1 viewport tall; `CrewPage` hover classes have no CSS yet (no-ops).

## Verification
`tsc --noEmit` clean. Components tab: 36 stories; Templates tab: 5 framed templates with index.

## Not in this PR
AsciiPlanet → static art.
