### PR TITLE
Design system: essential accessibility pass across UI primitives

### DIFF
--- a/web/src/app/components/ui/AddAction.tsx
+++ b/web/src/app/components/ui/AddAction.tsx
@@ -10,7 +10,7 @@ export interface AddActionProps {
 }
 
 const PlusGlyph = () => (
-  <svg width="16" height="16" viewBox="0 0 16 16" shape-rendering="crispEdges">
+  <svg width="16" height="16" viewBox="0 0 16 16" shape-rendering="crispEdges" aria-hidden="true">
     <g fill="currentColor">
       <rect x="7" y="3" width="2" height="10" />
       <rect x="3" y="7" width="10" height="2" />
@@ -62,7 +62,7 @@ export function AddAction({ variant = "row", label, onClick }: AddActionProps) {
       </span>
       <span style={{ fontSize: "11px", letterSpacing: ".04em", color: "var(--text-title)" }}>{text}</span>
       <span style={{ marginLeft: "auto" }}>
-        <svg width="9" height="12" viewBox="0 0 9 12" style={{ display: "block", filter: "drop-shadow(0 0 3px rgba(150,140,255,.5))" }}>
+        <svg width="9" height="12" viewBox="0 0 9 12" aria-hidden="true" style={{ display: "block", filter: "drop-shadow(0 0 3px rgba(150,140,255,.5))" }}>
           <path d="M0 0 L9 6 L0 12 Z" fill="var(--accent)" />
         </svg>
       </span>

--- a/web/src/app/components/ui/Button.css
+++ b/web/src/app/components/ui/Button.css
@@ -178,3 +178,9 @@
 .gsv-btn.is-disabled {
   cursor: not-allowed;
 }
+
+/* — keyboard focus ring (visible only for keyboard navigation) — */
+.gsv-btn:not(.is-disabled):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/web/src/app/components/ui/Button.tsx
+++ b/web/src/app/components/ui/Button.tsx
@@ -7,6 +7,7 @@ export interface ButtonProps {
   label?: string;
   disabled?: boolean;
   block?: boolean;
+  type?: "button" | "submit";
   onClick?: () => void;
   /** Extra data-* attributes spread onto the root (e.g. focus markers). */
   dataAttrs?: Record<`data-${string}`, string | number | boolean>;
@@ -21,12 +22,12 @@ const VARIANT_CLASS: Record<ButtonVariant, string> = {
 };
 
 /** Button — ported from Button.dc.html. */
-export function Button({ variant = "primary", label = "BUTTON", disabled = false, block = false, onClick, dataAttrs }: ButtonProps) {
+export function Button({ variant = "primary", label = "BUTTON", disabled = false, block = false, type = "button", onClick, dataAttrs }: ButtonProps) {
   const cls = `gsv-btn ${VARIANT_CLASS[variant]}${block ? " gsv-btn-block" : ""}${disabled ? " is-disabled" : ""}`;
   return (
     <button
       {...dataAttrs}
-      type="button"
+      type={type}
       class={cls}
       disabled={disabled}
       onClick={disabled ? undefined : onClick}

--- a/web/src/app/components/ui/Checkbox.css
+++ b/web/src/app/components/ui/Checkbox.css
@@ -31,6 +31,8 @@
 .gsv-cb-input:focus-visible + .gsv-cb-box {
   border-color: #b3aeff;
   box-shadow: 0 0 0 1px rgba(150, 140, 255, 0.35);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .gsv-cb-fill {
   background: #cbc7ff;

--- a/web/src/app/components/ui/Checkbox.tsx
+++ b/web/src/app/components/ui/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useId, useRef, useState } from "preact/hooks";
 import "./Checkbox.css";
 
 export type CheckboxSize = "small" | "medium" | "large";
@@ -36,6 +36,9 @@ export function Checkbox(props: CheckboxProps) {
     onChange,
   } = props;
 
+  const fieldId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const [checkedState, setCheckedState] = useState<boolean | undefined>(undefined);
   const checked = checkedState === undefined ? !!props.checked : checkedState;
   const on = checked && !indeterminate;
@@ -43,6 +46,12 @@ export function Checkbox(props: CheckboxProps) {
   useEffect(() => {
     setCheckedState(undefined);
   }, [props.checked]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
 
   const rawStat = status && status !== "none" ? status : "";
   const statKey = rawStat === "warning" ? "warn" : rawStat;
@@ -62,7 +71,10 @@ export function Checkbox(props: CheckboxProps) {
       {description ? <div class="gsv-cb-desc">{description}</div> : null}
       <label class={rootClass}>
         <input
+          ref={inputRef}
           aria-checked={indeterminate ? "mixed" : checked}
+          aria-describedby={hasStat ? `${fieldId}-msg` : undefined}
+          aria-invalid={status === "error" ? true : undefined}
           checked={checked}
           class="gsv-cb-input"
           disabled={disabled}
@@ -78,7 +90,7 @@ export function Checkbox(props: CheckboxProps) {
       {hasStat ? (
         <div class="gsv-cb-stat">
           <span class="gsv-cb-dot" />
-          <span class="gsv-cb-msg">{message}</span>
+          <span class="gsv-cb-msg" id={`${fieldId}-msg`}>{message}</span>
         </div>
       ) : null}
     </div>

--- a/web/src/app/components/ui/ConfirmModal.css
+++ b/web/src/app/components/ui/ConfirmModal.css
@@ -17,5 +17,8 @@
 .gsv-cm-close:hover,
 .gsv-cm-close:focus-visible {
   color: var(--accent-bright);
-  outline: none;
+}
+.gsv-cm-close:focus-visible {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: 2px;
 }

--- a/web/src/app/components/ui/ConfirmModal.tsx
+++ b/web/src/app/components/ui/ConfirmModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useId, useRef } from "preact/hooks";
 import { Button } from "./Button";
 import "./ConfirmModal.css";
 
@@ -25,8 +26,59 @@ export function ConfirmModal({
   onCancel,
   onConfirm,
 }: ConfirmModalProps) {
+  const titleId = useId();
+  const descId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const footerRef = useRef<HTMLDivElement>(null);
+
+  // On mount, move focus to the Cancel (secondary) button.
+  useEffect(() => {
+    const cancelBtn = footerRef.current?.querySelector("button");
+    cancelBtn?.focus();
+  }, []);
+
+  // Escape to cancel + a basic focus trap within the dialog.
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onCancel?.();
+        return;
+      }
+      if (e.key === "Tab") {
+        const root = rootRef.current;
+        if (!root) return;
+        const focusable = root.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey) {
+          if (active === first || !root.contains(active)) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (active === last || !root.contains(active)) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onCancel]);
+
   return (
     <div
+      ref={rootRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      tabIndex={-1}
       style={{
         position: "relative",
         width: `${width}px`,
@@ -53,7 +105,7 @@ export function ConfirmModal({
         }}
       >
         <span style={{ width: "7px", height: "7px", flex: "none", borderRadius: "1px", background: "var(--warn)", boxShadow: "0 0 8px var(--warn)" }} />
-        <span style={{ fontSize: "11px", letterSpacing: ".2em", color: "#e8d7b0" }}>{title}</span>
+        <span id={titleId} style={{ fontSize: "11px", letterSpacing: ".2em", color: "#e8d7b0" }}>{title}</span>
         <button type="button" class="gsv-cm-close" aria-label="Close modal" onClick={onCancel}>
           {"✕"}
         </button>
@@ -67,6 +119,7 @@ export function ConfirmModal({
           fill="none"
           stroke="var(--warn)"
           stroke-width="1.4"
+          aria-hidden="true"
           style={{ flex: "none", filter: "drop-shadow(0 0 6px rgba(224,166,76,.4))" }}
         >
           <path d="M12 3 L22 20 L2 20 Z" />
@@ -74,12 +127,12 @@ export function ConfirmModal({
           <rect x="11.1" y="16" width="1.8" height="1.8" fill="var(--warn)" stroke="none" />
         </svg>
         <div style={{ paddingTop: "2px", fontFamily: "'Space Grotesk',sans-serif" }}>
-          <div style={{ fontSize: "13.5px", lineHeight: "1.65", color: "var(--text)" }}>{message}</div>
+          <div id={descId} style={{ fontSize: "13.5px", lineHeight: "1.65", color: "var(--text)" }}>{message}</div>
           <div style={{ fontSize: "11px", color: "#9a95cf", marginTop: "9px", letterSpacing: ".04em" }}>{note}</div>
         </div>
       </div>
 
-      <div style={{ display: "flex", justifyContent: "flex-end", gap: "12px", padding: "0 22px 22px" }}>
+      <div ref={footerRef} style={{ display: "flex", justifyContent: "flex-end", gap: "12px", padding: "0 22px 22px" }}>
         <Button variant="secondary" label={cancelLabel} onClick={onCancel} />
         <Button variant="danger" label={confirmLabel} onClick={onConfirm} />
       </div>

--- a/web/src/app/components/ui/Counter.css
+++ b/web/src/app/components/ui/Counter.css
@@ -27,6 +27,10 @@
   color: #cbc7ff;
   outline: none;
 }
+.gsv-st-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .gsv-st-btn:not(:disabled):active {
   background: #201c4d;
   color: #fff;

--- a/web/src/app/components/ui/Counter.tsx
+++ b/web/src/app/components/ui/Counter.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useId, useState } from "preact/hooks";
 import "./Counter.css";
 
 export type CounterSize = "small" | "medium" | "large";
@@ -45,6 +45,8 @@ export function Counter(props: CounterProps) {
     onChange,
   } = props;
 
+  const fieldId = useId();
+
   const [stateVal, setStateVal] = useState<number | undefined>(undefined);
 
   const cur = stateVal === undefined ? props.value ?? 1 : stateVal;
@@ -69,26 +71,71 @@ export function Counter(props: CounterProps) {
   const dec = disabled ? undefined : () => set(val - step);
   const inc = disabled ? undefined : () => set(val + step);
 
+  const labelId = `${fieldId}-label`;
+  const descId = `${fieldId}-desc`;
+  const msgId = `${fieldId}-msg`;
+  const describedBy =
+    [description ? descId : "", hasStat ? msgId : ""].filter(Boolean).join(" ") || undefined;
+  const isError = hasStat && statKey === "error";
+
   return (
-    <div class={fldClass}>
+    <div
+      class={fldClass}
+      role="group"
+      aria-labelledby={hasFldLabel ? labelId : undefined}
+      aria-describedby={describedBy}
+      aria-invalid={isError ? true : undefined}
+    >
       {hasFldLabel ? (
         <div class="gsv-fld-lab">
-          <span class="gsv-fld-lab-t">{label}</span>
+          <span class="gsv-fld-lab-t" id={labelId}>
+            {label}
+          </span>
           {req ? (
             <span class="gsv-fld-req">{req === "required" ? "· REQUIRED" : "· OPTIONAL"}</span>
           ) : null}
         </div>
       ) : null}
-      {description ? <div class="gsv-fld-desc">{description}</div> : null}
+      {description ? (
+        <div class="gsv-fld-desc" id={descId}>
+          {description}
+        </div>
+      ) : null}
       <div class={rootClass}>
-        <button type="button" class="gsv-st-btn" disabled={disabled} onClick={dec}>
-          <svg width="11" height="11" viewBox="0 0 16 16" shape-rendering="crispEdges">
+        <button
+          type="button"
+          class="gsv-st-btn"
+          disabled={disabled}
+          onClick={dec}
+          aria-label={`Decrease ${label || "value"}`}
+        >
+          <svg
+            width="11"
+            height="11"
+            viewBox="0 0 16 16"
+            shape-rendering="crispEdges"
+            aria-hidden="true"
+          >
             <rect x="3" y="7" width="10" height="2" fill="currentColor" />
           </svg>
         </button>
-        <span class="gsv-st-val">{display}</span>
-        <button type="button" class="gsv-st-btn" disabled={disabled} onClick={inc}>
-          <svg width="11" height="11" viewBox="0 0 16 16" shape-rendering="crispEdges">
+        <span class="gsv-st-val" aria-live="polite" aria-atomic="true" role="status">
+          {display}
+        </span>
+        <button
+          type="button"
+          class="gsv-st-btn"
+          disabled={disabled}
+          onClick={inc}
+          aria-label={`Increase ${label || "value"}`}
+        >
+          <svg
+            width="11"
+            height="11"
+            viewBox="0 0 16 16"
+            shape-rendering="crispEdges"
+            aria-hidden="true"
+          >
             <g fill="currentColor">
               <rect x="7" y="3" width="2" height="10" />
               <rect x="3" y="7" width="10" height="2" />
@@ -97,7 +144,7 @@ export function Counter(props: CounterProps) {
         </button>
       </div>
       {hasStat ? (
-        <div class="gsv-fld-stat">
+        <div class="gsv-fld-stat" id={msgId}>
           <span class="gsv-fld-dot" />
           <span class="gsv-fld-msg">{message}</span>
         </div>

--- a/web/src/app/components/ui/IconButton.css
+++ b/web/src/app/components/ui/IconButton.css
@@ -1,9 +1,25 @@
 /* Ported from IconButton.dc.html — values transcribed verbatim. */
+/* Reset native <button> chrome so the button renders identically to the
+   original <div> (font inheritance + zero padding; box-sizing keeps the
+   inline width/height matching the old border-box div). */
+.gsv-ibtn,
+.gsv-ibtn-disabled {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  box-sizing: border-box;
+  -webkit-appearance: none;
+  appearance: none;
+}
 .gsv-ibtn {
   background: #0a0820;
   border: 1px solid #322e74;
   color: #9089d4;
   transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.gsv-ibtn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .gsv-ibtn:hover {
   background: #171441;

--- a/web/src/app/components/ui/IconButton.tsx
+++ b/web/src/app/components/ui/IconButton.tsx
@@ -77,13 +77,16 @@ export function IconButton({ glyph = "back", size = "medium", disabled = false, 
   const px = typeof size === "number" ? size : SIZE_MAP[size] ?? Number(size) ?? 30;
   const cls = disabled ? "gsv-ibtn-disabled" : "gsv-ibtn";
   return (
-    <div
+    <button
+      type="button"
       class={cls}
       title={title}
+      aria-label={title || undefined}
+      disabled={disabled}
       onClick={disabled ? undefined : onClick}
       style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", cursor: "pointer", width: `${px}px`, height: `${px}px` }}
     >
       {GLYPHS[glyph]}
-    </div>
+    </button>
   );
 }

--- a/web/src/app/components/ui/IconMenu.css
+++ b/web/src/app/components/ui/IconMenu.css
@@ -57,6 +57,11 @@
   outline: none;
 }
 
+.gsv-im-close:not(:disabled):focus-visible {
+  outline: 1px solid var(--accent-bright);
+  outline-offset: 2px;
+}
+
 .gsv-im-close:disabled {
   cursor: default;
   opacity: 0.45;
@@ -80,6 +85,10 @@
 .gsv-im-cell:not(:disabled):focus-visible {
   background: var(--hover) !important;
   outline: none;
+}
+.gsv-im-cell:not(:disabled):focus-visible {
+  outline: 1px solid var(--accent-bright);
+  outline-offset: -1px;
 }
 .gsv-im-cell:disabled {
   cursor: default;

--- a/web/src/app/components/ui/IconMenu.tsx
+++ b/web/src/app/components/ui/IconMenu.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "preact/hooks";
 import { Icon } from "./Icon";
 import "./IconMenu.css";
 
@@ -23,8 +24,31 @@ export function IconMenu({
   onTerminal,
   onSettings,
 }: IconMenuProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // On mount: move focus to the first enabled action button (or the close button).
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const firstEnabledCell = root.querySelector<HTMLButtonElement>(".gsv-im-cell:not(:disabled)");
+    const closeButton = root.querySelector<HTMLButtonElement>(".gsv-im-close");
+    (firstEnabledCell ?? closeButton)?.focus();
+  }, []);
+
+  // Escape closes the menu.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
   return (
     <div
+      ref={rootRef}
+      role="dialog"
+      aria-label={title}
       class="gsv-im"
       style={{
         width: `${width}px`,
@@ -53,6 +77,7 @@ export function IconMenu({
       >
         <div style={{ display: "flex", alignItems: "center", gap: "9px" }}>
           <span
+            aria-hidden="true"
             style={{
               width: "7px",
               height: "7px",
@@ -64,7 +89,7 @@ export function IconMenu({
           />
           <span style={{ fontSize: "11px", letterSpacing: ".24em", color: "var(--accent-bright)" }}>{title}</span>
         </div>
-        <button type="button" class="gsv-im-close" disabled={!onClose} onClick={onClose}>
+        <button type="button" aria-label="Close menu" class="gsv-im-close" disabled={!onClose} onClick={onClose}>
           [ X ]
         </button>
       </div>

--- a/web/src/app/components/ui/ListRow.tsx
+++ b/web/src/app/components/ui/ListRow.tsx
@@ -113,7 +113,7 @@ export function ListRow({
       {hasDot && statusDotPlacement === "trailing" ? <span class={dotClass} style={dotStyle} /> : null}
       {chevron ? (
         <span class="lr-chevron" style={{ display: "inline-flex", flex: "none", alignItems: "center" }}>
-          <svg width="9" height="12" viewBox="0 0 9 12" style={{ filter: "drop-shadow(0 0 3px rgba(150,140,255,.5))" }}>
+          <svg width="9" height="12" viewBox="0 0 9 12" aria-hidden="true" style={{ filter: "drop-shadow(0 0 3px rgba(150,140,255,.5))" }}>
             <path d="M0 0 L9 6 L0 12 Z" fill="var(--accent)" />
           </svg>
         </span>

--- a/web/src/app/components/ui/Radio.css
+++ b/web/src/app/components/ui/Radio.css
@@ -36,6 +36,8 @@
 .gsv-rd-input:focus-visible + .gsv-rd-ring {
   border-color: #b3aeff;
   box-shadow: 0 0 0 1px rgba(150, 140, 255, 0.35);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .gsv-rd-dot {
   border-radius: 50%;

--- a/web/src/app/components/ui/Radio.tsx
+++ b/web/src/app/components/ui/Radio.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "preact/hooks";
+import { useId, useRef, useState } from "preact/hooks";
 import "./Radio.css";
 
 export type RadioSize = "small" | "medium" | "large";
@@ -47,6 +47,7 @@ export function Radio(props: RadioProps) {
 
   const [idxState, setIdxState] = useState<number | undefined>(undefined);
   const nameRef = useRef(`gsv-radio-${Math.random().toString(36).slice(2)}`);
+  const groupId = useId();
 
   const opts = [o0, o1, o2, o3].filter((x) => x != null && x !== "");
   const labels = opts.length ? opts : ["ALLOW", "ASK", "DENY"];
@@ -67,16 +68,27 @@ export function Radio(props: RadioProps) {
     onChange?.(i);
   };
 
+  const labelId = hasFldLabel ? `${groupId}-label` : undefined;
+  const descId = description ? `${groupId}-desc` : undefined;
+  const msgId = hasStat ? `${groupId}-msg` : undefined;
+  const describedBy = [descId, msgId].filter(Boolean).join(" ") || undefined;
+
   return (
     <div class={fldClass}>
       {hasFldLabel ? (
         <div class="gsv-fld-lab">
-          <span class="gsv-fld-lab-t">{label}</span>
+          <span class="gsv-fld-lab-t" id={labelId}>{label}</span>
           {req ? <span class="gsv-fld-req">{fldReq}</span> : null}
         </div>
       ) : null}
-      {description ? <div class="gsv-fld-desc">{description}</div> : null}
-      <div class={rootClass}>
+      {description ? <div class="gsv-fld-desc" id={descId}>{description}</div> : null}
+      <div
+        class={rootClass}
+        role="radiogroup"
+        aria-labelledby={labelId}
+        aria-describedby={describedBy}
+        aria-invalid={status === "error" ? true : undefined}
+      >
         {labels.map((optLabel, i) => (
           <label class={`gsv-rd-opt${i === idx ? " is-on" : ""}`} key={i}>
             <input
@@ -95,7 +107,7 @@ export function Radio(props: RadioProps) {
       {hasStat ? (
         <div class="gsv-fld-stat">
           <span class="gsv-fld-dot" />
-          <span class="gsv-fld-msg">{message}</span>
+          <span class="gsv-fld-msg" id={msgId}>{message}</span>
         </div>
       ) : null}
     </div>

--- a/web/src/app/components/ui/Segmented.css
+++ b/web/src/app/components/ui/Segmented.css
@@ -37,6 +37,10 @@
 .gsv-sg-seg.is-sel:not(:disabled):focus-visible {
   background: #6b62c4;
 }
+.gsv-sg-seg:not(:disabled):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .gsv-sg.is-disabled {
   opacity: 0.45;
   pointer-events: none;

--- a/web/src/app/components/ui/Segmented.tsx
+++ b/web/src/app/components/ui/Segmented.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useId, useRef, useState } from "preact/hooks";
 import "./Segmented.css";
 
 export type SegmentedSize = "small" | "medium" | "large";
@@ -49,6 +49,8 @@ export function Segmented(props: SegmentedProps) {
 
   const [selState, setSelState] = useState<number | undefined>(undefined);
   const sel = selState === undefined ? props.value ?? 1 : selState;
+  const groupId = useId();
+  const segRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const req = requirement && requirement !== "none" ? requirement : "";
   const rawStatus = status && status !== "none" ? status : "";
@@ -63,44 +65,94 @@ export function Segmented(props: SegmentedProps) {
   const rootClass = `gsv-sg ${sizeClass}${disabled ? " is-disabled" : ""}`.trim();
   const fldClass = `gsv-fld${hasStatus ? ` is-${statusKey}` : ""}`;
 
+  // Indices of the segments actually rendered (respecting has2/has3).
+  const segIndices = [0, 1, ...(has2 ? [2] : []), ...(has3 ? [3] : [])];
+
   const pick = (i: number) => () => {
     setSelState(i);
     onChange?.(i);
   };
 
+  const moveTo = (i: number) => {
+    setSelState(i);
+    onChange?.(i);
+    segRefs.current[i]?.focus();
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (disabled) return;
+    const pos = segIndices.indexOf(sel);
+    const cur = pos < 0 ? 0 : pos;
+    let next: number | null = null;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        next = segIndices[(cur + 1) % segIndices.length];
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        next = segIndices[(cur - 1 + segIndices.length) % segIndices.length];
+        break;
+      case "Home":
+        next = segIndices[0];
+        break;
+      case "End":
+        next = segIndices[segIndices.length - 1];
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    if (next !== null) moveTo(next);
+  };
+
   const segCls = (i: number) => `gsv-sg-seg${sel === i ? " is-sel" : ""}`;
+
+  const labelId = hasFldLabel ? `${groupId}-label` : undefined;
+  const descId = description.length > 0 ? `${groupId}-desc` : undefined;
+  const msgId = hasStatus ? `${groupId}-msg` : undefined;
+  const describedBy = [descId, msgId].filter(Boolean).join(" ") || undefined;
+
+  const segProps = (i: number) => ({
+    type: "button" as const,
+    class: segCls(i),
+    disabled,
+    role: "radio" as const,
+    "aria-checked": sel === i,
+    tabIndex: sel === i ? 0 : -1,
+    ref: (el: HTMLButtonElement | null) => {
+      segRefs.current[i] = el;
+    },
+    onClick: pick(i),
+    onKeyDown,
+  });
 
   return (
     <div class={fldClass} style={{ width: `${width}px`, maxWidth: "100%" }}>
       {hasFldLabel ? (
         <div class="gsv-fld-lab">
-          <span class="gsv-fld-lab-t">{label}</span>
+          <span class="gsv-fld-lab-t" id={labelId}>{label}</span>
           {req ? <span class="gsv-fld-req">{req === "required" ? "· REQUIRED" : "· OPTIONAL"}</span> : null}
         </div>
       ) : null}
-      {description.length > 0 ? <div class="gsv-fld-desc">{description}</div> : null}
-      <div class={rootClass} style={{ width: "100%" }}>
-        <button type="button" class={segCls(0)} disabled={disabled} onClick={pick(0)}>
-          {l0}
-        </button>
-        <button type="button" class={segCls(1)} disabled={disabled} onClick={pick(1)}>
-          {l1}
-        </button>
-        {has2 ? (
-          <button type="button" class={segCls(2)} disabled={disabled} onClick={pick(2)}>
-            {l2}
-          </button>
-        ) : null}
-        {has3 ? (
-          <button type="button" class={segCls(3)} disabled={disabled} onClick={pick(3)}>
-            {l3}
-          </button>
-        ) : null}
+      {description.length > 0 ? <div class="gsv-fld-desc" id={descId}>{description}</div> : null}
+      <div
+        class={rootClass}
+        style={{ width: "100%" }}
+        role="radiogroup"
+        aria-labelledby={labelId}
+        aria-describedby={describedBy}
+        aria-invalid={status === "error" ? true : undefined}
+      >
+        <button {...segProps(0)}>{l0}</button>
+        <button {...segProps(1)}>{l1}</button>
+        {has2 ? <button {...segProps(2)}>{l2}</button> : null}
+        {has3 ? <button {...segProps(3)}>{l3}</button> : null}
       </div>
       {hasStatus ? (
         <div class="gsv-fld-stat">
           <span class="gsv-fld-dot" />
-          <span class="gsv-fld-msg">{message}</span>
+          <span class="gsv-fld-msg" id={msgId}>{message}</span>
         </div>
       ) : null}
     </div>

--- a/web/src/app/components/ui/Select.css
+++ b/web/src/app/components/ui/Select.css
@@ -23,6 +23,10 @@
   border-color: #6b62c4;
   outline: none;
 }
+.gsv-sel-trig:focus-visible {
+  outline: 2px solid #b3aeff;
+  outline-offset: 2px;
+}
 .gsv-sel.is-open .gsv-sel-trig {
   border-color: #b3aeff;
 }
@@ -74,9 +78,16 @@
   transition: background 0.12s;
 }
 .gsv-sel-row:hover,
-.gsv-sel-row:focus-visible {
+.gsv-sel-row:focus-visible,
+.gsv-sel-row.is-highlighted {
   background: #201c4d;
   outline: none;
+}
+/* Keyboard highlight stays visible even on the selected row, whose inline
+   background would otherwise override the .is-highlighted background. Scoped to
+   :not(:hover) so mouse hover keeps its original background-only appearance. */
+.gsv-sel-row.is-highlighted:not(:hover) {
+  box-shadow: inset 0 0 0 1px #6b62c4;
 }
 .gsv-fld {
   display: flex;

--- a/web/src/app/components/ui/Select.tsx
+++ b/web/src/app/components/ui/Select.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useId, useRef, useState } from "preact/hooks";
 import "./Select.css";
 
 export type SelectSize = "small" | "medium" | "large";
@@ -47,9 +47,13 @@ export function Select(props: SelectProps) {
     onChange,
   } = props;
 
+  const fieldId = useId();
   const [open, setOpen] = useState(false);
   const [idxState, setIdxState] = useState<number | undefined>(undefined);
+  const [highlight, setHighlight] = useState(0);
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
@@ -76,6 +80,39 @@ export function Select(props: SelectProps) {
   const rootClass = `gsv-sel ${sizeClass}${isOpen ? " is-open" : ""}${disabled ? " is-disabled" : ""}`.trim();
   const fldClass = `gsv-fld${hasStatus ? ` is-${statusKey}` : ""}`;
 
+  const labelId = `${fieldId}-label`;
+  const descId = `${fieldId}-desc`;
+  const msgId = `${fieldId}-msg`;
+  const triggerId = `${fieldId}-trigger`;
+  const listId = `${fieldId}-list`;
+  const optId = (i: number) => `${fieldId}-opt-${i}`;
+
+  const triggerLabelledBy = (hasFldLabel && label.length > 0 ? `${labelId} ` : "") + triggerId;
+  const describedByParts: string[] = [];
+  if (description.length > 0) describedByParts.push(descId);
+  if (hasStatus) describedByParts.push(msgId);
+  const triggerDescribedBy = describedByParts.length ? describedByParts.join(" ") : undefined;
+
+  // When opening, focus the listbox and highlight the current value.
+  useEffect(() => {
+    if (isOpen) {
+      setHighlight(idx);
+      listRef.current?.focus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  const openList = () => {
+    if (disabled) return;
+    setHighlight(idx);
+    setOpen(true);
+  };
+
+  const closeList = (returnFocus: boolean) => {
+    setOpen(false);
+    if (returnFocus) triggerRef.current?.focus();
+  };
+
   const toggle = () => {
     if (disabled) return;
     setOpen((o) => !o);
@@ -85,28 +122,94 @@ export function Select(props: SelectProps) {
     setIdxState(i);
     setOpen(false);
     onChange?.(i);
+    triggerRef.current?.focus();
+  };
+
+  const onTriggerKeyDown = (e: KeyboardEvent) => {
+    if (disabled) return;
+    if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      openList();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      openList();
+    }
+  };
+
+  const onListKeyDown = (e: KeyboardEvent) => {
+    const last = opts.length - 1;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setHighlight((h) => (h >= last ? 0 : h + 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setHighlight((h) => (h <= 0 ? last : h - 1));
+        break;
+      case "Home":
+        e.preventDefault();
+        setHighlight(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setHighlight(last);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        pick(highlight);
+        break;
+      case "Escape":
+        e.preventDefault();
+        closeList(true);
+        break;
+      case "Tab":
+        closeList(false);
+        break;
+    }
   };
 
   return (
     <div class={fldClass} style={{ width: `${width}px`, maxWidth: "100%" }}>
       {hasFldLabel ? (
         <div class="gsv-fld-lab">
-          <span class="gsv-fld-lab-t">{label}</span>
+          <span class="gsv-fld-lab-t" id={label.length > 0 ? labelId : undefined}>{label}</span>
           {req ? <span class="gsv-fld-req">{req === "required" ? "· REQUIRED" : "· OPTIONAL"}</span> : null}
         </div>
       ) : null}
-      {description.length > 0 ? <div class="gsv-fld-desc">{description}</div> : null}
+      {description.length > 0 ? <div class="gsv-fld-desc" id={descId}>{description}</div> : null}
       <div ref={rootRef} class={rootClass} style={{ width: "100%" }}>
-        <button type="button" class="gsv-sel-trig" disabled={disabled} onClick={toggle}>
+        <button
+          type="button"
+          class="gsv-sel-trig"
+          id={triggerId}
+          ref={triggerRef}
+          disabled={disabled}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          aria-controls={listId}
+          aria-labelledby={triggerLabelledBy}
+          aria-describedby={triggerDescribedBy}
+          onClick={toggle}
+          onKeyDown={onTriggerKeyDown}
+        >
           <span class="gsv-sel-val">{opts[idx]}</span>
           <span style={{ marginLeft: "auto", display: "flex" }}>
-            <svg width="9" height="6" viewBox="0 0 9 6">
+            <svg width="9" height="6" viewBox="0 0 9 6" aria-hidden="true">
               <path d="M0 0 L9 0 L4.5 6 Z" fill="#b3aeff" />
             </svg>
           </span>
         </button>
         {isOpen ? (
           <div
+            id={listId}
+            ref={listRef}
+            role="listbox"
+            tabIndex={-1}
+            aria-labelledby={hasFldLabel && label.length > 0 ? labelId : undefined}
+            aria-activedescendant={optId(highlight)}
+            onKeyDown={onListKeyDown}
             style={{
               position: "absolute",
               left: 0,
@@ -117,21 +220,28 @@ export function Select(props: SelectProps) {
               background: "#13112e",
               border: "1px solid #4a449e",
               boxShadow: "0 12px 30px rgba(0,0,0,.55)",
+              outline: "none",
             }}
           >
             {opts.map((optLabel, i) => (
               <button
                 type="button"
-                class="gsv-sel-row"
+                class={`gsv-sel-row${i === highlight ? " is-highlighted" : ""}`}
                 key={i}
+                id={optId(i)}
+                role="option"
+                aria-selected={i === idx}
+                tabIndex={-1}
                 style={i === idx ? { background: "#171441" } : undefined}
                 onClick={() => pick(i)}
+                onMouseEnter={() => setHighlight(i)}
               >
                 <span style={{ fontSize: "11px", letterSpacing: ".03em", color: i === idx ? "#fff" : "#c4bfee" }}>
                   {optLabel}
                 </span>
                 {i === idx ? (
                   <span
+                    aria-hidden="true"
                     style={{
                       marginLeft: "auto",
                       width: "6px",
@@ -149,8 +259,8 @@ export function Select(props: SelectProps) {
       </div>
       {hasStatus ? (
         <div class="gsv-fld-stat">
-          <span class="gsv-fld-dot" />
-          <span class="gsv-fld-msg">{message}</span>
+          <span class="gsv-fld-dot" aria-hidden="true" />
+          <span class="gsv-fld-msg" id={msgId}>{message}</span>
         </div>
       ) : null}
     </div>

--- a/web/src/app/components/ui/Slider.css
+++ b/web/src/app/components/ui/Slider.css
@@ -51,6 +51,10 @@
   box-shadow: 0 0 8px rgba(150, 140, 255, 0.6);
   transform: translate(-50%, -50%);
 }
+.gsv-sl-thumb:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .gsv-sl.is-disabled {
   opacity: 0.45;
   pointer-events: none;

--- a/web/src/app/components/ui/Slider.tsx
+++ b/web/src/app/components/ui/Slider.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "preact/hooks";
+import { useRef, useState, useEffect, useId } from "preact/hooks";
 import "./Slider.css";
 
 export type SliderRequirement = "none" | "required" | "optional";
@@ -38,6 +38,7 @@ export function Slider(props: SliderProps) {
     onChange,
   } = props;
 
+  const fieldId = useId();
   const [val, setVal] = useState<number | undefined>(undefined);
   const trackRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef(false);
@@ -55,6 +56,19 @@ export function Slider(props: SliderProps) {
     "gsv-sl" + (disabled ? " is-disabled" : "") + (hasStat ? " is-" + statKey : "");
   const hasTop = label.length > 0 || showValue || !!req;
 
+  const hasLabel = label.length > 0;
+  const hasDesc = !!description;
+  const describedBy =
+    [hasDesc ? `${fieldId}-desc` : "", hasStat ? `${fieldId}-msg` : ""]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
+  const commit = (v: number) => {
+    v = Math.max(min, Math.min(max, v));
+    setVal(v);
+    onChange?.(v);
+  };
+
   const setFromX = (clientX: number) => {
     const el = trackRef.current;
     if (!el) return;
@@ -63,10 +77,40 @@ export function Slider(props: SliderProps) {
     p = Math.max(0, Math.min(1, p));
     let v = min + p * (max - min);
     v = Math.round(v / step) * step;
-    v = Math.max(min, Math.min(max, v));
-    setVal(v);
-    onChange?.(v);
+    commit(v);
   };
+
+  const onKeyDown = disabled
+    ? undefined
+    : (e: KeyboardEvent) => {
+        let next: number | undefined;
+        switch (e.key) {
+          case "ArrowRight":
+          case "ArrowUp":
+            next = value + step;
+            break;
+          case "ArrowLeft":
+          case "ArrowDown":
+            next = value - step;
+            break;
+          case "Home":
+            next = min;
+            break;
+          case "End":
+            next = max;
+            break;
+          case "PageUp":
+            next = value + 10 * step;
+            break;
+          case "PageDown":
+            next = value - 10 * step;
+            break;
+          default:
+            return;
+        }
+        e.preventDefault();
+        commit(next);
+      };
 
   useEffect(() => {
     const move = (e: PointerEvent) => {
@@ -95,7 +139,7 @@ export function Slider(props: SliderProps) {
     <div class={rootClass} style={{ width: `${width}px`, maxWidth: "100%" }}>
       {hasTop ? (
         <div class="gsv-sl-top">
-          <span class="gsv-sl-label">
+          <span class="gsv-sl-label" id={hasLabel ? `${fieldId}-label` : undefined}>
             {label}
             {req ? (
               <span class="gsv-sl-req">{req === "required" ? "· REQUIRED" : "· OPTIONAL"}</span>
@@ -104,17 +148,36 @@ export function Slider(props: SliderProps) {
           {showValue ? <span class="gsv-sl-num">{value}</span> : null}
         </div>
       ) : null}
-      {description ? <div class="gsv-sl-desc">{description}</div> : null}
+      {description ? (
+        <div class="gsv-sl-desc" id={`${fieldId}-desc`}>
+          {description}
+        </div>
+      ) : null}
       <div class="gsv-sl-hit" onPointerDown={onDown}>
         <div class="gsv-sl-track" ref={trackRef}>
           <div class="gsv-sl-fill" style={{ width: pctStr }} />
-          <div class="gsv-sl-thumb" style={{ left: pctStr }} />
+          <div
+            class="gsv-sl-thumb"
+            style={{ left: pctStr }}
+            tabIndex={disabled ? undefined : 0}
+            role="slider"
+            aria-valuemin={min}
+            aria-valuemax={max}
+            aria-valuenow={value}
+            aria-orientation="horizontal"
+            aria-labelledby={hasLabel ? `${fieldId}-label` : undefined}
+            aria-describedby={describedBy}
+            aria-disabled={disabled ? true : undefined}
+            onKeyDown={onKeyDown}
+          />
         </div>
       </div>
       {hasStat ? (
         <div class="gsv-sl-stat">
           <span class="gsv-sl-dot" />
-          <span class="gsv-sl-msg">{message}</span>
+          <span class="gsv-sl-msg" id={`${fieldId}-msg`}>
+            {message}
+          </span>
         </div>
       ) : null}
     </div>

--- a/web/src/app/components/ui/Stepper.css
+++ b/web/src/app/components/ui/Stepper.css
@@ -21,7 +21,9 @@
   text-align: center;
 }
 .gsv-sp-step:focus-visible {
-  outline: none;
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 4px;
 }
 .gsv-sp-step:focus-visible .gsv-sp-dot {
   box-shadow: 0 0 0 1px rgba(150, 140, 255, 0.35), 0 0 12px rgba(150, 140, 255, 0.45);

--- a/web/src/app/components/ui/Stepper.tsx
+++ b/web/src/app/components/ui/Stepper.tsx
@@ -56,11 +56,17 @@ export function Stepper(props: StepperProps) {
   }
 
   return (
-    <div class={rootClass} style={{ width: `${width}px`, maxWidth: "100%" }}>
-      {steps.map((s) => (
+    <div role="group" aria-label="Progress" class={rootClass} style={{ width: `${width}px`, maxWidth: "100%" }}>
+      {steps.map((s, i) => (
         <Fragment key={s.num}>
           {s.hasLine ? <span class={s.lineCls} /> : null}
-          <button type="button" class="gsv-sp-step" onClick={s.pick}>
+          <button
+            type="button"
+            class="gsv-sp-step"
+            aria-current={i === cur ? "step" : undefined}
+            aria-label={`Step ${s.num}${s.label ? `: ${s.label}` : ""}`}
+            onClick={s.pick}
+          >
             <span class={s.dotCls}>{s.num}</span>
             {s.hasLabel ? <span class={s.labelCls}>{s.label}</span> : null}
           </button>

--- a/web/src/app/components/ui/Tabs.css
+++ b/web/src/app/components/ui/Tabs.css
@@ -1,0 +1,4 @@
+.gsv-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}

--- a/web/src/app/components/ui/Tabs.tsx
+++ b/web/src/app/components/ui/Tabs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import "./Tabs.css";
 
 export interface TabsProps {
   tabs?: string[];
@@ -15,6 +16,7 @@ export interface TabsProps {
  *  the bar's measured width via a ResizeObserver. */
 export function Tabs({ tabs, value, onChange, onClose, width, sticky = false }: TabsProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const tabRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [hover, setHover] = useState(-1);
   const [w, setW] = useState(0);
   const [sel, setSel] = useState(0);
@@ -40,6 +42,41 @@ export function Tabs({ tabs, value, onChange, onClose, width, sticky = false }: 
   const val = Math.max(0, Math.min(controlled ? (value as number) | 0 : sel | 0, tabList.length - 1));
   const emit = onChange || (() => {});
   const closeable = typeof onClose === "function";
+
+  const select = (i: number, focus: boolean) => {
+    if (!controlled) setSel(i);
+    emit(i);
+    if (focus) tabRefs.current[i]?.focus();
+  };
+  const onTabKeyDown = (e: KeyboardEvent, i: number) => {
+    const last = tabList.length - 1;
+    let next = -1;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        next = i >= last ? 0 : i + 1;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        next = i <= 0 ? last : i - 1;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = last;
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        select(i, true);
+        return;
+      default:
+        return;
+    }
+    e.preventDefault();
+    select(next, true);
+  };
 
   // width drives the single continuous rail path; prefer an explicit prop, else self-measured, else a safe default
   const W = (width != null ? +width : 0) || w || 600;
@@ -125,14 +162,23 @@ export function Tabs({ tabs, value, onChange, onClose, width, sticky = false }: 
     "z-index:6;display:flex;align-items:flex-end;overflow:visible;padding:" + (narrow ? "12px 12px 0" : "16px 30px 0") + ";background:transparent;";
 
   return (
-    <div ref={rootRef} style={barStyle}>
+    <div ref={rootRef} role="tablist" style={barStyle}>
       {railSvg}
       {tabList.map((label, i) => (
         <div
+          ref={(el) => {
+            tabRefs.current[i] = el;
+          }}
+          id={"gsv-tab-" + i}
+          class="gsv-tab"
+          role="tab"
+          aria-selected={i === val}
+          tabIndex={i === val ? 0 : -1}
           onClick={() => {
             if (!controlled) setSel(i);
             emit(i);
           }}
+          onKeyDown={(e) => onTabKeyDown(e, i)}
           onMouseEnter={() => setHover(i)}
           onMouseLeave={() => setHover(-1)}
           style={outerStyle(i)}

--- a/web/src/app/components/ui/TextArea.tsx
+++ b/web/src/app/components/ui/TextArea.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useId, useState } from "preact/hooks";
 import "./TextArea.css";
 
 export type TextAreaSize = "small" | "medium" | "large";
@@ -45,6 +45,7 @@ export function TextArea(props: TextAreaProps) {
     onChange,
   } = props;
 
+  const fieldId = useId();
   const [val, setVal] = useState<string | undefined>(undefined);
 
   const value = val !== undefined ? val : props.value ?? "";
@@ -61,6 +62,11 @@ export function TextArea(props: TextAreaProps) {
   const hasDesc = description.length > 0;
   const hasStatusRow = hasStatusMsg || showCounter;
 
+  const describedBy =
+    [hasDesc ? `${fieldId}-desc` : "", hasStatusMsg ? `${fieldId}-msg` : ""]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
   const rootClass = `gsv-ta ${SIZE_CLASS[size]}${rawStatus ? ` is-${statusKey}` : ""}`;
   const boxClass = `gsv-ta-box ${disabled ? "is-disabled" : readonly ? "is-readonly" : ""}`.trim();
 
@@ -73,21 +79,25 @@ export function TextArea(props: TextAreaProps) {
     <div class={rootClass}>
       {hasLabelRow ? (
         <div class="gsv-ta-labelrow">
-          <span class="gsv-ta-label">
+          <span class="gsv-ta-label" id={`${fieldId}-label`}>
             {label}
             {req ? <span class="gsv-ta-req"> {req === "required" ? "· REQUIRED" : "· OPTIONAL"}</span> : null}
           </span>
         </div>
       ) : null}
-      {hasDesc ? <div class="gsv-ta-desc">{description}</div> : null}
+      {hasDesc ? <div class="gsv-ta-desc" id={`${fieldId}-desc`}>{description}</div> : null}
       <textarea
         class={boxClass}
+        id={fieldId}
         value={value}
         placeholder={placeholder}
         rows={rows}
         disabled={disabled}
         readOnly={readonly}
         spellcheck={false}
+        aria-labelledby={hasLabelRow && label.length > 0 ? `${fieldId}-label` : undefined}
+        aria-describedby={describedBy}
+        aria-invalid={status === "error" ? true : undefined}
         onInput={(e) => emit((e.target as HTMLTextAreaElement).value)}
       />
       {hasStatusRow ? (
@@ -95,7 +105,7 @@ export function TextArea(props: TextAreaProps) {
           {hasStatusMsg ? (
             <span class="gsv-ta-right">
               <span class="gsv-ta-dot" />
-              <span class="gsv-ta-msg">{message}</span>
+              <span class="gsv-ta-msg" id={`${fieldId}-msg`}>{message}</span>
             </span>
           ) : null}
           {showCounter ? <span class="gsv-ta-counter">{counterText}</span> : null}

--- a/web/src/app/components/ui/TextInput.tsx
+++ b/web/src/app/components/ui/TextInput.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "preact";
-import { useState } from "preact/hooks";
+import { useId, useState } from "preact/hooks";
 import "./TextInput.css";
 
 export type TextInputSize = "small" | "medium" | "large";
@@ -56,6 +56,7 @@ export function TextInput(props: TextInputProps) {
     inputProps,
   } = props;
 
+  const fieldId = useId();
   const [val, setVal] = useState<string | undefined>(undefined);
   const [revealed, setRevealed] = useState(false);
 
@@ -75,6 +76,11 @@ export function TextInput(props: TextInputProps) {
   const hasLabelRow = label.length > 0 || !!req;
   const hasStatusRow = hasStatusMsg || showCounter;
 
+  const describedBy =
+    [description ? `${fieldId}-desc` : "", hasStatusMsg ? `${fieldId}-msg` : ""]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
   const rootClass = `gsv-ti ${SIZE_CLASS[size]}${rawStatus ? ` is-${statusKey}` : ""}`;
   const wrapClass = `gsv-ti-wrap ${disabled ? "is-disabled" : readonly ? "is-readonly" : ""}`.trim();
 
@@ -87,28 +93,32 @@ export function TextInput(props: TextInputProps) {
     <div class={rootClass}>
       {hasLabelRow ? (
         <div class="gsv-ti-labelrow">
-          <span class="gsv-ti-label">
+          <span class="gsv-ti-label" id={`${fieldId}-label`}>
             {label}
             {req ? <span class="gsv-ti-req"> {req === "required" ? "· REQUIRED" : "· OPTIONAL"}</span> : null}
           </span>
         </div>
       ) : null}
-      {description ? <div class="gsv-ti-desc">{description}</div> : null}
+      {description ? <div class="gsv-ti-desc" id={`${fieldId}-desc`}>{description}</div> : null}
       <div class={wrapClass}>
         {prefix ? <span class="gsv-ti-affix">{prefix}</span> : null}
         <input
           {...inputProps}
           class="gsv-ti-input"
+          id={fieldId}
           type={isPassword && !revealed ? "password" : "text"}
           value={value}
           placeholder={placeholder}
           disabled={disabled}
           readOnly={readonly}
+          aria-labelledby={hasLabelRow && label.length > 0 ? `${fieldId}-label` : undefined}
+          aria-describedby={describedBy}
+          aria-invalid={status === "error" ? true : undefined}
           onInput={(e) => emit((e.target as HTMLInputElement).value)}
         />
         {showClear ? (
           <button type="button" class="gsv-ti-x" aria-label="Clear input" onClick={() => emit("")}>
-            <svg width="11" height="11" viewBox="0 0 16 16" stroke="currentColor" stroke-width="1.6" stroke-linecap="square">
+            <svg aria-hidden="true" width="11" height="11" viewBox="0 0 16 16" stroke="currentColor" stroke-width="1.6" stroke-linecap="square">
               <line x1="3" y1="3" x2="13" y2="13" />
               <line x1="13" y1="3" x2="3" y2="13" />
             </svg>
@@ -119,6 +129,8 @@ export function TextInput(props: TextInputProps) {
             type="button"
             class="gsv-ti-btn"
             disabled={disabled}
+            aria-pressed={revealed}
+            aria-label={revealed ? "Hide password" : "Show password"}
             onClick={() => setRevealed((r) => !r)}
           >
             {revealed ? "HIDE" : "SHOW"}
@@ -131,7 +143,7 @@ export function TextInput(props: TextInputProps) {
           {hasStatusMsg ? (
             <span class="gsv-ti-right">
               <span class="gsv-ti-dot" />
-              <span class="gsv-ti-msg">{message}</span>
+              <span class="gsv-ti-msg" id={`${fieldId}-msg`}>{message}</span>
             </span>
           ) : (
             <span />

--- a/web/src/app/components/ui/Toggle.css
+++ b/web/src/app/components/ui/Toggle.css
@@ -29,6 +29,8 @@
 .gsv-tg-input:focus-visible + .gsv-tg-track {
   border-color: #b3aeff;
   box-shadow: 0 0 0 1px rgba(150, 140, 255, 0.35);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .gsv-tg.is-on .gsv-tg-track {
   background: #5a52a8;

--- a/web/src/app/components/ui/Toggle.tsx
+++ b/web/src/app/components/ui/Toggle.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useId, useState } from "preact/hooks";
 import "./Toggle.css";
 
 export type ToggleSize = "small" | "medium" | "large";
@@ -34,6 +34,8 @@ export function Toggle(props: ToggleProps) {
     onChange,
   } = props;
 
+  const fieldId = useId();
+
   const [onState, setOnState] = useState<boolean | undefined>(undefined);
   const on = onState === undefined ? props.on === true : onState;
 
@@ -55,6 +57,8 @@ export function Toggle(props: ToggleProps) {
       {description ? <div class="gsv-tg-desc">{description}</div> : null}
       <label class={rootClass}>
         <input
+          aria-describedby={hasStat ? `${fieldId}-msg` : undefined}
+          aria-invalid={status === "error" ? true : undefined}
           checked={on}
           class="gsv-tg-input"
           disabled={disabled}
@@ -70,7 +74,7 @@ export function Toggle(props: ToggleProps) {
       {hasStat ? (
         <div class="gsv-tg-stat">
           <span class="gsv-tg-dot" />
-          <span class="gsv-tg-msg">{message}</span>
+          <span class="gsv-tg-msg" id={`${fieldId}-msg`}>{message}</span>
         </div>
       ) : null}
     </div>

--- a/web/src/app/components/ui/Tooltip.css
+++ b/web/src/app/components/ui/Tooltip.css
@@ -5,11 +5,21 @@
   font-family: var(--gsv-font-mono);
 }
 .gsv-tt-trigger {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: default;
   font-size: 11px;
   letter-spacing: 0.06em;
   color: #b3aeff;
   border-bottom: 1px dashed #6b62c4;
   cursor: help;
+}
+.gsv-tt-trigger:focus-visible {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: 2px;
 }
 .gsv-tt-bub {
   position: absolute;
@@ -28,7 +38,8 @@
   pointer-events: none;
   transition: opacity 0.12s ease, transform 0.12s ease;
 }
-.gsv-tt:hover .gsv-tt-bub {
+.gsv-tt:hover .gsv-tt-bub,
+.gsv-tt:focus-within .gsv-tt-bub {
   opacity: 1;
 }
 .gsv-tt-arrow {
@@ -45,7 +56,8 @@
   margin-bottom: 9px;
   transform: translateX(-50%) translateY(4px);
 }
-.gsv-tt-top:hover .gsv-tt-bub {
+.gsv-tt-top:hover .gsv-tt-bub,
+.gsv-tt-top:focus-within .gsv-tt-bub {
   transform: translateX(-50%) translateY(0);
 }
 .gsv-tt-top .gsv-tt-arrow {
@@ -61,7 +73,8 @@
   margin-top: 9px;
   transform: translateX(-50%) translateY(-4px);
 }
-.gsv-tt-bottom:hover .gsv-tt-bub {
+.gsv-tt-bottom:hover .gsv-tt-bub,
+.gsv-tt-bottom:focus-within .gsv-tt-bub {
   transform: translateX(-50%) translateY(0);
 }
 .gsv-tt-bottom .gsv-tt-arrow {
@@ -77,7 +90,8 @@
   margin-right: 9px;
   transform: translateY(-50%) translateX(4px);
 }
-.gsv-tt-left:hover .gsv-tt-bub {
+.gsv-tt-left:hover .gsv-tt-bub,
+.gsv-tt-left:focus-within .gsv-tt-bub {
   transform: translateY(-50%) translateX(0);
 }
 .gsv-tt-left .gsv-tt-arrow {
@@ -93,7 +107,8 @@
   margin-left: 9px;
   transform: translateY(-50%) translateX(-4px);
 }
-.gsv-tt-right:hover .gsv-tt-bub {
+.gsv-tt-right:hover .gsv-tt-bub,
+.gsv-tt-right:focus-within .gsv-tt-bub {
   transform: translateY(-50%) translateX(0);
 }
 .gsv-tt-right .gsv-tt-arrow {

--- a/web/src/app/components/ui/Tooltip.tsx
+++ b/web/src/app/components/ui/Tooltip.tsx
@@ -1,3 +1,4 @@
+import { useId } from "preact/hooks";
 import "./Tooltip.css";
 
 export type TooltipPosition = "top" | "bottom" | "left" | "right";
@@ -22,10 +23,13 @@ export function Tooltip({
   text = "A short hint about this control.",
   position = "top",
 }: TooltipProps) {
+  const bubbleId = useId();
   return (
     <span class={`gsv-tt ${POS_CLASS[position]}`}>
-      <span class="gsv-tt-trigger">{trigger}</span>
-      <span class="gsv-tt-bub">
+      <button type="button" class="gsv-tt-trigger" aria-describedby={bubbleId}>
+        {trigger}
+      </button>
+      <span class="gsv-tt-bub" id={bubbleId} role="tooltip">
         {text}
         <span class="gsv-tt-arrow" />
       </span>

--- a/web/src/app/features/session/LoginScreen.tsx
+++ b/web/src/app/features/session/LoginScreen.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "preact/hooks";
+import { useState } from "preact/hooks";
 import { SectionHeader } from "../../components/ui/SectionHeader";
 import { TextInput } from "../../components/ui/TextInput";
 import { Button } from "../../components/ui/Button";
@@ -52,7 +52,6 @@ export function LoginScreen({
   onSubmit,
 }: LoginScreenProps) {
   const [showToken, setShowToken] = useState(false);
-  const formRef = useRef<HTMLFormElement>(null);
 
   return (
     <AuthLayout background="galaxy" visible={visible}>
@@ -65,7 +64,7 @@ export function LoginScreen({
             {loading ? (
               <LoginSkeleton />
             ) : (
-              <form ref={formRef} class="gsv-login-fields" onSubmit={onSubmit}>
+              <form class="gsv-login-fields" onSubmit={onSubmit}>
               <TextInput
                 label="USERNAME"
                 placeholder="e.g. captain"
@@ -116,7 +115,7 @@ export function LoginScreen({
                   label="SIGN IN"
                   block
                   disabled={busy}
-                  onClick={() => formRef.current?.requestSubmit()}
+                  type="submit"
                 />
               </div>
               </form>


### PR DESCRIPTION
## Summary

An accessibility audit of the design-system UI primitives against the [a11yproject checklist](https://www.a11yproject.com/checklist/), focused on **essential support**. Prompted by a regression where the login **"Sign in" button stopped responding to Enter**.

All changes are either invisible (ARIA attributes) or keyboard-only (`:focus-visible` rings appear only on keyboard focus). **No visual changes for mouse users** — verified the one risky spot (Select hover) and scoped it to keyboard-only.

## The Enter-to-submit fix
Root cause: `Button` hardcoded `type="button"`, so the login `<form>` had no submit control and HTML implicit submission never fired. `Button` now takes a `type` prop and the SIGN IN button is a real `type="submit"`.

## Changes by priority

**P0 — keyboard operability** (were mouse-only `<div>`s)
- **IconButton** `<div>` → `<button>` (window controls now focusable + Enter/Space)
- **Tabs** → `role="tablist"`/`tab`, roving tabindex, arrow/Home/End nav, `aria-selected`
- **Slider** → `role="slider"`, arrow/Home/End/PageUp-Down keys, `aria-valuenow/min/max`

**P1 — form semantics & custom widgets**
- **TextInput/TextArea/Select/Radio/Segmented/Slider/Counter** → programmatic label/description/status association (`aria-labelledby`/`describedby`/`aria-invalid`)
- **Radio** + **Segmented** → real `radiogroup`s with arrow-key navigation
- **Select** → `listbox`/`option` semantics, `aria-expanded`/`haspopup`, Escape, arrow nav, focus return
- **ConfirmModal** → `role="dialog"` + `aria-modal`, Escape, focus trap, initial focus
- **IconMenu** → dialog semantics, Escape, focus-first-item, close `aria-label`
- **Counter** → `aria-label`led −/+ buttons, `aria-live` value

**P2**
- **Tooltip** → focusable trigger, reveals on focus (WCAG 1.4.13)
- **Checkbox** → native `.indeterminate`; **Stepper** → `aria-current="step"`
- Decorative SVGs marked `aria-hidden`; `:focus-visible` rings added throughout

## Verification
- `tsc --noEmit` ✅ &nbsp; `vite build` ✅
- Login renders with no console errors; SIGN IN confirmed `type="submit"`; input labels resolve via `aria-labelledby`

## Follow-up
The restyled auth screens on `design-system-register` (`AuthLayout`, Setup wizard) inherit the `Button` fix automatically but their submit buttons still need the same `type="submit"` flip once that branch merges.
