### PR TITLE
Messengers redesign: Telegram + Discord connect flows, card grid, family status

### DIFF
--- a/gateway/wrangler.jsonc
+++ b/gateway/wrangler.jsonc
@@ -57,9 +57,9 @@
 	// Channel service bindings (Gateway → Channel RPC)
 	"services": [
 		{
-			"binding": "CHANNEL_WHATSAPP",
-			"service": "gsv-channel-whatsapp",
-			"entrypoint": "WhatsAppChannelEntrypoint"
+			"binding": "CHANNEL_TELEGRAM",
+			"service": "gsv-channel-telegram",
+			"entrypoint": "TelegramChannel"
 		},
 		{
 			"binding": "CHANNEL_DISCORD",

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -7,13 +7,13 @@ STATE_ROOT="$ROOT_DIR/.wrangler/dev-state/v3"
 mkdir -p "$STATE_ROOT/do/ripgit-Repository"
 mkdir -p "$STATE_ROOT/do/gsv-Kernel"
 mkdir -p "$STATE_ROOT/do/gsv-Process"
-mkdir -p "$STATE_ROOT/do/gsv-channel-whatsapp-WhatsAppAccount"
+mkdir -p "$STATE_ROOT/do/gsv-channel-telegram-TelegramAccount"
 
 cd "$ROOT_DIR/ripgit"
 exec npm exec -- wrangler dev \
   -c ../gateway/wrangler.jsonc \
   -c ../assembler/wrangler.toml \
-  -c ../adapters/whatsapp/wrangler.jsonc \
+  -c ../adapters/telegram/wrangler.jsonc \
   -c wrangler.toml \
   --ip 0.0.0.0 \
   --persist-to ../.wrangler/dev-state

--- a/web/src/app/components/ui/Link.css
+++ b/web/src/app/components/ui/Link.css
@@ -1,0 +1,39 @@
+.gsv-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--link, #8fb6ff);
+  font-family: var(--gsv-font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.gsv-link-label {
+  border-bottom: 1px solid var(--link, #8fb6ff);
+  padding-bottom: 2px;
+  transition: border-color 120ms ease;
+}
+
+.gsv-link:hover,
+.gsv-link:focus-visible {
+  color: var(--link-hover, #b8d2ff);
+}
+
+.gsv-link:hover .gsv-link-label,
+.gsv-link:focus-visible .gsv-link-label {
+  border-color: var(--link-hover, #b8d2ff);
+}
+
+.gsv-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 1px;
+}
+
+.gsv-link-arrow {
+  font-size: 12px;
+  line-height: 1;
+}

--- a/web/src/app/components/ui/Link.tsx
+++ b/web/src/app/components/ui/Link.tsx
@@ -1,0 +1,34 @@
+import type { ComponentChildren } from "preact";
+import "./Link.css";
+
+export interface LinkProps {
+  href: string;
+  children: ComponentChildren;
+  /** Open in a new tab with a safe `rel`. Defaults to true for http(s) URLs. */
+  external?: boolean;
+  /** Render a trailing arrow glyph (for "read more"-style links). */
+  arrow?: boolean;
+  className?: string;
+  onClick?: () => void;
+}
+
+/** Link — the design system's text link / anchor primitive. Token-styled
+ *  (accent colour + underline rule, focus-visible ring) and, unlike
+ *  `Button variant="link"`, it is a real `<a href>` so external destinations,
+ *  middle-click, and right-click "open in new tab" all behave natively. */
+export function Link({ href, children, external, arrow = false, className = "", onClick }: LinkProps) {
+  const isExternal = external ?? /^https?:\/\//i.test(href);
+  const cls = ["gsv-link", className].filter(Boolean).join(" ");
+
+  return (
+    <a
+      class={cls}
+      href={href}
+      onClick={onClick}
+      {...(isExternal ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+    >
+      <span class="gsv-link-label">{children}</span>
+      {arrow ? <span class="gsv-link-arrow" aria-hidden="true">→</span> : null}
+    </a>
+  );
+}

--- a/web/src/app/components/ui/SectionHeader.tsx
+++ b/web/src/app/components/ui/SectionHeader.tsx
@@ -69,7 +69,7 @@ export function SectionHeader({
         {title}
       </span>
       {hasMeta ? (
-        <span class="gsv-section-header-meta" style={{ marginLeft: "auto", fontSize: "10px", letterSpacing: ".16em", color: "#7d78b8" }}>{meta}</span>
+        <span class="gsv-section-header-meta" style={{ marginLeft: "auto", fontSize: "10px", letterSpacing: ".16em", color: "var(--meta)" }}>{meta}</span>
       ) : null}
       {chevron ? <span class="gsv-section-header-chevron" aria-hidden="true" /> : null}
     </>

--- a/web/src/app/features/gsv-console/components/ConsoleDetailHeader.tsx
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailHeader.tsx
@@ -1,0 +1,32 @@
+import { Icon } from "../../../components/ui/Icon";
+import { StatusDot, type StatusTone } from "../../../components/ui/StatusDot";
+import "./ConsoleDetailPage.css";
+
+export type ConsoleDetailHeaderProps = {
+  icon: string;
+  title: string;
+  typeLabel: string;
+  statusLabel: string;
+  tone: StatusTone;
+};
+
+/** The standard console object-detail header: framed icon + title + a
+ *  type-label / status row. Shared by ConsoleDetailPage and the messenger
+ *  connect flow so they read as the same family. */
+export function ConsoleDetailHeader({ icon, title, typeLabel, statusLabel, tone }: ConsoleDetailHeaderProps) {
+  return (
+    <header class="gsv-console-detail-head">
+      <span class="gsv-console-detail-icon">
+        <Icon name={icon} size={30} />
+      </span>
+      <div class="gsv-console-detail-title">
+        <h2>{title}</h2>
+        <div>
+          <span>{typeLabel}</span>
+          <StatusDot tone={tone} size={7} />
+          <span>{statusLabel}</span>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
@@ -54,8 +54,10 @@
 .gsv-console-detail-title div {
   min-width: 0;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 12px;
+  row-gap: 6px;
   color: #a8a2dc;
   font-size: 10px;
   letter-spacing: 0.16em;
@@ -70,7 +72,7 @@
 .gsv-console-detail-blurb {
   max-width: 640px;
   margin: 0;
-  color: #9089d4;
+  color: var(--prose-dim);
   font-family: var(--gsv-font-prose);
   font-size: 14px;
   line-height: 1.65;

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
@@ -1,9 +1,9 @@
 import type { ComponentChildren } from "preact";
 import { Button } from "../../../components/ui/Button";
-import { Icon } from "../../../components/ui/Icon";
 import { ListRow, type ListRowStatus } from "../../../components/ui/ListRow";
 import { SectionHeader } from "../../../components/ui/SectionHeader";
-import { StatusDot, type StatusTone } from "../../../components/ui/StatusDot";
+import type { StatusTone } from "../../../components/ui/StatusDot";
+import { ConsoleDetailHeader } from "./ConsoleDetailHeader";
 import "./ConsoleDetailPage.css";
 
 export type ConsoleDetailRow = {
@@ -59,19 +59,13 @@ export function ConsoleDetailPage({
   return (
     <section class="gsv-console-detail-page">
       <div class="gsv-console-detail-shell">
-        <header class="gsv-console-detail-head">
-          <span class="gsv-console-detail-icon">
-            <Icon name={icon} size={30} />
-          </span>
-          <div class="gsv-console-detail-title">
-            <h2>{title}</h2>
-            <div>
-              <span>{typeLabel}</span>
-              <StatusDot tone={tone} size={7} />
-              <span>{statusLabel}</span>
-            </div>
-          </div>
-        </header>
+        <ConsoleDetailHeader
+          icon={icon}
+          title={title}
+          typeLabel={typeLabel}
+          statusLabel={statusLabel}
+          tone={tone}
+        />
 
         <p class="gsv-console-detail-blurb">{blurb}</p>
 

--- a/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.css
+++ b/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.css
@@ -66,22 +66,149 @@
   overflow: hidden;
 }
 
-.gsv-messenger-flow-panel > .gsv-messenger-form-grid,
+.gsv-messenger-flow-panel > .gsv-messenger-steps,
+.gsv-messenger-flow-panel > .gsv-messenger-caps,
+.gsv-messenger-flow-panel > .gsv-messenger-success-lede,
 .gsv-messenger-flow-panel > .gsv-messenger-form-note,
 .gsv-messenger-flow-panel > .gsv-messenger-form-error,
-.gsv-messenger-flow-panel > .gsv-messenger-challenge,
 .gsv-messenger-flow-panel > p {
   margin-inline: 22px;
 }
 
-.gsv-messenger-form-grid {
+/* Numbered prep steps + token field */
+.gsv-messenger-steps {
   display: grid;
-  gap: 18px;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
-.gsv-messenger-form-grid .lr {
-  border: 1px solid var(--rule-inner) !important;
-  background: rgba(11, 8, 30, 0.48) !important;
+.gsv-messenger-step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.gsv-messenger-step-num {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  border: 1px solid var(--rule-inner);
+  background: rgba(11, 8, 30, 0.48);
+  color: var(--accent);
+  font-family: var(--gsv-font-mono);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.gsv-messenger-step-body {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.gsv-messenger-step-title {
+  color: var(--text-hi);
+  font-family: var(--gsv-font-mono);
+  font-size: 12.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.gsv-messenger-step-text {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--label);
+  font-family: var(--gsv-font-prose);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.gsv-messenger-step-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+}
+
+.gsv-messenger-token-field {
+  margin-top: 4px;
+}
+
+/* Help links */
+.gsv-messenger-help-link {
+  display: inline-flex;
+  align-items: center;
+  color: var(--accent);
+  font-family: var(--gsv-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  padding-bottom: 1px;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+
+.gsv-messenger-help-link:hover,
+.gsv-messenger-help-link:focus-visible {
+  color: var(--text-hi);
+  border-bottom-color: var(--text-hi);
+  outline: none;
+}
+
+/* Success — capabilities */
+.gsv-messenger-success-lede {
+  margin: 0;
+  color: var(--label);
+  font-family: var(--gsv-font-prose);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.gsv-messenger-caps {
+  display: grid;
+  gap: 14px;
+}
+
+.gsv-messenger-caps-title {
+  color: var(--text-hi);
+  font-family: var(--gsv-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.gsv-messenger-caps-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.gsv-messenger-caps-list li {
+  display: grid;
+  gap: 3px;
+  padding: 12px 14px;
+  border: 1px solid var(--rule-inner);
+  background: rgba(11, 8, 30, 0.48);
+}
+
+.gsv-messenger-cap-title {
+  color: var(--text-hi);
+  font-family: var(--gsv-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+.gsv-messenger-cap-detail {
+  color: var(--label);
+  font-family: var(--gsv-font-prose);
+  font-size: 12.5px;
+  line-height: 1.45;
 }
 
 .gsv-messenger-form-note,
@@ -98,39 +225,6 @@
 
 .gsv-messenger-form-error {
   color: var(--error);
-}
-
-.gsv-messenger-challenge {
-  display: grid;
-  gap: 16px;
-  padding: 18px;
-}
-
-.gsv-messenger-challenge p,
-.gsv-messenger-challenge small {
-  margin: 0;
-  color: #9d96d8;
-  font-family: var(--gsv-font-prose);
-  font-size: 13px;
-  line-height: 1.55;
-}
-
-.gsv-messenger-challenge img {
-  width: min(280px, 100%);
-  image-rendering: pixelated;
-  background: #fff;
-}
-
-.gsv-messenger-challenge pre {
-  max-width: 100%;
-  overflow: auto;
-  margin: 0;
-  padding: 14px;
-  border: 1px solid var(--rule-inner);
-  color: var(--text);
-  background: #08061d;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
 }
 
 .gsv-messenger-flow-actions {
@@ -155,10 +249,11 @@
     grid-column: 2;
   }
 
-  .gsv-messenger-flow-panel > .gsv-messenger-form-grid,
+  .gsv-messenger-flow-panel > .gsv-messenger-steps,
+  .gsv-messenger-flow-panel > .gsv-messenger-caps,
+  .gsv-messenger-flow-panel > .gsv-messenger-success-lede,
   .gsv-messenger-flow-panel > .gsv-messenger-form-note,
   .gsv-messenger-flow-panel > .gsv-messenger-form-error,
-  .gsv-messenger-flow-panel > .gsv-messenger-challenge,
   .gsv-messenger-flow-panel > p {
     margin-inline: 16px;
   }

--- a/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.css
+++ b/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.css
@@ -1,260 +1,132 @@
-.gsv-messenger-onboarding {
+/* Connect messenger bot — object-detail header + a progressive-disclosure
+   wizard (one large, well-spaced step at a time). Header mirrors
+   ConsoleDetailPage so it reads as the same family as the detail pages. */
+.gsv-connect {
+  flex: 1;
+  min-width: 0; /* shrink to the console column instead of min-content */
   min-height: 100%;
-  display: grid;
-  place-items: start center;
-  padding: clamp(18px, 3vw, 34px);
+  background: transparent;
+  /* respond to the column's OWN width, not the viewport (ChatDock/rail vary it) */
+  container-type: inline-size;
+  container-name: connect;
 }
 
-.gsv-messenger-onboarding-shell {
-  width: min(760px, 100%);
-  display: grid;
-  gap: 18px;
+.gsv-connect-shell {
+  width: min(720px, 100%);
+  margin: 0 auto;
+  /* generous bottom room so the in-card footer clears the floating chat dock */
+  padding: 34px 26px 104px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
 }
 
-.gsv-messenger-onboarding-head {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: start;
-  gap: 15px;
-}
+/* Header + blurb use the shared ConsoleDetailHeader / .gsv-console-detail-blurb. */
 
-.gsv-messenger-onboarding-head > div {
-  min-width: 0;
-}
-
-.gsv-messenger-onboarding-kicker {
-  display: block;
-  margin-bottom: 7px;
-  color: var(--accent);
-  font-size: 9px;
-  letter-spacing: 0.18em;
-}
-
-.gsv-messenger-onboarding-head h2 {
-  margin: 0;
-  color: var(--text-hi);
-  font-size: clamp(21px, 3vw, 32px);
-  line-height: 1;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.gsv-messenger-onboarding-head p {
-  margin: 10px 0 0;
-  max-width: 62ch;
-  color: var(--label);
-  font-family: var(--gsv-font-prose);
-  font-size: 13px;
-  line-height: 1.45;
-}
-
-.gsv-messenger-onboarding-stepper {
+/* ── Stepper ──────────────────────────────────────────────────────── */
+.gsv-connect-stepper {
   display: flex;
   justify-content: center;
-  padding: 2px 0 4px;
+  padding: 6px 0 2px;
 }
 
-.gsv-messenger-onboarding-stepper .gsv-sp,
-.gsv-messenger-onboarding-stepper .gsv-sp-step {
-  pointer-events: none;
+/* ── Current step panel (large + spaced) ──────────────────────────── */
+.gsv-connect-step {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-raised);
+  background: var(--panel);
+  box-shadow: inset 0 0 0 1px var(--frame-inset), 0 0 30px rgba(80, 70, 180, 0.1);
 }
 
-.gsv-messenger-flow-panel {
-  display: grid;
-  gap: 22px;
-  padding: 0;
-  overflow: hidden;
-}
-
-.gsv-messenger-flow-panel > .gsv-messenger-steps,
-.gsv-messenger-flow-panel > .gsv-messenger-caps,
-.gsv-messenger-flow-panel > .gsv-messenger-success-lede,
-.gsv-messenger-flow-panel > .gsv-messenger-form-note,
-.gsv-messenger-flow-panel > .gsv-messenger-form-error,
-.gsv-messenger-flow-panel > p {
-  margin-inline: 22px;
-}
-
-/* Numbered prep steps + token field */
-.gsv-messenger-steps {
-  display: grid;
+.gsv-connect-step-body {
+  display: flex;
+  flex-direction: column;
   gap: 20px;
+  min-height: 200px;
+  padding: 32px 36px 36px;
+}
+
+.gsv-connect-step-desc {
   margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.gsv-messenger-step {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 14px;
-  align-items: start;
-}
-
-.gsv-messenger-step-num {
-  display: grid;
-  place-items: center;
-  width: 26px;
-  height: 26px;
-  flex: none;
-  border: 1px solid var(--rule-inner);
-  background: rgba(11, 8, 30, 0.48);
-  color: var(--accent);
-  font-family: var(--gsv-font-mono);
-  font-size: 12px;
-  line-height: 1;
-}
-
-.gsv-messenger-step-body {
-  display: grid;
-  gap: 7px;
-  min-width: 0;
-}
-
-.gsv-messenger-step-title {
-  color: var(--text-hi);
-  font-family: var(--gsv-font-mono);
-  font-size: 12.5px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.gsv-messenger-step-text {
-  margin: 0;
-  max-width: 60ch;
+  max-width: 560px;
   color: var(--label);
   font-family: var(--gsv-font-prose);
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: 14px;
+  line-height: 1.65;
+  text-wrap: pretty;
 }
 
-.gsv-messenger-step-links {
+.gsv-connect-step-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 16px;
-}
-
-.gsv-messenger-token-field {
+  gap: 18px;
   margin-top: 4px;
 }
 
-/* Help links */
-.gsv-messenger-help-link {
-  display: inline-flex;
-  align-items: center;
-  color: var(--accent);
-  font-family: var(--gsv-font-mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-decoration: none;
-  border-bottom: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
-  padding-bottom: 1px;
-  transition: color 0.12s ease, border-color 0.12s ease;
+.gsv-connect-token-field {
+  margin-top: 6px;
+  max-width: 520px;
 }
 
-.gsv-messenger-help-link:hover,
-.gsv-messenger-help-link:focus-visible {
-  color: var(--text-hi);
-  border-bottom-color: var(--text-hi);
-  outline: none;
+/* ── Success step ─────────────────────────────────────────────────── */
+.gsv-connect-caps {
+  display: flex;
+  flex-direction: column;
 }
 
-/* Success — capabilities */
-.gsv-messenger-success-lede {
-  margin: 0;
-  color: var(--label);
-  font-family: var(--gsv-font-prose);
-  font-size: 13px;
-  line-height: 1.5;
+/* ListRow rows sit under the THINGS YOU CAN DO SectionHeader, framed like the
+   detail-page sections (border with the header capping the top). */
+.gsv-connect-caps-rows {
+  border: 1px solid var(--border);
+  border-top: none;
 }
 
-.gsv-messenger-caps {
-  display: grid;
-  gap: 14px;
-}
-
-.gsv-messenger-caps-title {
-  color: var(--text-hi);
-  font-family: var(--gsv-font-mono);
-  font-size: 12px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.gsv-messenger-caps-list {
-  display: grid;
-  gap: 12px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.gsv-messenger-caps-list li {
-  display: grid;
-  gap: 3px;
-  padding: 12px 14px;
-  border: 1px solid var(--rule-inner);
-  background: rgba(11, 8, 30, 0.48);
-}
-
-.gsv-messenger-cap-title {
-  color: var(--text-hi);
-  font-family: var(--gsv-font-mono);
-  font-size: 12px;
-  letter-spacing: 0.04em;
-}
-
-.gsv-messenger-cap-detail {
-  color: var(--label);
-  font-family: var(--gsv-font-prose);
-  font-size: 12.5px;
-  line-height: 1.45;
-}
-
-.gsv-messenger-form-note,
-.gsv-messenger-form-error {
-  margin: 0;
-  font-family: var(--gsv-font-prose);
-  font-size: 13px;
-  line-height: 1.55;
-}
-
-.gsv-messenger-form-note {
-  color: var(--online);
-}
-
-.gsv-messenger-form-error {
-  color: var(--error);
-}
-
-.gsv-messenger-flow-actions {
+/* ── Footer nav — lives INSIDE the card so it can never sit under the
+   floating ChatDock launcher (bottom-right of the viewport). ── */
+.gsv-connect-actions {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 12px;
-  padding: 16px 20px 20px;
-  border-top: 1px solid var(--rule-inner);
+  padding: 18px 36px 20px;
+  border-top: 1px solid var(--border);
 }
 
-@media (max-width: 520px) {
-  .gsv-messenger-onboarding {
-    padding: 18px 14px;
+@container connect (max-width: 680px) {
+  .gsv-connect-shell {
+    padding: 22px 16px 96px;
   }
 
-  .gsv-messenger-onboarding-head {
-    grid-template-columns: auto minmax(0, 1fr);
+  .gsv-connect-step-body {
+    padding: 24px 20px 26px;
   }
 
-  .gsv-messenger-onboarding-head > span:last-child {
-    grid-column: 2;
+  .gsv-connect-actions {
+    flex-direction: column-reverse;
+    padding: 16px 20px 18px;
   }
 
-  .gsv-messenger-flow-panel > .gsv-messenger-steps,
-  .gsv-messenger-flow-panel > .gsv-messenger-caps,
-  .gsv-messenger-flow-panel > .gsv-messenger-success-lede,
-  .gsv-messenger-flow-panel > .gsv-messenger-form-note,
-  .gsv-messenger-flow-panel > .gsv-messenger-form-error,
-  .gsv-messenger-flow-panel > p {
-    margin-inline: 16px;
+  .gsv-connect-actions .gsv-btn {
+    width: 100%;
+  }
+}
+
+/* Below ~520px the four stepper labels collide — keep just the numbered dots. */
+@container connect (max-width: 520px) {
+  .gsv-connect-stepper .gsv-sp-label {
+    display: none;
+  }
+
+  .gsv-connect-shell {
+    padding: 20px 14px 96px;
+  }
+
+  .gsv-connect-step-body {
+    padding: 22px 16px 24px;
+  }
+
+  .gsv-connect-actions {
+    padding: 16px 16px 18px;
   }
 }

--- a/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
@@ -8,8 +8,8 @@ import { SectionHeader } from "../../../components/ui/SectionHeader";
 import { Stepper } from "../../../components/ui/Stepper";
 import { TextInput } from "../../../components/ui/TextInput";
 import { ConsoleDetailHeader } from "../components/ConsoleDetailHeader";
-import type { ConnectConsoleAdapterResult } from "../backend/consoleService";
-import { useConnectConsoleAdapter } from "../hooks/useConsoleData";
+import type { ConnectConsoleAdapterResult, IdentityLinkMutationResult } from "../backend/consoleService";
+import { useConnectConsoleAdapter, useConsumeIdentityLinkCode } from "../hooks/useConsoleData";
 import { BOTFATHER_URL, DISCORD_DEVELOPER_URL, MESSENGER_CAPABILITIES, adapterDocUrl } from "./messengerDocs";
 import { adapterDetailId, adapterName, deriveTelegramAccountId, iconForAdapterName } from "./messengerPresentation";
 import "./MessengerOnboardingFlow.css";
@@ -24,10 +24,16 @@ type MessengerOnboardingFlowProps = {
 const STEP_CREATE = 0;
 const STEP_TOKEN = 1;
 const STEP_CONNECT = 2;
-const STEP_ONLINE = 3;
+const STEP_LINK = 3;
 
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : error ? String(error) : "";
+}
+
+function linkedText(result: IdentityLinkMutationResult): string {
+  return result.link
+    ? `${adapterName(result.link.adapter)} / ${result.link.actorId}`
+    : "Messenger identity";
 }
 
 export function MessengerOnboardingFlow({
@@ -36,16 +42,22 @@ export function MessengerOnboardingFlow({
   onConnected,
 }: MessengerOnboardingFlowProps): JSX.Element {
   const connect = useConnectConsoleAdapter();
+  const consumeLinkCode = useConsumeIdentityLinkCode();
   const [step, setStep] = useState(STEP_CREATE);
   const [token, setToken] = useState("");
+  const [linkCode, setLinkCode] = useState("");
   const [result, setResult] = useState<ConnectConsoleAdapterResult | null>(null);
   const [formError, setFormError] = useState("");
+  const [linkError, setLinkError] = useState("");
+  const [linkResultText, setLinkResultText] = useState("");
 
   const isTelegram = adapterId === "telegram";
   const name = adapterName(adapterId);
   const docUrl = adapterDocUrl(adapterId);
-  const connected = step === STEP_ONLINE;
+  const botConnected = Boolean(result?.ok);
+  const linked = linkResultText.length > 0;
   const canSubmit = token.trim().length > 0 && !connect.isPending;
+  const canLinkUser = botConnected && linkCode.trim().length > 0 && !consumeLinkCode.isPending;
   // Steps 1-2 are performed on the messaging platform; 3-4 happen inside GSV.
   const onPlatform = step <= STEP_TOKEN;
 
@@ -58,7 +70,7 @@ export function MessengerOnboardingFlow({
     setStep((current) => current - 1);
   };
   const goToStep = (target: number) => {
-    if (connected || target >= step) return;
+    if (linked || target >= step) return;
     setStep(target);
   };
 
@@ -76,12 +88,30 @@ export function MessengerOnboardingFlow({
       });
       if (next.ok) {
         setResult(next);
-        setStep(STEP_ONLINE);
+        setLinkCode("");
+        setLinkError("");
+        setLinkResultText("");
+        setStep(STEP_LINK);
         return;
       }
       setFormError(next.error || next.message);
     } catch (error) {
       setFormError(errorText(error));
+    }
+  };
+
+  const submitLinkCode = async () => {
+    if (!canLinkUser) {
+      return;
+    }
+    setLinkError("");
+    setLinkResultText("");
+    try {
+      const next = await consumeLinkCode.mutateAsync({ code: linkCode });
+      setLinkCode("");
+      setLinkResultText(linkedText(next));
+    } catch (error) {
+      setLinkError(errorText(error));
     }
   };
 
@@ -109,7 +139,7 @@ export function MessengerOnboardingFlow({
         ? "Generate an access token"
         : step === STEP_CONNECT
           ? "Insert your access token"
-          : "Messenger-bot online!";
+          : "Link your GSV user";
 
   return (
     <section class="gsv-connect">
@@ -118,8 +148,8 @@ export function MessengerOnboardingFlow({
           icon={iconForAdapterName(adapterId)}
           title={`Connect ${name} bot`}
           typeLabel={`${name.toUpperCase()} · NEW MESSENGER`}
-          statusLabel={connected ? "CONNECTED" : "NOT CONNECTED"}
-          tone={connected ? "online" : "idle"}
+          statusLabel={linked ? "LINKED" : botConnected ? "CONNECTED" : "NOT CONNECTED"}
+          tone={botConnected ? "online" : "idle"}
         />
 
         <p class="gsv-console-detail-blurb">
@@ -133,7 +163,7 @@ export function MessengerOnboardingFlow({
             l0="CREATE BOT"
             l1="GET TOKEN"
             l2="CONNECT"
-            l3="ONLINE"
+            l3="LINK USER"
             size="medium"
             width={520}
             onChange={goToStep}
@@ -143,7 +173,7 @@ export function MessengerOnboardingFlow({
         <div class="gsv-connect-step">
           <SectionHeader
             title={stepTitle}
-            meta={onPlatform ? `IN ${name.toUpperCase()}` : "IN GSV"}
+            meta={step === STEP_LINK ? "FINALIZE" : onPlatform ? `IN ${name.toUpperCase()}` : "IN GSV"}
             divider
           />
           <div class="gsv-connect-step-body">
@@ -206,35 +236,84 @@ export function MessengerOnboardingFlow({
             ) : (
               <>
                 <p class="gsv-connect-step-desc">
-                  Your {name} bot is connected. Start messaging your GSV — open a chat and ask it to message your bot,
-                  or message the bot directly.
+                  Your {name} bot account has been created. Message the bot from the user account you want to link,
+                  then paste the authorization code it sends back.
                 </p>
-                <div class="gsv-connect-caps">
-                  <SectionHeader title="THINGS YOU CAN DO" titleSize="section" divider />
-                  <div class="gsv-connect-caps-rows">
-                    {MESSENGER_CAPABILITIES.map((cap) => (
-                      <ListRow key={cap.title} label={cap.title} sub={cap.detail} status="none" />
-                    ))}
+                <Alert
+                  variant={linked ? "success" : "attention"}
+                  title={linked ? "USER LINKED" : `MESSAGE YOUR ${name.toUpperCase()} BOT`}
+                  text={linked
+                    ? `${linkResultText} can now authenticate with this GSV.`
+                    : "Send the bot a message, wait for its link code response, and enter that code here to finish setup."}
+                />
+                {!linked ? (
+                  <div class="gsv-connect-token-field">
+                    <TextInput
+                      label="AUTHORIZATION CODE"
+                      size="large"
+                      requirement="required"
+                      value={linkCode}
+                      placeholder="ABC123"
+                      clearable
+                      status={linkError ? "error" : "none"}
+                      message={linkError}
+                      onChange={(value) => {
+                        if (linkError) setLinkError("");
+                        setLinkCode(value);
+                      }}
+                      inputProps={{
+                        autoComplete: "one-time-code",
+                        name: "messengerIdentityLinkCode",
+                        onKeyDown: (event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            void submitLinkCode();
+                          }
+                        },
+                      }}
+                    />
                   </div>
-                </div>
-                <div class="gsv-connect-step-links">
-                  <Link href={docUrl} arrow>Read the docs</Link>
-                </div>
-                {result?.challenge ? (
-                  <Alert
-                    variant="warning"
-                    text="This adapter returned an extra authentication step — open the bot detail to finish it."
-                  />
+                ) : null}
+                {linked ? (
+                  <>
+                    <div class="gsv-connect-caps">
+                      <SectionHeader title="THINGS YOU CAN DO" titleSize="section" divider />
+                      <div class="gsv-connect-caps-rows">
+                        {MESSENGER_CAPABILITIES.map((cap) => (
+                          <ListRow key={cap.title} label={cap.title} sub={cap.detail} status="none" />
+                        ))}
+                      </div>
+                    </div>
+                    <div class="gsv-connect-step-links">
+                      <Link href={docUrl} arrow>Read the docs</Link>
+                    </div>
+                    {result?.challenge ? (
+                      <Alert
+                        variant="warning"
+                        text="This adapter returned an extra authentication step — open the bot detail to finish it."
+                      />
+                    ) : null}
+                  </>
                 ) : null}
               </>
             )}
           </div>
 
           <div class="gsv-connect-actions">
-            {step === STEP_ONLINE ? (
+            {step === STEP_LINK && linked ? (
               <>
                 <Button variant="secondary" label="VIEW BOT" onClick={goToDetail} />
                 <Button variant="primary" label="DONE" onClick={onBack} />
+              </>
+            ) : step === STEP_LINK ? (
+              <>
+                <Button variant="secondary" label="BACK" disabled={consumeLinkCode.isPending} onClick={goBack} />
+                <Button
+                  variant="primary"
+                  label={consumeLinkCode.isPending ? "LINKING" : "LINK USER"}
+                  disabled={!canLinkUser}
+                  onClick={submitLinkCode}
+                />
               </>
             ) : step === STEP_CONNECT ? (
               <>

--- a/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
@@ -1,16 +1,17 @@
 import type { JSX } from "preact";
 import { useState } from "preact/hooks";
+import { Alert } from "../../../components/ui/Alert";
 import { Button } from "../../../components/ui/Button";
-import { IconButton } from "../../../components/ui/IconButton";
+import { Link } from "../../../components/ui/Link";
+import { ListRow } from "../../../components/ui/ListRow";
 import { SectionHeader } from "../../../components/ui/SectionHeader";
 import { Stepper } from "../../../components/ui/Stepper";
-import { Surface } from "../../../components/ui/Surface";
-import { Tag } from "../../../components/ui/Tag";
 import { TextInput } from "../../../components/ui/TextInput";
+import { ConsoleDetailHeader } from "../components/ConsoleDetailHeader";
 import type { ConnectConsoleAdapterResult } from "../backend/consoleService";
 import { useConnectConsoleAdapter } from "../hooks/useConsoleData";
 import { BOTFATHER_URL, MESSENGER_CAPABILITIES, adapterDocUrl } from "./messengerDocs";
-import { adapterDetailId, adapterName, deriveTelegramAccountId } from "./messengerPresentation";
+import { adapterDetailId, adapterName, deriveTelegramAccountId, iconForAdapterName } from "./messengerPresentation";
 import "./MessengerOnboardingFlow.css";
 
 type MessengerOnboardingFlowProps = {
@@ -19,16 +20,14 @@ type MessengerOnboardingFlowProps = {
   onConnected: (detailId: string) => void;
 };
 
+/** Step indices for the progressive-disclosure wizard. */
+const STEP_CREATE = 0;
+const STEP_TOKEN = 1;
+const STEP_CONNECT = 2;
+const STEP_ONLINE = 3;
+
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : error ? String(error) : "";
-}
-
-function HelpLink({ href, label }: { href: string; label: string }): JSX.Element {
-  return (
-    <a class="gsv-messenger-help-link" href={href} target="_blank" rel="noreferrer">
-      {label}
-    </a>
-  );
 }
 
 export function MessengerOnboardingFlow({
@@ -37,6 +36,7 @@ export function MessengerOnboardingFlow({
   onConnected,
 }: MessengerOnboardingFlowProps): JSX.Element {
   const connect = useConnectConsoleAdapter();
+  const [step, setStep] = useState(STEP_CREATE);
   const [token, setToken] = useState("");
   const [result, setResult] = useState<ConnectConsoleAdapterResult | null>(null);
   const [formError, setFormError] = useState("");
@@ -44,15 +44,29 @@ export function MessengerOnboardingFlow({
   const isTelegram = adapterId === "telegram";
   const name = adapterName(adapterId);
   const docUrl = adapterDocUrl(adapterId);
-  const connected = Boolean(result?.ok);
+  const connected = step === STEP_ONLINE;
   const canSubmit = token.trim().length > 0 && !connect.isPending;
+  // Steps 1-2 are performed on the messaging platform; 3-4 happen inside GSV.
+  const onPlatform = step <= STEP_TOKEN;
+
+  const goNext = () => setStep((current) => Math.min(current + 1, STEP_CONNECT));
+  const goBack = () => {
+    if (step === STEP_CREATE) {
+      onBack();
+      return;
+    }
+    setStep((current) => current - 1);
+  };
+  const goToStep = (target: number) => {
+    if (connected || target >= step) return;
+    setStep(target);
+  };
 
   const submit = async () => {
     if (!canSubmit) {
       return;
     }
     setFormError("");
-    setResult(null);
     try {
       const accountId = isTelegram ? deriveTelegramAccountId(token) : "main";
       const next = await connect.mutateAsync({
@@ -62,6 +76,7 @@ export function MessengerOnboardingFlow({
       });
       if (next.ok) {
         setResult(next);
+        setStep(STEP_ONLINE);
         return;
       }
       setFormError(next.error || next.message);
@@ -87,138 +102,156 @@ export function MessengerOnboardingFlow({
     }));
   };
 
-  return (
-    <section class="gsv-messenger-onboarding">
-      <div class="gsv-messenger-onboarding-shell">
-        <header class="gsv-messenger-onboarding-head">
-          <IconButton glyph="arrowBack" size="medium" title="Back to messengers" onClick={onBack} />
-          <div>
-            <span class="gsv-messenger-onboarding-kicker">FLEET / NEW MESSENGER</span>
-            <h2>Connect {name}</h2>
-            <p>Link a {name} bot to your GSV so you can message it from anywhere.</p>
-          </div>
-          <Tag tone={connected ? "online" : "idle"} label={connected ? "CONNECTED" : "NOT CONNECTED"} boxed dot />
-        </header>
+  const stepTitle =
+    step === STEP_CREATE
+      ? "Create your GSV messenger bot"
+      : step === STEP_TOKEN
+        ? "Generate an access token"
+        : step === STEP_CONNECT
+          ? "Insert your access token"
+          : "Messenger-bot online!";
 
-        <div class="gsv-messenger-onboarding-stepper" aria-label="Messenger connection progress">
+  return (
+    <section class="gsv-connect">
+      <div class="gsv-connect-shell">
+        <ConsoleDetailHeader
+          icon={iconForAdapterName(adapterId)}
+          title="Connect messenger bot"
+          typeLabel={`${name.toUpperCase()} · NEW MESSENGER`}
+          statusLabel={connected ? "CONNECTED" : "NOT CONNECTED"}
+          tone={connected ? "online" : "idle"}
+        />
+
+        <p class="gsv-console-detail-blurb">
+          Link a {name} bot to your GSV so you can check files, approve tasks, and stay in control from anywhere.
+        </p>
+
+        <div class="gsv-connect-stepper" aria-label="Connection progress">
           <Stepper
             count={4}
-            current={connected ? 3 : 2}
+            current={step}
             l0="CREATE BOT"
             l1="GET TOKEN"
             l2="CONNECT"
             l3="ONLINE"
-            width={440}
-            size="small"
+            size="medium"
+            width={520}
+            onChange={goToStep}
           />
         </div>
 
-        {connected ? (
-          <Surface class="gsv-messenger-flow-panel" level={2}>
-            <SectionHeader title="MESSENGER-BOT ONLINE" meta={name.toUpperCase()} divider />
-            <p class="gsv-messenger-success-lede">
-              Your {name} messenger-bot is connected. Start messaging your GSV.
-            </p>
-            <div class="gsv-messenger-caps">
-              <span class="gsv-messenger-caps-title">Things you can do with your messenger-bot</span>
-              <ul class="gsv-messenger-caps-list">
-                {MESSENGER_CAPABILITIES.map((cap) => (
-                  <li key={cap.title}>
-                    <span class="gsv-messenger-cap-title">{cap.title}</span>
-                    <span class="gsv-messenger-cap-detail">{cap.detail}</span>
-                  </li>
-                ))}
-              </ul>
-              <HelpLink href={docUrl} label="Read the docs" />
-            </div>
-            {result?.message ? <p class="gsv-messenger-form-note">{result.message}</p> : null}
-            {result?.challenge ? (
-              <p class="gsv-messenger-form-note">
-                This adapter returned an extra authentication step — open the bot detail to finish it.
-              </p>
-            ) : null}
-            <div class="gsv-messenger-flow-actions">
-              <Button variant="secondary" label="VIEW BOT" onClick={goToDetail} />
-              <Button variant="primary" label="DONE" onClick={onBack} />
-            </div>
-          </Surface>
-        ) : (
-          <Surface class="gsv-messenger-flow-panel" level={2}>
-            <SectionHeader title="CONNECT BOT" meta={name.toUpperCase()} divider />
-
-            <ol class="gsv-messenger-steps">
-              <li class="gsv-messenger-step">
-                <span class="gsv-messenger-step-num">1</span>
-                <div class="gsv-messenger-step-body">
-                  <span class="gsv-messenger-step-title">Create your GSV messenger-bot</span>
-                  <p class="gsv-messenger-step-text">
-                    {isTelegram
-                      ? "Open BotFather and create a new bot for your GSV."
-                      : "Create a new bot application in the Discord developer portal."}
-                  </p>
-                  <div class="gsv-messenger-step-links">
-                    {isTelegram ? <HelpLink href={BOTFATHER_URL} label="Open BotFather" /> : null}
-                    <HelpLink href={docUrl} label="Don't know how? Find help here" />
-                  </div>
-                </div>
-              </li>
-
-              <li class="gsv-messenger-step">
-                <span class="gsv-messenger-step-num">2</span>
-                <div class="gsv-messenger-step-body">
-                  <span class="gsv-messenger-step-title">Generate an access token to connect your bot to GSV</span>
-                  <p class="gsv-messenger-step-text">
-                    {isTelegram
-                      ? "BotFather hands you an access token once the bot is created. Copy it."
-                      : "In the bot settings, create a token and copy it."}
-                  </p>
-                  <div class="gsv-messenger-step-links">
-                    <HelpLink href={docUrl} label="Don't know how? Find help here" />
-                  </div>
-                </div>
-              </li>
-
-              <li class="gsv-messenger-step">
-                <span class="gsv-messenger-step-num">3</span>
-                <div class="gsv-messenger-step-body">
-                  <span class="gsv-messenger-step-title">Insert your access token</span>
-                  <p class="gsv-messenger-step-text">Paste the token below and connect.</p>
-                  <div class="gsv-messenger-token-field">
-                    <TextInput
-                      label="ACCESS TOKEN"
-                      requirement="required"
-                      value={token}
-                      placeholder="123456789:AA…"
-                      type="password"
-                      clearable
-                      status={formError ? "error" : "none"}
-                      message={formError}
-                      onChange={(value) => {
-                        if (formError) setFormError("");
-                        setToken(value);
-                      }}
-                      inputProps={{ name: "botToken", autoComplete: "off" }}
-                    />
-                  </div>
-                </div>
-              </li>
-            </ol>
-
-            {connect.error && !formError ? (
-              <p class="gsv-messenger-form-error">{errorText(connect.error)}</p>
-            ) : null}
-
-            <div class="gsv-messenger-flow-actions">
-              <Button variant="secondary" label="BACK" disabled={connect.isPending} onClick={onBack} />
-              <Button
-                variant="primary"
-                label={connect.isPending ? "CONNECTING" : "CONNECT"}
-                disabled={!canSubmit}
-                onClick={submit}
+        <div class="gsv-connect-step">
+          <SectionHeader
+            title={stepTitle}
+            meta={onPlatform ? `IN ${name.toUpperCase()}` : "IN GSV"}
+            divider
+          />
+          <div class="gsv-connect-step-body">
+            {onPlatform ? (
+              <Alert
+                variant="attention"
+                text={`Do this step in ${name} — finish it there, then come back to GSV to continue.`}
               />
-            </div>
-          </Surface>
-        )}
+            ) : null}
+
+            {step === STEP_CREATE ? (
+              <>
+                <p class="gsv-connect-step-desc">
+                  {isTelegram
+                    ? "Open BotFather in Telegram and create a new bot to act as your GSV's messenger."
+                    : "Create a new bot application in the Discord developer portal to act as your GSV's messenger."}
+                </p>
+                <div class="gsv-connect-step-links">
+                  {isTelegram ? <Link href={BOTFATHER_URL}>Open BotFather</Link> : null}
+                  <Link href={docUrl} arrow>Need help? Documentation</Link>
+                </div>
+              </>
+            ) : step === STEP_TOKEN ? (
+              <>
+                <p class="gsv-connect-step-desc">
+                  {isTelegram
+                    ? "BotFather hands you an access token once the bot is created. Copy it — you'll paste it in the next step."
+                    : "In your bot's settings, create a bot token and copy it — you'll paste it in the next step."}
+                </p>
+                <div class="gsv-connect-step-links">
+                  <Link href={docUrl} arrow>Need help? Documentation</Link>
+                </div>
+              </>
+            ) : step === STEP_CONNECT ? (
+              <>
+                <p class="gsv-connect-step-desc">
+                  Paste the token below to connect your {name} bot to GSV.
+                </p>
+                <div class="gsv-connect-token-field">
+                  <TextInput
+                    label="ACCESS TOKEN"
+                    size="large"
+                    requirement="required"
+                    value={token}
+                    placeholder="123456789:AA…"
+                    type="password"
+                    clearable
+                    status={formError ? "error" : "none"}
+                    message={formError}
+                    onChange={(value) => {
+                      if (formError) setFormError("");
+                      setToken(value);
+                    }}
+                    inputProps={{ name: "botToken", autoComplete: "off" }}
+                  />
+                </div>
+              </>
+            ) : (
+              <>
+                <p class="gsv-connect-step-desc">
+                  Your {name} bot is connected. Start messaging your GSV — open a chat and ask it to message your bot,
+                  or message the bot directly.
+                </p>
+                <div class="gsv-connect-caps">
+                  <SectionHeader title="THINGS YOU CAN DO" titleSize="section" divider />
+                  <div class="gsv-connect-caps-rows">
+                    {MESSENGER_CAPABILITIES.map((cap) => (
+                      <ListRow key={cap.title} label={cap.title} sub={cap.detail} status="none" />
+                    ))}
+                  </div>
+                </div>
+                <div class="gsv-connect-step-links">
+                  <Link href={docUrl} arrow>Read the docs</Link>
+                </div>
+                {result?.challenge ? (
+                  <Alert
+                    variant="warning"
+                    text="This adapter returned an extra authentication step — open the bot detail to finish it."
+                  />
+                ) : null}
+              </>
+            )}
+          </div>
+
+          <div class="gsv-connect-actions">
+            {step === STEP_ONLINE ? (
+              <>
+                <Button variant="secondary" label="VIEW BOT" onClick={goToDetail} />
+                <Button variant="primary" label="DONE" onClick={onBack} />
+              </>
+            ) : step === STEP_CONNECT ? (
+              <>
+                <Button variant="secondary" label="BACK" disabled={connect.isPending} onClick={goBack} />
+                <Button
+                  variant="primary"
+                  label={connect.isPending ? "CONNECTING" : "CONNECT"}
+                  disabled={!canSubmit}
+                  onClick={submit}
+                />
+              </>
+            ) : (
+              <>
+                <Button variant="secondary" label={step === STEP_CREATE ? "CANCEL" : "BACK"} onClick={goBack} />
+                <Button variant="primary" label="NEXT" onClick={goNext} />
+              </>
+            )}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
@@ -10,7 +10,7 @@ import { TextInput } from "../../../components/ui/TextInput";
 import { ConsoleDetailHeader } from "../components/ConsoleDetailHeader";
 import type { ConnectConsoleAdapterResult } from "../backend/consoleService";
 import { useConnectConsoleAdapter } from "../hooks/useConsoleData";
-import { BOTFATHER_URL, MESSENGER_CAPABILITIES, adapterDocUrl } from "./messengerDocs";
+import { BOTFATHER_URL, DISCORD_DEVELOPER_URL, MESSENGER_CAPABILITIES, adapterDocUrl } from "./messengerDocs";
 import { adapterDetailId, adapterName, deriveTelegramAccountId, iconForAdapterName } from "./messengerPresentation";
 import "./MessengerOnboardingFlow.css";
 
@@ -116,7 +116,7 @@ export function MessengerOnboardingFlow({
       <div class="gsv-connect-shell">
         <ConsoleDetailHeader
           icon={iconForAdapterName(adapterId)}
-          title="Connect messenger bot"
+          title={`Connect ${name} bot`}
           typeLabel={`${name.toUpperCase()} · NEW MESSENGER`}
           statusLabel={connected ? "CONNECTED" : "NOT CONNECTED"}
           tone={connected ? "online" : "idle"}
@@ -162,7 +162,9 @@ export function MessengerOnboardingFlow({
                     : "Create a new bot application in the Discord developer portal to act as your GSV's messenger."}
                 </p>
                 <div class="gsv-connect-step-links">
-                  {isTelegram ? <Link href={BOTFATHER_URL}>Open BotFather</Link> : null}
+                  <Link href={isTelegram ? BOTFATHER_URL : DISCORD_DEVELOPER_URL}>
+                    {isTelegram ? "Open BotFather" : "Open Discord Developer Portal"}
+                  </Link>
                   <Link href={docUrl} arrow>Need help? Documentation</Link>
                 </div>
               </>

--- a/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
@@ -1,210 +1,91 @@
-import { useMemo, useState } from "preact/hooks";
+import type { JSX } from "preact";
+import { useState } from "preact/hooks";
 import { Button } from "../../../components/ui/Button";
-import { Checkbox } from "../../../components/ui/Checkbox";
 import { IconButton } from "../../../components/ui/IconButton";
-import { ListRow } from "../../../components/ui/ListRow";
-import { Select } from "../../../components/ui/Select";
 import { SectionHeader } from "../../../components/ui/SectionHeader";
 import { Stepper } from "../../../components/ui/Stepper";
 import { Surface } from "../../../components/ui/Surface";
 import { Tag } from "../../../components/ui/Tag";
 import { TextInput } from "../../../components/ui/TextInput";
 import type { ConnectConsoleAdapterResult } from "../backend/consoleService";
-import { listRowStatusForTone } from "../components/consoleDetailRows";
-import type { ConsoleAdapter } from "../domain/consoleModels";
 import { useConnectConsoleAdapter } from "../hooks/useConsoleData";
-import {
-  adapterDetailId,
-  adapterName,
-  iconForAdapterName,
-  statusForAdapterFamily,
-  toneForAdapterFamily,
-} from "./messengerPresentation";
+import { BOTFATHER_URL, MESSENGER_CAPABILITIES, adapterDocUrl } from "./messengerDocs";
+import { adapterDetailId, adapterName, deriveTelegramAccountId } from "./messengerPresentation";
 import "./MessengerOnboardingFlow.css";
 
 type MessengerOnboardingFlowProps = {
-  adapters: readonly ConsoleAdapter[];
-  initialAccountId?: string | null;
-  initialAdapter?: string | null;
+  adapterId: string;
   onBack: () => void;
   onConnected: (detailId: string) => void;
 };
-
-type Challenge = NonNullable<ConnectConsoleAdapterResult["challenge"]>;
-
-function defaultAccountId(adapter: string): string {
-  if (adapter === "discord") return "main";
-  if (adapter === "telegram") return "bot";
-  return "primary";
-}
 
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : error ? String(error) : "";
 }
 
-function validUrl(value: string): boolean {
-  if (!value.trim()) return true;
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
-function buildAdapterConfig(args: {
-  adapter: string;
-  botToken: string;
-  forcePairing: boolean;
-  webhookBaseUrl: string;
-  webhookSecret: string;
-}): Record<string, unknown> | undefined {
-  const config: Record<string, unknown> = {};
-  if (args.adapter === "whatsapp") {
-    config.force = args.forcePairing;
-  }
-  if ((args.adapter === "discord" || args.adapter === "telegram") && args.botToken.trim()) {
-    config.botToken = args.botToken.trim();
-  }
-  if (args.adapter === "telegram" && args.webhookBaseUrl.trim()) {
-    config.webhookBaseUrl = args.webhookBaseUrl.trim();
-  }
-  if (args.adapter === "telegram" && args.webhookSecret.trim()) {
-    config.webhookSecret = args.webhookSecret.trim();
-  }
-  return Object.keys(config).length > 0 ? config : undefined;
-}
-
-function ChallengePanel({ challenge }: { challenge: Challenge }) {
-  const isImage = /^data:image\//i.test(challenge.data);
+function HelpLink({ href, label }: { href: string; label: string }): JSX.Element {
   return (
-    <Surface class="gsv-messenger-challenge" level={1}>
-      <SectionHeader title={challenge.type === "qr" ? "PAIR DEVICE" : "NEXT STEP"} meta={challenge.type.toUpperCase()} divider />
-      <p>{challenge.message || "Complete the adapter authentication step, then check account status."}</p>
-      {challenge.data ? (
-        isImage ? (
-          <img src={challenge.data} alt="Adapter authentication challenge" />
-        ) : (
-          <pre>{challenge.data}</pre>
-        )
-      ) : null}
-      {challenge.expiresAt ? <small>EXPIRES {new Date(challenge.expiresAt).toLocaleString()}</small> : null}
-    </Surface>
+    <a class="gsv-messenger-help-link" href={href} target="_blank" rel="noreferrer">
+      {label}
+    </a>
   );
 }
 
 export function MessengerOnboardingFlow({
-  adapters,
-  initialAccountId = null,
-  initialAdapter = null,
+  adapterId,
   onBack,
   onConnected,
-}: MessengerOnboardingFlowProps) {
-  const availableAdapters = adapters.filter((adapter) => adapter.available && adapter.supportsConnect);
-  const selectableAdapters = availableAdapters.length > 0 ? availableAdapters : adapters;
-  const initialIndex = Math.max(0, selectableAdapters.findIndex((adapter) => adapter.adapter === initialAdapter));
+}: MessengerOnboardingFlowProps): JSX.Element {
   const connect = useConnectConsoleAdapter();
-  const [adapterIndex, setAdapterIndex] = useState(initialIndex);
-  const selectedAdapter = selectableAdapters[adapterIndex] ?? selectableAdapters[0] ?? null;
-  const selectedAdapterId = selectedAdapter?.adapter ?? "";
-  const initialAccount = initialAccountId?.trim() || defaultAccountId(selectedAdapterId);
-  const [accountId, setAccountId] = useState(initialAccount);
-  const [accountTouched, setAccountTouched] = useState(Boolean(initialAccountId?.trim()));
-  const [botToken, setBotToken] = useState("");
-  const [forcePairing, setForcePairing] = useState(false);
-  const [webhookBaseUrl, setWebhookBaseUrl] = useState("");
-  const [webhookSecret, setWebhookSecret] = useState("");
+  const [token, setToken] = useState("");
   const [result, setResult] = useState<ConnectConsoleAdapterResult | null>(null);
   const [formError, setFormError] = useState("");
-  const webhookValid = validUrl(webhookBaseUrl);
-  const canSubmit = Boolean(selectedAdapterId && accountId.trim()) && webhookValid && !connect.isPending;
-  const currentStep = result?.challenge ? 2 : accountId.trim() ? 1 : 0;
-  const options = selectableAdapters.map((adapter) => adapterName(adapter.adapter));
 
-  const selectedRow = useMemo(() => selectedAdapter ? {
-    icon: iconForAdapterName(selectedAdapter.adapter),
-    label: adapterName(selectedAdapter.adapter),
-    status: listRowStatusForTone(toneForAdapterFamily(selectedAdapter)),
-    statusLabel: statusForAdapterFamily(selectedAdapter),
-    sub: selectedAdapter.available
-      ? `${selectedAdapter.accounts.length} configured account${selectedAdapter.accounts.length === 1 ? "" : "s"}`
-      : "Adapter worker not deployed",
-  } : null, [selectedAdapter]);
-
-  const selectAdapter = (index: number) => {
-    const next = selectableAdapters[index] ?? null;
-    setAdapterIndex(index);
-    setResult(null);
-    setFormError("");
-    if (next && !accountTouched) {
-      setAccountId(next.adapter === initialAdapter && initialAccountId?.trim() ? initialAccountId.trim() : defaultAccountId(next.adapter));
-    }
-  };
+  const isTelegram = adapterId === "telegram";
+  const name = adapterName(adapterId);
+  const docUrl = adapterDocUrl(adapterId);
+  const connected = Boolean(result?.ok);
+  const canSubmit = token.trim().length > 0 && !connect.isPending;
 
   const submit = async () => {
-    if (!selectedAdapter || !canSubmit) {
+    if (!canSubmit) {
       return;
     }
     setFormError("");
     setResult(null);
     try {
+      const accountId = isTelegram ? deriveTelegramAccountId(token) : "main";
       const next = await connect.mutateAsync({
-        adapter: selectedAdapter.adapter,
+        adapter: adapterId,
         accountId,
-        config: buildAdapterConfig({
-          adapter: selectedAdapter.adapter,
-          botToken,
-          forcePairing,
-          webhookBaseUrl,
-          webhookSecret,
-        }),
+        config: { botToken: token.trim() },
       });
-      setResult(next);
-      if (!next.ok) {
-        setFormError(next.error || next.message);
+      if (next.ok) {
+        setResult(next);
         return;
       }
-      if (!next.challenge) {
-        onConnected(adapterDetailId({
-          adapter: next.adapter,
-          accountId: next.accountId,
-          connected: next.connected,
-          authenticated: next.authenticated,
-          mode: "",
-          lastActivity: null,
-          error: "",
-          extra: {},
-        }));
-      }
+      setFormError(next.error || next.message);
     } catch (error) {
       setFormError(errorText(error));
     }
   };
 
-  if (selectableAdapters.length === 0) {
-    return (
-      <section class="gsv-messenger-onboarding">
-        <div class="gsv-messenger-onboarding-shell">
-          <header class="gsv-messenger-onboarding-head">
-            <IconButton glyph="arrowBack" size="medium" title="Back to messengers" onClick={onBack} />
-            <div>
-              <span class="gsv-messenger-onboarding-kicker">FLEET / NEW MESSENGER</span>
-              <h2>Connect messenger</h2>
-              <p>Add an external messaging account to route conversations into GSV.</p>
-            </div>
-            <Tag tone="idle" label="NO ADAPTERS" boxed dot />
-          </header>
-          <Surface class="gsv-messenger-flow-panel" level={2}>
-            <SectionHeader title="ADAPTERS" meta="UNAVAILABLE" divider />
-            <p>No adapter workers were discovered on this GSV instance.</p>
-            <div class="gsv-messenger-flow-actions">
-              <Button variant="secondary" label="BACK TO MESSENGERS" onClick={onBack} />
-            </div>
-          </Surface>
-        </div>
-      </section>
-    );
-  }
+  const goToDetail = () => {
+    if (!result) {
+      onBack();
+      return;
+    }
+    onConnected(adapterDetailId({
+      adapter: result.adapter,
+      accountId: result.accountId,
+      connected: result.connected,
+      authenticated: result.authenticated,
+      mode: "",
+      lastActivity: null,
+      error: "",
+      extra: {},
+    }));
+  };
 
   return (
     <section class="gsv-messenger-onboarding">
@@ -213,136 +94,131 @@ export function MessengerOnboardingFlow({
           <IconButton glyph="arrowBack" size="medium" title="Back to messengers" onClick={onBack} />
           <div>
             <span class="gsv-messenger-onboarding-kicker">FLEET / NEW MESSENGER</span>
-            <h2>Connect messenger</h2>
-            <p>Add an external messaging account to route conversations into GSV.</p>
+            <h2>Connect {name}</h2>
+            <p>Link a {name} bot to your GSV so you can message it from anywhere.</p>
           </div>
-          <Tag tone={result?.ok ? "online" : "idle"} label={result?.ok ? "CONNECTED" : "NOT CONFIGURED"} boxed dot />
+          <Tag tone={connected ? "online" : "idle"} label={connected ? "CONNECTED" : "NOT CONNECTED"} boxed dot />
         </header>
 
         <div class="gsv-messenger-onboarding-stepper" aria-label="Messenger connection progress">
-          <Stepper count={3} current={currentStep} l0="ADAPTER" l1="ACCOUNT" l2="AUTH" width={420} size="small" />
+          <Stepper
+            count={4}
+            current={connected ? 3 : 2}
+            l0="CREATE BOT"
+            l1="GET TOKEN"
+            l2="CONNECT"
+            l3="ONLINE"
+            width={440}
+            size="small"
+          />
         </div>
 
-        <Surface class="gsv-messenger-flow-panel" level={2}>
-          <SectionHeader title="ACCOUNT" meta={selectedAdapter ? adapterName(selectedAdapter.adapter).toUpperCase() : "ADAPTER"} divider />
-          <div class="gsv-messenger-form-grid">
-            <Select
-              label="ADAPTER"
-              description="Only deployed adapter workers can create new accounts."
-              requirement="required"
-              options={options}
-              value={adapterIndex}
-              onChange={selectAdapter}
-            />
-            {selectedRow ? (
-              <ListRow
-                icon={selectedRow.icon}
-                label={selectedRow.label}
-                status={selectedRow.status}
-                statusDotPlacement="trailing"
-                statusLabel={selectedRow.statusLabel}
-                sub={selectedRow.sub}
-              />
+        {connected ? (
+          <Surface class="gsv-messenger-flow-panel" level={2}>
+            <SectionHeader title="MESSENGER-BOT ONLINE" meta={name.toUpperCase()} divider />
+            <p class="gsv-messenger-success-lede">
+              Your {name} messenger-bot is connected. Start messaging your GSV.
+            </p>
+            <div class="gsv-messenger-caps">
+              <span class="gsv-messenger-caps-title">Things you can do with your messenger-bot</span>
+              <ul class="gsv-messenger-caps-list">
+                {MESSENGER_CAPABILITIES.map((cap) => (
+                  <li key={cap.title}>
+                    <span class="gsv-messenger-cap-title">{cap.title}</span>
+                    <span class="gsv-messenger-cap-detail">{cap.detail}</span>
+                  </li>
+                ))}
+              </ul>
+              <HelpLink href={docUrl} label="Read the docs" />
+            </div>
+            {result?.message ? <p class="gsv-messenger-form-note">{result.message}</p> : null}
+            {result?.challenge ? (
+              <p class="gsv-messenger-form-note">
+                This adapter returned an extra authentication step — open the bot detail to finish it.
+              </p>
             ) : null}
-            <TextInput
-              label="ACCOUNT ID"
-              description="Local account handle for this adapter."
-              requirement="required"
-              value={accountId}
-              placeholder={defaultAccountId(selectedAdapterId)}
-              clearable
-              onChange={(value) => {
-                setAccountTouched(true);
-                setAccountId(value);
-              }}
-              inputProps={{ required: true, name: "accountId" }}
-            />
+            <div class="gsv-messenger-flow-actions">
+              <Button variant="secondary" label="VIEW BOT" onClick={goToDetail} />
+              <Button variant="primary" label="DONE" onClick={onBack} />
+            </div>
+          </Surface>
+        ) : (
+          <Surface class="gsv-messenger-flow-panel" level={2}>
+            <SectionHeader title="CONNECT BOT" meta={name.toUpperCase()} divider />
 
-            {selectedAdapterId === "whatsapp" ? (
-              <Checkbox
-                checked={forcePairing}
-                label="FORCE FRESH QR SESSION"
-                description="Start a fresh pairing session even if cached state exists."
-                onChange={setForcePairing}
-              />
-            ) : selectedAdapterId === "discord" || selectedAdapterId === "telegram" ? (
-              <TextInput
-                label="BOT TOKEN"
-                description="Optional when the adapter worker has a deployment token configured."
-                requirement="optional"
-                value={botToken}
-                placeholder="Use deployment default"
-                type="password"
-                clearable
-                onChange={setBotToken}
-                inputProps={{ name: "botToken", autoComplete: "off" }}
-              />
+            <ol class="gsv-messenger-steps">
+              <li class="gsv-messenger-step">
+                <span class="gsv-messenger-step-num">1</span>
+                <div class="gsv-messenger-step-body">
+                  <span class="gsv-messenger-step-title">Create your GSV messenger-bot</span>
+                  <p class="gsv-messenger-step-text">
+                    {isTelegram
+                      ? "Open BotFather and create a new bot for your GSV."
+                      : "Create a new bot application in the Discord developer portal."}
+                  </p>
+                  <div class="gsv-messenger-step-links">
+                    {isTelegram ? <HelpLink href={BOTFATHER_URL} label="Open BotFather" /> : null}
+                    <HelpLink href={docUrl} label="Don't know how? Find help here" />
+                  </div>
+                </div>
+              </li>
+
+              <li class="gsv-messenger-step">
+                <span class="gsv-messenger-step-num">2</span>
+                <div class="gsv-messenger-step-body">
+                  <span class="gsv-messenger-step-title">Generate an access token to connect your bot to GSV</span>
+                  <p class="gsv-messenger-step-text">
+                    {isTelegram
+                      ? "BotFather hands you an access token once the bot is created. Copy it."
+                      : "In the bot settings, create a token and copy it."}
+                  </p>
+                  <div class="gsv-messenger-step-links">
+                    <HelpLink href={docUrl} label="Don't know how? Find help here" />
+                  </div>
+                </div>
+              </li>
+
+              <li class="gsv-messenger-step">
+                <span class="gsv-messenger-step-num">3</span>
+                <div class="gsv-messenger-step-body">
+                  <span class="gsv-messenger-step-title">Insert your access token</span>
+                  <p class="gsv-messenger-step-text">Paste the token below and connect.</p>
+                  <div class="gsv-messenger-token-field">
+                    <TextInput
+                      label="ACCESS TOKEN"
+                      requirement="required"
+                      value={token}
+                      placeholder="123456789:AA…"
+                      type="password"
+                      clearable
+                      status={formError ? "error" : "none"}
+                      message={formError}
+                      onChange={(value) => {
+                        if (formError) setFormError("");
+                        setToken(value);
+                      }}
+                      inputProps={{ name: "botToken", autoComplete: "off" }}
+                    />
+                  </div>
+                </div>
+              </li>
+            </ol>
+
+            {connect.error && !formError ? (
+              <p class="gsv-messenger-form-error">{errorText(connect.error)}</p>
             ) : null}
 
-            {selectedAdapterId === "telegram" ? (
-              <>
-                <TextInput
-                  label="WEBHOOK BASE URL"
-                  description="Needed only when the adapter worker has no deployment default."
-                  requirement="optional"
-                  status={webhookValid ? "none" : "error"}
-                  message={webhookValid ? "" : "Enter an http(s) URL or leave blank."}
-                  value={webhookBaseUrl}
-                  placeholder="https://telegram-adapter.example.com"
-                  clearable
-                  onChange={setWebhookBaseUrl}
-                  inputProps={{ name: "webhookBaseUrl", inputMode: "url" }}
-                />
-                <TextInput
-                  label="WEBHOOK SECRET"
-                  description="Leave blank to use the worker default."
-                  requirement="optional"
-                  value={webhookSecret}
-                  placeholder="Use deployment default"
-                  type="password"
-                  clearable
-                  onChange={setWebhookSecret}
-                  inputProps={{ name: "webhookSecret", autoComplete: "off" }}
-                />
-              </>
-            ) : null}
-          </div>
-
-          {formError || connect.error ? (
-            <p class="gsv-messenger-form-error">{formError || errorText(connect.error)}</p>
-          ) : result?.message ? (
-            <p class="gsv-messenger-form-note">{result.message}</p>
-          ) : null}
-
-          {result?.challenge ? <ChallengePanel challenge={result.challenge} /> : null}
-
-          <div class="gsv-messenger-flow-actions">
-            <Button variant="secondary" label="BACK" disabled={connect.isPending} onClick={onBack} />
-            {result?.ok ? (
+            <div class="gsv-messenger-flow-actions">
+              <Button variant="secondary" label="BACK" disabled={connect.isPending} onClick={onBack} />
               <Button
                 variant="primary"
-                label="VIEW ACCOUNT"
-                onClick={() => onConnected(adapterDetailId({
-                  adapter: result.adapter,
-                  accountId: result.accountId,
-                  connected: result.connected,
-                  authenticated: result.authenticated,
-                  mode: "",
-                  lastActivity: null,
-                  error: "",
-                  extra: {},
-                }))}
-              />
-            ) : (
-              <Button
-                variant="primary"
-                label={connect.isPending ? "CONNECTING" : selectedAdapterId === "whatsapp" ? "PAIR" : "CONNECT"}
+                label={connect.isPending ? "CONNECTING" : "CONNECT"}
                 disabled={!canSubmit}
                 onClick={submit}
               />
-            )}
-          </div>
-        </Surface>
+            </div>
+          </Surface>
+        )}
       </div>
     </section>
   );

--- a/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
@@ -11,7 +11,7 @@ import { ConsoleDetailHeader } from "../components/ConsoleDetailHeader";
 import type { ConnectConsoleAdapterResult, IdentityLinkMutationResult } from "../backend/consoleService";
 import { useConnectConsoleAdapter, useConsumeIdentityLinkCode } from "../hooks/useConsoleData";
 import { BOTFATHER_URL, DISCORD_DEVELOPER_URL, MESSENGER_CAPABILITIES, adapterDocUrl } from "./messengerDocs";
-import { adapterDetailId, adapterName, deriveTelegramAccountId, iconForAdapterName } from "./messengerPresentation";
+import { adapterDetailId, adapterName, deriveAccountId, iconForAdapterName } from "./messengerPresentation";
 import "./MessengerOnboardingFlow.css";
 
 type MessengerOnboardingFlowProps = {
@@ -54,7 +54,7 @@ export function MessengerOnboardingFlow({
   const isTelegram = adapterId === "telegram";
   const name = adapterName(adapterId);
   const docUrl = adapterDocUrl(adapterId);
-  const botConnected = Boolean(result?.ok);
+  const botConnected = Boolean(result?.ok && result?.connected && result?.authenticated);
   const linked = linkResultText.length > 0;
   const canSubmit = token.trim().length > 0 && !connect.isPending;
   const canLinkUser = botConnected && linkCode.trim().length > 0 && !consumeLinkCode.isPending;
@@ -80,18 +80,29 @@ export function MessengerOnboardingFlow({
     }
     setFormError("");
     try {
-      const accountId = isTelegram ? deriveTelegramAccountId(token) : "main";
+      const accountId = deriveAccountId(adapterId, token.trim());
       const next = await connect.mutateAsync({
         adapter: adapterId,
         accountId,
         config: { botToken: token.trim() },
       });
-      if (next.ok) {
+      if (next.ok && next.connected && next.authenticated) {
         setResult(next);
         setLinkCode("");
         setLinkError("");
         setLinkResultText("");
         setStep(STEP_LINK);
+        return;
+      }
+      if (next.ok) {
+        // The adapter accepted the token but the bot isn't online/authenticated
+        // yet — e.g. the Discord gateway opened before READY, or the token is
+        // invalid/revoked. Don't advance and claim a false success.
+        setResult(next);
+        setFormError(
+          next.challenge?.message ||
+            "The bot connected but isn't authenticated yet. Check the token is valid, then try again.",
+        );
         return;
       }
       setFormError(next.error || next.message);

--- a/web/src/app/features/gsv-console/messengers/MessengersPage.css
+++ b/web/src/app/features/gsv-console/messengers/MessengersPage.css
@@ -1,0 +1,163 @@
+/* Messengers roster — modelled on the Crew page: glyph-textured panel capping a
+   responsive grid of platform cards (one per supported messenger). */
+.gsv-messengers {
+  position: relative;
+  flex: 1;
+  min-height: 100%;
+  overflow: hidden;
+  background: var(--void);
+}
+
+.gsv-messengers::before,
+.gsv-messengers::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.gsv-messengers::before {
+  z-index: 0;
+  background-image:
+    linear-gradient(rgba(150, 140, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(150, 140, 255, 0.04) 1px, transparent 1px);
+  background-size: 46px 46px;
+}
+
+.gsv-messengers::after {
+  z-index: 1;
+  background:
+    radial-gradient(circle at 16% 13%, rgba(182, 177, 255, 0.12), transparent 1px),
+    radial-gradient(circle at 62% 8%, rgba(205, 213, 230, 0.12), transparent 1px),
+    radial-gradient(circle at 85% 30%, rgba(182, 177, 255, 0.1), transparent 1px),
+    radial-gradient(circle at 40% 52%, rgba(205, 213, 230, 0.11), transparent 1px),
+    radial-gradient(circle at 22% 78%, rgba(182, 177, 255, 0.09), transparent 1px);
+}
+
+.gsv-messengers-panel {
+  position: relative;
+  z-index: 2;
+  min-height: 100%;
+  border: 1px solid var(--border-raised);
+  background: rgba(9, 7, 26, 0.72);
+  box-shadow: inset 0 0 0 1px #060414, 0 0 30px rgba(80, 70, 180, 0.1);
+}
+
+.gsv-messengers-grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(312px, 1fr));
+  align-items: stretch;
+  gap: 22px;
+  padding: 26px;
+}
+
+.gsv-messengers-link-code {
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+  padding: 24px 26px 0;
+}
+
+/* ── Card ─────────────────────────────────────────────────────────── */
+.gsv-messenger-card {
+  min-width: 0;
+  min-height: 430px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  box-shadow: 0 0 22px rgba(60, 52, 150, 0.12);
+}
+
+.gsv-messenger-card-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 20px 22px;
+  border-bottom: 1px solid var(--border);
+  background: var(--header-bar);
+}
+
+.gsv-messenger-card-glyph {
+  flex: none;
+  width: 46px;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-raised);
+  background: var(--panel-2);
+  color: var(--accent-bright);
+}
+
+.gsv-messenger-card-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  align-items: flex-start;
+}
+
+.gsv-messenger-card-name {
+  font-family: var(--gsv-font-mono);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--text-hi);
+  text-shadow: 0 0 7px rgba(150, 140, 255, 0.35);
+}
+
+.gsv-messenger-card-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 22px;
+}
+
+.gsv-messenger-card-blurb {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.65;
+  letter-spacing: 0.03em;
+  color: #9a95d8;
+}
+
+.gsv-messenger-card-bots {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.gsv-messenger-card-bots-label {
+  font-family: var(--gsv-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.22em;
+  color: #7d78b8;
+  padding-bottom: 2px;
+}
+
+.gsv-messenger-card-bots .lr {
+  border: 1px solid var(--rule-inner);
+}
+
+.gsv-messenger-card-hint {
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+
+.gsv-messenger-card-foot {
+  margin-top: auto;
+  padding: 16px 22px 20px;
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 680px) {
+  .gsv-messengers-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+    padding: 16px;
+  }
+}

--- a/web/src/app/features/gsv-console/messengers/MessengersPage.css
+++ b/web/src/app/features/gsv-console/messengers/MessengersPage.css
@@ -157,6 +157,42 @@
   color: var(--text-dim);
 }
 
+/* "N more messengers" → opens the dedicated per-platform page. */
+.gsv-messenger-card-more {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 4px;
+  padding: 9px 4px 5px;
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--rule-inner);
+  font-family: var(--gsv-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--link);
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.gsv-messenger-card-more:hover,
+.gsv-messenger-card-more:focus-visible {
+  color: var(--link-hover);
+  outline: none;
+}
+
+.gsv-messenger-card-more-chevron {
+  font-size: 15px;
+  line-height: 1;
+}
+
+/* Dedicated per-platform bot list (inside ConsoleDetailPage children slot). */
+.gsv-messenger-platform-rows {
+  border: 1px solid var(--border);
+  border-top: none;
+}
+
 .gsv-messenger-card-foot {
   margin-top: auto;
   padding: 16px 22px 20px;

--- a/web/src/app/features/gsv-console/messengers/MessengersPage.css
+++ b/web/src/app/features/gsv-console/messengers/MessengersPage.css
@@ -3,6 +3,7 @@
 .gsv-messengers {
   position: relative;
   flex: 1;
+  min-width: 0;
   min-height: 100%;
   overflow: hidden;
   background: var(--void);
@@ -40,13 +41,18 @@
   min-height: 100%;
   border: 1px solid var(--border-raised);
   background: rgba(9, 7, 26, 0.72);
-  box-shadow: inset 0 0 0 1px #060414, 0 0 30px rgba(80, 70, 180, 0.1);
+  box-shadow: inset 0 0 0 1px var(--frame-inset), 0 0 30px rgba(80, 70, 180, 0.1);
+  /* respond to the panel's own width (console column), not the viewport */
+  container-type: inline-size;
+  container-name: messengers;
 }
 
 .gsv-messengers-grid {
   min-width: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(312px, 1fr));
+  /* min(312px,100%) lets the track shrink below 312 in a narrow console
+     column (e.g. ChatDock open) instead of forcing horizontal scroll. */
+  grid-template-columns: repeat(auto-fill, minmax(min(312px, 100%), 1fr));
   align-items: stretch;
   gap: 22px;
   padding: 26px;
@@ -100,6 +106,8 @@
 }
 
 .gsv-messenger-card-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
   font-family: var(--gsv-font-mono);
   font-size: 15px;
   font-weight: 700;
@@ -118,10 +126,11 @@
 
 .gsv-messenger-card-blurb {
   margin: 0;
+  font-family: var(--gsv-font-prose);
   font-size: 11px;
   line-height: 1.65;
   letter-spacing: 0.03em;
-  color: #9a95d8;
+  color: var(--prose-dim);
 }
 
 .gsv-messenger-card-bots {
@@ -134,7 +143,7 @@
   font-family: var(--gsv-font-mono);
   font-size: 9.5px;
   letter-spacing: 0.22em;
-  color: #7d78b8;
+  color: var(--meta);
   padding-bottom: 2px;
 }
 
@@ -154,10 +163,15 @@
   border-top: 1px solid var(--border);
 }
 
-@media (max-width: 680px) {
+@container messengers (max-width: 680px) {
   .gsv-messengers-grid {
     grid-template-columns: minmax(0, 1fr);
     gap: 16px;
     padding: 16px;
+  }
+
+  /* single-column cards size to content instead of a tall fixed floor */
+  .gsv-messenger-card {
+    min-height: auto;
   }
 }

--- a/web/src/app/features/gsv-console/messengers/MessengersPage.css
+++ b/web/src/app/features/gsv-console/messengers/MessengersPage.css
@@ -58,13 +58,6 @@
   padding: 26px;
 }
 
-.gsv-messengers-link-code {
-  min-width: 0;
-  display: flex;
-  justify-content: center;
-  padding: 24px 26px 0;
-}
-
 /* ── Card ─────────────────────────────────────────────────────────── */
 .gsv-messenger-card {
   min-width: 0;

--- a/web/src/app/features/gsv-console/messengers/MessengersPage.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengersPage.tsx
@@ -6,6 +6,7 @@ import { SectionHeader } from "../../../components/ui/SectionHeader";
 import { Tag, type TagTone } from "../../../components/ui/Tag";
 import { Tooltip } from "../../../components/ui/Tooltip";
 import { listRowStatusForTone } from "../components/consoleDetailRows";
+import { ConsoleDetailPage } from "../components/ConsoleDetailPage";
 import {
   ConsolePage,
   ConsoleResourceBoundary,
@@ -107,19 +108,25 @@ function PlatformStatusBadge({ adapter }: { adapter: ConsoleAdapter }) {
   ) : badge;
 }
 
+const MAX_CARD_BOTS = 2;
+
 function MessengerCard({
   adapter,
   identityLinks,
   onConnect,
   onOpenDetail,
+  onOpenPlatform,
 }: {
   adapter: ConsoleAdapter;
   identityLinks: readonly ConsoleIdentityLink[];
   onConnect: (adapter: ConsoleAdapter) => void;
   onOpenDetail: (account: ConsoleAdapterAccount) => void;
+  onOpenPlatform: (adapter: ConsoleAdapter) => void;
 }) {
   const platform = adapterName(adapter.adapter).toUpperCase();
   const bots = adapter.accounts;
+  const visible = bots.slice(0, MAX_CARD_BOTS);
+  const extra = bots.length - visible.length;
 
   return (
     <article class="gsv-messenger-card">
@@ -141,7 +148,7 @@ function MessengerCard({
             <div class="gsv-messenger-card-bots-label">
               {bots.length} {bots.length === 1 ? "BOT" : "BOTS"}
             </div>
-            {bots.map((account) => (
+            {visible.map((account) => (
               <ListRow
                 key={adapterDetailId(account)}
                 icon={iconForAdapterName(account.adapter)}
@@ -154,6 +161,12 @@ function MessengerCard({
                 onClick={() => onOpenDetail(account)}
               />
             ))}
+            {extra > 0 ? (
+              <button type="button" class="gsv-messenger-card-more" onClick={() => onOpenPlatform(adapter)}>
+                <span>{extra} more messenger{extra === 1 ? "" : "s"}</span>
+                <span class="gsv-messenger-card-more-chevron" aria-hidden="true">›</span>
+              </button>
+            ) : null}
           </div>
         ) : (
           <div class="gsv-messenger-card-hint">No bot connected yet.</div>
@@ -179,6 +192,7 @@ function MessengersRoster({
   identityLinksRefreshing,
   onConnect,
   onOpenDetail,
+  onOpenPlatform,
   refreshing,
 }: {
   adapters: readonly ConsoleAdapter[];
@@ -187,6 +201,7 @@ function MessengersRoster({
   identityLinksRefreshing: boolean;
   onConnect: (adapter: ConsoleAdapter) => void;
   onOpenDetail: (account: ConsoleAdapterAccount) => void;
+  onOpenPlatform: (adapter: ConsoleAdapter) => void;
   refreshing: boolean;
 }) {
   const platforms = supportedAdapters(adapters);
@@ -214,11 +229,67 @@ function MessengersRoster({
               identityLinks={identityLinks}
               onConnect={onConnect}
               onOpenDetail={onOpenDetail}
+              onOpenPlatform={onOpenPlatform}
             />
           ))}
         </div>
       </div>
     </section>
+  );
+}
+
+/** Dedicated per-platform page listing every bot for one messenger — opened
+ *  from a card's "N more messengers" affordance. Reuses the standard
+ *  ConsoleDetailPage chrome (header + back + primary action). */
+function MessengerPlatformPage({
+  adapter,
+  identityLinks,
+  onBack,
+  onConnect,
+  onOpenDetail,
+}: {
+  adapter: ConsoleAdapter;
+  identityLinks: readonly ConsoleIdentityLink[];
+  onBack: () => void;
+  onConnect: (adapter: ConsoleAdapter) => void;
+  onOpenDetail: (account: ConsoleAdapterAccount) => void;
+}) {
+  const info = familyStatus(adapter);
+  const platform = adapterName(adapter.adapter).toUpperCase();
+  const total = adapter.accounts.length;
+
+  return (
+    <ConsoleDetailPage
+      icon={iconForAdapterName(adapter.adapter)}
+      title={adapterName(adapter.adapter)}
+      typeLabel="GSV · MESSENGER"
+      statusLabel={info.label}
+      tone={info.tone}
+      blurb={`${info.connectedCount} of ${total} ${total === 1 ? "bot" : "bots"} connected.`}
+      parentLabel="MESSENGERS"
+      primaryLabel={`CONNECT ANOTHER ${platform}`}
+      onPrimary={() => onConnect(adapter)}
+      onBack={onBack}
+    >
+      <section class="gsv-messenger-platform">
+        <SectionHeader title="BOTS" meta={String(total)} divider />
+        <div class="gsv-messenger-platform-rows">
+          {adapter.accounts.map((account) => (
+            <ListRow
+              key={adapterDetailId(account)}
+              icon={iconForAdapterName(account.adapter)}
+              label={adapterLabel(account)}
+              sub={accountSub(account, identityLinks)}
+              status={listRowStatusForTone(toneForAdapter(account)) as ListRowStatus}
+              statusDotPlacement="trailing"
+              statusLabel={statusForAdapter(account)}
+              chevron
+              onClick={() => onOpenDetail(account)}
+            />
+          ))}
+        </div>
+      </section>
+    </ConsoleDetailPage>
   );
 }
 
@@ -277,6 +348,9 @@ export function MessengersPage({
   const openDetail = (account: ConsoleAdapterAccount) =>
     selectDetail({ kind: "messengers", id: adapterDetailId(account), label: `${adapterName(account.adapter)} · ${adapterLabel(account)}` });
 
+  const openPlatform = (adapter: ConsoleAdapter) =>
+    selectDetail({ kind: "messengers", id: adapter.adapter, label: `${adapterName(adapter.adapter)} · all bots` });
+
   const reconnect = (account: ConsoleAdapterAccount) => {
     setPreferredAdapter(account.adapter);
     selectDetail({ kind: "messengers", id: NEW_DETAIL_ID, createNew: true, label: `Reconnect ${adapterName(account.adapter)}` });
@@ -306,12 +380,25 @@ export function MessengersPage({
             const platform = SUPPORTED_MESSENGER_ADAPTERS.find((id) => id === selectedDetail.id);
             if (platform) {
               const target = supportedAdapters(data).find((entry) => entry.adapter === platform);
-              if (target && target.accounts.length === 0) {
+              if (target) {
+                // No bots yet → straight to the connect flow; otherwise the
+                // dedicated full-list page for the platform.
+                if (target.accounts.length === 0) {
+                  return (
+                    <MessengerOnboardingFlow
+                      adapterId={platform}
+                      onBack={() => selectDetail(null)}
+                      onConnected={(id) => selectDetail({ kind: "messengers", id })}
+                    />
+                  );
+                }
                 return (
-                  <MessengerOnboardingFlow
-                    adapterId={platform}
+                  <MessengerPlatformPage
+                    adapter={target}
+                    identityLinks={identityLinks.links}
                     onBack={() => selectDetail(null)}
-                    onConnected={(id) => selectDetail({ kind: "messengers", id })}
+                    onConnect={openCreate}
+                    onOpenDetail={openDetail}
                   />
                 );
               }
@@ -340,6 +427,7 @@ export function MessengersPage({
               identityLinksRefreshing={identityLinksRefreshing}
               onConnect={openCreate}
               onOpenDetail={openDetail}
+              onOpenPlatform={openPlatform}
               refreshing={adapters.resource.isRefreshing}
             />
           );

--- a/web/src/app/features/gsv-console/messengers/MessengersPage.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengersPage.tsx
@@ -30,7 +30,6 @@ import {
 import { useConsoleListSelection } from "../hooks/useConsoleListSelection";
 import { MessengerDetailPage } from "./MessengerDetailPage";
 import { linksForMessengerAccount } from "./MessengerIdentityLinks";
-import { MessengerLinkCodePanel } from "./MessengerLinkCodePanel";
 import { MessengerOnboardingFlow } from "./MessengerOnboardingFlow";
 import {
   SUPPORTED_MESSENGER_ADAPTERS,
@@ -188,8 +187,6 @@ function MessengerCard({
 function MessengersRoster({
   adapters,
   identityLinks,
-  identityLinksError,
-  identityLinksRefreshing,
   onConnect,
   onOpenDetail,
   onOpenPlatform,
@@ -197,8 +194,6 @@ function MessengersRoster({
 }: {
   adapters: readonly ConsoleAdapter[];
   identityLinks: readonly ConsoleIdentityLink[];
-  identityLinksError?: string;
-  identityLinksRefreshing: boolean;
   onConnect: (adapter: ConsoleAdapter) => void;
   onOpenDetail: (account: ConsoleAdapterAccount) => void;
   onOpenPlatform: (adapter: ConsoleAdapter) => void;
@@ -214,13 +209,6 @@ function MessengersRoster({
     <section class="gsv-messengers">
       <div class="gsv-messengers-panel">
         <SectionHeader title="MESSENGERS" meta={meta} divider />
-        <div class="gsv-messengers-link-code">
-          <MessengerLinkCodePanel
-            errorText={identityLinksError}
-            linkCount={identityLinks.length}
-            refreshing={identityLinksRefreshing}
-          />
-        </div>
         <div class="gsv-messengers-grid">
           {platforms.map((adapter) => (
             <MessengerCard
@@ -423,8 +411,6 @@ export function MessengersPage({
             <MessengersRoster
               adapters={data}
               identityLinks={identityLinks.links}
-              identityLinksError={identityLinksError}
-              identityLinksRefreshing={identityLinksRefreshing}
               onConnect={openCreate}
               onOpenDetail={openDetail}
               onOpenPlatform={openPlatform}

--- a/web/src/app/features/gsv-console/messengers/MessengersPage.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengersPage.tsx
@@ -1,5 +1,11 @@
 import { useState } from "preact/hooks";
-import { SettingsListPanel } from "../components/SettingsListPanel";
+import { Button } from "../../../components/ui/Button";
+import { Icon } from "../../../components/ui/Icon";
+import { ListRow, type ListRowStatus } from "../../../components/ui/ListRow";
+import { SectionHeader } from "../../../components/ui/SectionHeader";
+import { Tag, type TagTone } from "../../../components/ui/Tag";
+import { Tooltip } from "../../../components/ui/Tooltip";
+import { listRowStatusForTone } from "../components/consoleDetailRows";
 import {
   ConsolePage,
   ConsoleResourceBoundary,
@@ -22,22 +28,22 @@ import {
 } from "../hooks/useConsoleData";
 import { useConsoleListSelection } from "../hooks/useConsoleListSelection";
 import { MessengerDetailPage } from "./MessengerDetailPage";
-import {
-  linksForMessengerAccount,
-} from "./MessengerIdentityLinks";
+import { linksForMessengerAccount } from "./MessengerIdentityLinks";
 import { MessengerLinkCodePanel } from "./MessengerLinkCodePanel";
 import { MessengerOnboardingFlow } from "./MessengerOnboardingFlow";
 import {
+  SUPPORTED_MESSENGER_ADAPTERS,
   adapterDetailId,
   adapterLabel,
   adapterName,
   adapterSub,
+  familyStatus,
   iconForAdapterName,
   parseAdapterDetailId,
   statusForAdapter,
-  statusForAdapterFamily,
   toneForAdapter,
 } from "./messengerPresentation";
+import "./MessengersPage.css";
 
 type MessengersPageProps = {
   initialCreate?: boolean;
@@ -45,6 +51,35 @@ type MessengersPageProps = {
   initialDetailLabel?: string | null;
   onSelectionChange?: (selection: ConsoleListSelection | null) => void;
 };
+
+const PLATFORM_BLURB: Record<string, string> = {
+  telegram: "Message your GSV from Telegram — check files, approve tasks, and stay in control from anywhere.",
+  discord: "Bring your GSV into Discord — check files, approve tasks, and stay in control from anywhere.",
+};
+
+function platformBlurb(adapter: string): string {
+  return PLATFORM_BLURB[adapter] ?? `Connect ${adapterName(adapter)} to message your GSV remotely.`;
+}
+
+function placeholderAdapter(adapter: string): ConsoleAdapter {
+  return {
+    adapter,
+    available: false,
+    supportsConnect: true,
+    supportsDisconnect: false,
+    supportsSend: false,
+    supportsStatus: false,
+    supportsShellExec: false,
+    supportsActivity: false,
+    accounts: [],
+  };
+}
+
+function supportedAdapters(inventory: readonly ConsoleAdapter[]): ConsoleAdapter[] {
+  return SUPPORTED_MESSENGER_ADAPTERS.map(
+    (id) => inventory.find((entry) => entry.adapter === id) ?? placeholderAdapter(id),
+  );
+}
 
 function resourceWithLocalEmptyState<T>(resource: ConsoleResourceState<T>): ConsoleResourceState<T> {
   return { ...resource, isEmpty: false };
@@ -57,31 +92,92 @@ function linkedIdentityCountLabel(count: number): string {
   return `${count} linked ${count === 1 ? "identity" : "identities"}`;
 }
 
-function accountRows(
-  adapter: ConsoleAdapter,
-  identityLinks: readonly ConsoleIdentityLink[],
-  onOpenDetail: (account: ConsoleAdapterAccount) => void,
-) {
-  return adapter.accounts.map((account) => ({
-    id: adapterDetailId(account),
-    icon: iconForAdapterName(account.adapter),
-    label: adapterLabel(account),
-    sub: [
-      adapterSub(account),
-      linkedIdentityCountLabel(linksForMessengerAccount(account, identityLinks).length),
-    ].filter(Boolean).join(" / "),
-    tone: toneForAdapter(account),
-    statusLabel: statusForAdapter(account),
-    onOpen: () => onOpenDetail(account),
-  }));
+function accountSub(account: ConsoleAdapterAccount, identityLinks: readonly ConsoleIdentityLink[]): string {
+  return [
+    adapterSub(account),
+    linkedIdentityCountLabel(linksForMessengerAccount(account, identityLinks).length),
+  ].filter(Boolean).join(" / ");
 }
 
-function MessengersConsoleSections({
+function PlatformStatusBadge({ adapter }: { adapter: ConsoleAdapter }) {
+  const info = familyStatus(adapter);
+  const badge = <Tag tone={info.tone as TagTone} label={info.label} dot boxed />;
+  return info.tooltip ? (
+    <Tooltip text={info.tooltip} position="top">{badge}</Tooltip>
+  ) : badge;
+}
+
+function MessengerCard({
+  adapter,
+  identityLinks,
+  onConnect,
+  onOpenDetail,
+}: {
+  adapter: ConsoleAdapter;
+  identityLinks: readonly ConsoleIdentityLink[];
+  onConnect: (adapter: ConsoleAdapter) => void;
+  onOpenDetail: (account: ConsoleAdapterAccount) => void;
+}) {
+  const platform = adapterName(adapter.adapter).toUpperCase();
+  const bots = adapter.accounts;
+
+  return (
+    <article class="gsv-messenger-card">
+      <header class="gsv-messenger-card-head">
+        <span class="gsv-messenger-card-glyph">
+          <Icon name={iconForAdapterName(adapter.adapter)} size={26} />
+        </span>
+        <div class="gsv-messenger-card-heading">
+          <span class="gsv-messenger-card-name">{platform}</span>
+          <PlatformStatusBadge adapter={adapter} />
+        </div>
+      </header>
+
+      <div class="gsv-messenger-card-body">
+        <p class="gsv-messenger-card-blurb">{platformBlurb(adapter.adapter)}</p>
+
+        {bots.length > 0 ? (
+          <div class="gsv-messenger-card-bots">
+            <div class="gsv-messenger-card-bots-label">
+              {bots.length} {bots.length === 1 ? "BOT" : "BOTS"}
+            </div>
+            {bots.map((account) => (
+              <ListRow
+                key={adapterDetailId(account)}
+                icon={iconForAdapterName(account.adapter)}
+                label={adapterLabel(account)}
+                sub={accountSub(account, identityLinks)}
+                status={listRowStatusForTone(toneForAdapter(account)) as ListRowStatus}
+                statusDotPlacement="trailing"
+                statusLabel={statusForAdapter(account)}
+                chevron
+                onClick={() => onOpenDetail(account)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div class="gsv-messenger-card-hint">No bot connected yet.</div>
+        )}
+      </div>
+
+      <footer class="gsv-messenger-card-foot">
+        <Button
+          variant={bots.length > 0 ? "secondary" : "primary"}
+          block
+          label={bots.length > 0 ? `CONNECT ANOTHER ${platform}` : `CONNECT ${platform}`}
+          onClick={() => onConnect(adapter)}
+        />
+      </footer>
+    </article>
+  );
+}
+
+function MessengersRoster({
   adapters,
   identityLinks,
   identityLinksError,
   identityLinksRefreshing,
-  onOpenCreate,
+  onConnect,
   onOpenDetail,
   refreshing,
 }: {
@@ -89,48 +185,40 @@ function MessengersConsoleSections({
   identityLinks: readonly ConsoleIdentityLink[];
   identityLinksError?: string;
   identityLinksRefreshing: boolean;
-  onOpenCreate: (adapter: ConsoleAdapter) => void;
-  onOpenDetail: (adapter: ConsoleAdapterAccount) => void;
+  onConnect: (adapter: ConsoleAdapter) => void;
+  onOpenDetail: (account: ConsoleAdapterAccount) => void;
   refreshing: boolean;
 }) {
+  const platforms = supportedAdapters(adapters);
+  const connected = platforms.filter((adapter) => familyStatus(adapter).status === "connected").length;
+  const meta = refreshing
+    ? "REFRESHING"
+    : `${platforms.length} SERVICES / ${connected} CONNECTED`;
+
   return (
-    <>
-      <MessengerLinkCodePanel
-        errorText={identityLinksError}
-        linkCount={identityLinks.length}
-        refreshing={identityLinksRefreshing}
-      />
-      {adapters.length === 0 ? (
-        <SettingsListPanel
-          title="MESSENGERS"
-          meta={refreshing ? "REFRESHING" : "0 ADAPTERS"}
-          emptyLabel="NO ADAPTER WORKERS"
-          rows={[]}
-        />
-      ) : adapters.map((adapter) => {
-        const connected = adapter.accounts.filter((account) => account.connected && account.authenticated && !account.error).length;
-        const meta = !adapter.available
-          ? statusForAdapterFamily(adapter)
-          : adapter.accounts.length === 0
-            ? "READY"
-            : `${connected}/${adapter.accounts.length} CONNECTED`;
-        return (
-          <SettingsListPanel
-            key={adapter.adapter}
-            fitContent
-            title={adapterName(adapter.adapter).toUpperCase()}
-            meta={refreshing ? "REFRESHING" : meta}
-            emptyLabel={`NO ${adapterName(adapter.adapter).toUpperCase()} ACCOUNTS`}
-            rows={accountRows(adapter, identityLinks, onOpenDetail)}
-            action={adapter.available && adapter.supportsConnect
-              ? { label: `CONNECT ${adapterName(adapter.adapter).toUpperCase()}`, onClick: () => onOpenCreate(adapter) }
-              : adapter.available
-                ? { label: "CONNECT UNSUPPORTED" }
-                : { label: "ADAPTER UNAVAILABLE" }}
+    <section class="gsv-messengers">
+      <div class="gsv-messengers-panel">
+        <SectionHeader title="MESSENGERS" meta={meta} divider />
+        <div class="gsv-messengers-link-code">
+          <MessengerLinkCodePanel
+            errorText={identityLinksError}
+            linkCount={identityLinks.length}
+            refreshing={identityLinksRefreshing}
           />
-        );
-      })}
-    </>
+        </div>
+        <div class="gsv-messengers-grid">
+          {platforms.map((adapter) => (
+            <MessengerCard
+              key={adapter.adapter}
+              adapter={adapter}
+              identityLinks={identityLinks}
+              onConnect={onConnect}
+              onOpenDetail={onOpenDetail}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -173,7 +261,6 @@ export function MessengersPage({
   const accounts = useConsoleAccounts({ enabled: true });
   const identityLinks = useConsoleIdentityLinks({ enabled: true });
   const [preferredAdapter, setPreferredAdapter] = useState<string | null>(null);
-  const [preferredAccount, setPreferredAccount] = useState<string | null>(null);
   const { selectedDetail, selectDetail } = useConsoleListSelection({
     initialCreate,
     initialDetailId,
@@ -181,6 +268,19 @@ export function MessengersPage({
     kind: "messengers",
     onSelectionChange,
   });
+
+  const openCreate = (adapter: ConsoleAdapter) => {
+    setPreferredAdapter(adapter.adapter);
+    selectDetail({ kind: "messengers", id: NEW_DETAIL_ID, createNew: true, label: `New ${adapterName(adapter.adapter)}` });
+  };
+
+  const openDetail = (account: ConsoleAdapterAccount) =>
+    selectDetail({ kind: "messengers", id: adapterDetailId(account), label: `${adapterName(account.adapter)} · ${adapterLabel(account)}` });
+
+  const reconnect = (account: ConsoleAdapterAccount) => {
+    setPreferredAdapter(account.adapter);
+    selectDetail({ kind: "messengers", id: NEW_DETAIL_ID, createNew: true, label: `Reconnect ${adapterName(account.adapter)}` });
+  };
 
   return (
     <ConsolePage flush>
@@ -191,49 +291,58 @@ export function MessengersPage({
         render={(data) => {
           const identityLinksError = identityLinks.resource.isError ? identityLinks.resource.errorText : undefined;
           const identityLinksRefreshing = identityLinks.resource.isLoading || identityLinks.resource.isRefreshing;
-          return selectedDetail?.kind === "messengers" && selectedDetail.createNew ? (
-            <MessengerOnboardingFlow
-              adapters={data}
-              initialAccountId={preferredAccount}
-              initialAdapter={preferredAdapter}
-              onBack={() => selectDetail(null)}
-              onConnected={(id) => selectDetail({ kind: "messengers", id })}
-            />
-          ) : selectedDetail?.kind === "messengers" && selectedDetail.id !== NEW_DETAIL_ID
-            ? renderMessengerDetail(accounts.accounts, data, identityLinks.links, identityLinksError, identityLinksRefreshing, selectedDetail.id, () => selectDetail(null), (account) => {
-              setPreferredAdapter(account.adapter);
-              setPreferredAccount(account.accountId);
-              selectDetail({ kind: "messengers", id: NEW_DETAIL_ID, createNew: true, label: `Reconnect ${adapterName(account.adapter)} · ${account.accountId}` });
-            }) ?? (
-              <MessengersConsoleSections
-                adapters={data}
-                identityLinks={identityLinks.links}
-                identityLinksError={identityLinksError}
-                identityLinksRefreshing={identityLinksRefreshing}
-                onOpenCreate={(adapter) => {
-                  setPreferredAdapter(adapter.adapter);
-                  setPreferredAccount(null);
-                  selectDetail({ kind: "messengers", id: NEW_DETAIL_ID, createNew: true, label: `New ${adapterName(adapter.adapter)}` });
-                }}
-                onOpenDetail={(adapter) => selectDetail({ kind: "messengers", id: adapterDetailId(adapter), label: `${adapterName(adapter.adapter)} · ${adapterLabel(adapter)}` })}
-                refreshing={adapters.resource.isRefreshing}
-              />
-            )
-            : (
-              <MessengersConsoleSections
-                adapters={data}
-                identityLinks={identityLinks.links}
-                identityLinksError={identityLinksError}
-                identityLinksRefreshing={identityLinksRefreshing}
-                onOpenCreate={(adapter) => {
-                  setPreferredAdapter(adapter.adapter);
-                  setPreferredAccount(null);
-                  selectDetail({ kind: "messengers", id: NEW_DETAIL_ID, createNew: true, label: `New ${adapterName(adapter.adapter)}` });
-                }}
-                onOpenDetail={(adapter) => selectDetail({ kind: "messengers", id: adapterDetailId(adapter), label: `${adapterName(adapter.adapter)} · ${adapterLabel(adapter)}` })}
-                refreshing={adapters.resource.isRefreshing}
+
+          if (selectedDetail?.kind === "messengers" && selectedDetail.createNew) {
+            return (
+              <MessengerOnboardingFlow
+                adapterId={preferredAdapter ?? "telegram"}
+                onBack={() => selectDetail(null)}
+                onConnected={(id) => selectDetail({ kind: "messengers", id })}
               />
             );
+          }
+
+          if (selectedDetail?.kind === "messengers" && selectedDetail.id !== NEW_DETAIL_ID) {
+            const platform = SUPPORTED_MESSENGER_ADAPTERS.find((id) => id === selectedDetail.id);
+            if (platform) {
+              const target = supportedAdapters(data).find((entry) => entry.adapter === platform);
+              if (target && target.accounts.length === 0) {
+                return (
+                  <MessengerOnboardingFlow
+                    adapterId={platform}
+                    onBack={() => selectDetail(null)}
+                    onConnected={(id) => selectDetail({ kind: "messengers", id })}
+                  />
+                );
+              }
+            }
+
+            const detail = renderMessengerDetail(
+              accounts.accounts,
+              data,
+              identityLinks.links,
+              identityLinksError,
+              identityLinksRefreshing,
+              selectedDetail.id,
+              () => selectDetail(null),
+              reconnect,
+            );
+            if (detail) {
+              return detail;
+            }
+          }
+
+          return (
+            <MessengersRoster
+              adapters={data}
+              identityLinks={identityLinks.links}
+              identityLinksError={identityLinksError}
+              identityLinksRefreshing={identityLinksRefreshing}
+              onConnect={openCreate}
+              onOpenDetail={openDetail}
+              refreshing={adapters.resource.isRefreshing}
+            />
+          );
         }}
       />
     </ConsolePage>

--- a/web/src/app/features/gsv-console/messengers/messengerDocs.ts
+++ b/web/src/app/features/gsv-console/messengers/messengerDocs.ts
@@ -1,0 +1,40 @@
+// External documentation per adapter (GSV adapters repo).
+export const ADAPTER_DOC_URLS: Record<string, string> = {
+  telegram: "https://github.com/deathbyknowledge/gsv/tree/main/adapters/telegram",
+  discord: "https://github.com/deathbyknowledge/gsv/tree/main/adapters/discord",
+};
+
+const ADAPTERS_ROOT_URL = "https://github.com/deathbyknowledge/gsv/tree/main/adapters";
+
+// Returns the doc URL for an adapter, falling back to the adapters root.
+export function adapterDocUrl(adapter: string): string {
+  return ADAPTER_DOC_URLS[adapter.toLowerCase()] ?? ADAPTERS_ROOT_URL;
+}
+
+// Telegram BotFather (where users create a bot + get a token).
+export const BOTFATHER_URL = "https://t.me/botfather";
+
+// "Things you can do with your messenger-bot" — shown on the success step.
+export interface MessengerCapability {
+  title: string;
+  detail: string;
+}
+
+export const MESSENGER_CAPABILITIES: MessengerCapability[] = [
+  {
+    title: "Check remote files",
+    detail: "Browse and pull files from your GSV from anywhere.",
+  },
+  {
+    title: "Approve tasks remotely",
+    detail: "Review and approve pending tasks without opening the console.",
+  },
+  {
+    title: "Message your GSV",
+    detail: "Chat with your GSV and get replies straight in the messenger.",
+  },
+  {
+    title: "Stay in control",
+    detail: "Run commands and steer your GSV remotely, wherever you are.",
+  },
+];

--- a/web/src/app/features/gsv-console/messengers/messengerDocs.ts
+++ b/web/src/app/features/gsv-console/messengers/messengerDocs.ts
@@ -13,6 +13,8 @@ export function adapterDocUrl(adapter: string): string {
 
 // Telegram BotFather (where users create a bot + get a token).
 export const BOTFATHER_URL = "https://t.me/botfather";
+// Discord developer portal (where users create a bot application + token).
+export const DISCORD_DEVELOPER_URL = "https://discord.com/developers/applications";
 
 // "Things you can do with your messenger-bot" — shown on the success step.
 export interface MessengerCapability {

--- a/web/src/app/features/gsv-console/messengers/messengerPresentation.ts
+++ b/web/src/app/features/gsv-console/messengers/messengerPresentation.ts
@@ -118,3 +118,105 @@ export function adapterDetailSections(adapter: ConsoleAdapterAccount): ConsoleDe
     },
   ];
 }
+
+export type AdapterFamilyStatus = "not-enabled" | "connected" | "disconnected" | "attention";
+
+export interface AdapterFamilyStatusInfo {
+  status: AdapterFamilyStatus;
+  tone: StatusTone;
+  label: string;
+  connectedCount: number;
+  disconnectedCount: number;
+  total: number;
+  tooltip: string | null;
+}
+
+export function familyStatus(adapter: ConsoleAdapter): AdapterFamilyStatusInfo {
+  return familyStatusFromAccounts(adapter.accounts);
+}
+
+export function familyStatusFromAccounts(
+  accounts: readonly ConsoleAdapterAccount[],
+): AdapterFamilyStatusInfo {
+  const total = accounts.length;
+  const connectedCount = accounts.filter(
+    (account) => account.connected && account.authenticated && !account.error,
+  ).length;
+  const disconnectedCount = total - connectedCount;
+
+  if (total === 0) {
+    return {
+      status: "not-enabled",
+      tone: "idle",
+      label: "NOT ENABLED",
+      connectedCount,
+      disconnectedCount,
+      total,
+      tooltip: null,
+    };
+  }
+
+  if (connectedCount === total) {
+    return {
+      status: "connected",
+      tone: "online",
+      label: "CONNECTED",
+      connectedCount,
+      disconnectedCount,
+      total,
+      tooltip: null,
+    };
+  }
+
+  if (connectedCount === 0) {
+    return {
+      status: "disconnected",
+      tone: "error",
+      label: "DISCONNECTED",
+      connectedCount,
+      disconnectedCount,
+      total,
+      tooltip: null,
+    };
+  }
+
+  return {
+    status: "attention",
+    tone: "warn",
+    label: "ATTENTION",
+    connectedCount,
+    disconnectedCount,
+    total,
+    tooltip: `${connectedCount} connected / ${disconnectedCount} disconnected`,
+  };
+}
+
+/** Messenger platforms GSV supports, in display order. These are ALWAYS shown
+ *  (as "NOT ENABLED" when no bot is connected) — there is no empty state. */
+export const SUPPORTED_MESSENGER_ADAPTERS = ["telegram", "discord"] as const;
+
+export interface MessengerFamily {
+  adapter: string;
+  accounts: ConsoleAdapterAccount[];
+  status: AdapterFamilyStatusInfo;
+}
+
+/** Group a flat list of adapter accounts into the canonical supported platforms,
+ *  each with its aggregated family status. Always returns one entry per platform. */
+export function messengerFamilies(
+  accounts: readonly ConsoleAdapterAccount[],
+): MessengerFamily[] {
+  return SUPPORTED_MESSENGER_ADAPTERS.map((adapter) => {
+    const own = accounts.filter((account) => account.adapter === adapter);
+    return { adapter, accounts: own, status: familyStatusFromAccounts(own) };
+  });
+}
+
+export function deriveTelegramAccountId(botToken: string): string {
+  const separator = botToken.indexOf(":");
+  if (separator <= 0) {
+    return "bot";
+  }
+  const botId = botToken.slice(0, separator).trim();
+  return /^\d+$/.test(botId) ? botId : "bot";
+}

--- a/web/src/app/features/gsv-console/messengers/messengerPresentation.ts
+++ b/web/src/app/features/gsv-console/messengers/messengerPresentation.ts
@@ -132,17 +132,33 @@ export interface AdapterFamilyStatusInfo {
 }
 
 export function familyStatus(adapter: ConsoleAdapter): AdapterFamilyStatusInfo {
-  return familyStatusFromAccounts(adapter.accounts);
+  return familyStatusFromAccounts(adapter.accounts, adapter.available);
 }
 
 export function familyStatusFromAccounts(
   accounts: readonly ConsoleAdapterAccount[],
+  available = true,
 ): AdapterFamilyStatusInfo {
   const total = accounts.length;
   const connectedCount = accounts.filter(
     (account) => account.connected && account.authenticated && !account.error,
   ).length;
   const disconnectedCount = total - connectedCount;
+
+  // When the adapter worker/service binding is absent, persisted account
+  // statuses are stale — a no-longer-deployed bot must not keep showing
+  // CONNECTED across the card grid, overview, and desktop objects.
+  if (!available) {
+    return {
+      status: total > 0 ? "attention" : "not-enabled",
+      tone: total > 0 ? "warn" : "idle",
+      label: total > 0 ? "UNAVAILABLE" : "NOT ENABLED",
+      connectedCount,
+      disconnectedCount,
+      total,
+      tooltip: total > 0 ? "Adapter worker unavailable — status may be stale" : null,
+    };
+  }
 
   if (total === 0) {
     return {
@@ -205,10 +221,15 @@ export interface MessengerFamily {
  *  each with its aggregated family status. Always returns one entry per platform. */
 export function messengerFamilies(
   accounts: readonly ConsoleAdapterAccount[],
+  inventory: readonly ConsoleAdapter[] = [],
 ): MessengerFamily[] {
+  const availableByAdapter = new Map(inventory.map((entry) => [entry.adapter, entry.available]));
   return SUPPORTED_MESSENGER_ADAPTERS.map((adapter) => {
     const own = accounts.filter((account) => account.adapter === adapter);
-    return { adapter, accounts: own, status: familyStatusFromAccounts(own) };
+    // Absent inventory entry → assume available so we don't falsely flag
+    // platforms when callers don't supply availability info.
+    const available = availableByAdapter.get(adapter) ?? true;
+    return { adapter, accounts: own, status: familyStatusFromAccounts(own, available) };
   });
 }
 
@@ -219,4 +240,29 @@ export function deriveTelegramAccountId(botToken: string): string {
   }
   const botId = botToken.slice(0, separator).trim();
   return /^\d+$/.test(botId) ? botId : "bot";
+}
+
+/** Discord bot tokens encode the bot's user id (a snowflake) in their first
+ *  dot-delimited segment as base64url. Decoding it yields a stable, per-bot
+ *  account id — so connecting a second Discord bot gets its own gateway status
+ *  entry and Durable Object instead of reusing/overwriting the first ("main"),
+ *  while reconnecting the same bot keeps reusing its instance. */
+export function deriveDiscordAccountId(botToken: string): string {
+  const segment = botToken.split(".")[0]?.trim() ?? "";
+  if (!segment) {
+    return "bot";
+  }
+  try {
+    const base64 = segment.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    const decoded = atob(padded);
+    return /^\d+$/.test(decoded) ? decoded : "bot";
+  } catch {
+    return "bot";
+  }
+}
+
+/** Pick a stable per-bot account id from the bot token for the given adapter. */
+export function deriveAccountId(adapter: string, botToken: string): string {
+  return adapter === "telegram" ? deriveTelegramAccountId(botToken) : deriveDiscordAccountId(botToken);
 }

--- a/web/src/app/features/gsv-console/pages/ConsoleOverviewPanels.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleOverviewPanels.tsx
@@ -23,6 +23,7 @@ import {
 } from "../domain/agentPresentation";
 import type {
   ConsoleAccount,
+  ConsoleAdapter,
   ConsoleAdapterAccount,
   ConsoleConfigEntry,
   ConsoleMcpServer,
@@ -650,6 +651,7 @@ function ModelsTasksPanel({
 
 function FleetPanel({
   adapters,
+  adapterInventory,
   integrations,
   onOpenListCreate,
   onOpenListDetail,
@@ -657,6 +659,7 @@ function FleetPanel({
   targets,
 }: {
   adapters: readonly ConsoleAdapterAccount[];
+  adapterInventory: readonly ConsoleAdapter[];
   integrations: readonly ConsoleMcpServer[];
   onOpenListCreate?: OpenListCreate;
   onOpenListDetail?: OpenListDetail;
@@ -664,7 +667,7 @@ function FleetPanel({
   targets: readonly ConsoleTarget[];
 }) {
   const targetRows = sortTargets(targets).map(targetRow);
-  const adapterRows = messengerFamilies(adapters).map(familyRow);
+  const adapterRows = messengerFamilies(adapters, adapterInventory).map(familyRow);
   const integrationRows = sortMcpServers(integrations).map(integrationRow);
   const openList = (surface: ConsoleOverviewTarget) => onOpenSurface ? () => onOpenSurface(surface) : undefined;
   const openDetail = (kind: ConsoleListKind, row: OverviewRow, surface: ConsoleOverviewTarget) => (
@@ -804,6 +807,7 @@ export function SettingsOverviewDashboard({
       <div class="gsv-settings-right">
         <FleetPanel
           adapters={data.adapters}
+          adapterInventory={data.adapterInventory}
           integrations={data.mcpServers}
           onOpenListCreate={onOpenListCreate}
           onOpenListDetail={onOpenListDetail}

--- a/web/src/app/features/gsv-console/pages/ConsoleOverviewPanels.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleOverviewPanels.tsx
@@ -39,6 +39,10 @@ import {
   statusForProcess,
   toneForProcess,
 } from "../runtime/runtimePresentation";
+import {
+  type MessengerFamily,
+  messengerFamilies,
+} from "../messengers/messengerPresentation";
 
 type OverviewRow = {
   id: string;
@@ -136,17 +140,14 @@ function targetRow(target: ConsoleTarget): OverviewRow {
   };
 }
 
-function adapterRow(adapter: ConsoleAdapterAccount): OverviewRow {
-  const hasError = adapter.error.trim().length > 0;
-  const connected = adapter.connected && !hasError;
-  const accountLabel = adapter.accountId.trim();
+function familyRow(family: MessengerFamily): OverviewRow {
   return {
-    id: `${adapter.adapter}:${adapter.accountId}`,
-    icon: adapter.adapter === "telegram" ? "telegram" : adapter.adapter === "discord" ? "discord" : adapter.adapter === "whatsapp" ? "messenger" : "chat",
-    label: formatTokenLabel(adapter.adapter),
-    meta: joinMeta([accountLabel, hasError ? adapter.error : undefined]),
-    tone: connected ? "online" : hasError ? "error" : "idle",
-    statusLabel: hasError ? "ERROR" : undefined,
+    id: family.adapter,
+    icon: family.adapter === "telegram" ? "telegram" : "discord",
+    label: formatTokenLabel(family.adapter),
+    tone: family.status.tone,
+    statusLabel: family.status.label,
+    meta: family.status.tooltip ?? undefined,
   };
 }
 
@@ -217,10 +218,6 @@ function crewCards(accounts: readonly ConsoleAccount[], processes: readonly Cons
 
 function sortTargets(targets: readonly ConsoleTarget[]): ConsoleTarget[] {
   return [...targets].sort((left, right) => Number(right.online) - Number(left.online) || left.label.localeCompare(right.label));
-}
-
-function sortAdapters(adapters: readonly ConsoleAdapterAccount[]): ConsoleAdapterAccount[] {
-  return [...adapters].sort((left, right) => Number(right.connected) - Number(left.connected) || left.adapter.localeCompare(right.adapter));
 }
 
 function sortPackages(packages: readonly ConsolePackage[]): ConsolePackage[] {
@@ -667,7 +664,7 @@ function FleetPanel({
   targets: readonly ConsoleTarget[];
 }) {
   const targetRows = sortTargets(targets).map(targetRow);
-  const adapterRows = sortAdapters(adapters).map(adapterRow);
+  const adapterRows = messengerFamilies(adapters).map(familyRow);
   const integrationRows = sortMcpServers(integrations).map(integrationRow);
   const openList = (surface: ConsoleOverviewTarget) => onOpenSurface ? () => onOpenSurface(surface) : undefined;
   const openDetail = (kind: ConsoleListKind, row: OverviewRow, surface: ConsoleOverviewTarget) => (
@@ -700,7 +697,7 @@ function FleetPanel({
               title="MESSENGERS"
               onClick={openList("messengers")}
             />
-            {adapterRows.length === 0 ? <EmptyRow label="NO MESSENGERS" /> : rowLimit(adapterRows, 3).map((row) => (
+            {rowLimit(adapterRows, 3).map((row) => (
               <MiniRow key={row.id} row={row} onClick={openDetail("messengers", row, "messengers")} />
             ))}
             <AddRow label="CONNECT MESSENGER" onClick={openCreate("messengers", "messengers")} />

--- a/web/src/app/features/gsv-shell/domain/desktopObjects.test.ts
+++ b/web/src/app/features/gsv-shell/domain/desktopObjects.test.ts
@@ -140,10 +140,17 @@ describe("buildDesktopObjectsFromConsole", () => {
       kind: "machines",
       detailId: "hank-linux",
     });
+    expect(objects.find((object) => object.id === "messengers")?.children).toHaveLength(2);
     expect(objects.find((object) => object.id === "messengers")?.children[0]?.route).toEqual({
       kind: "messengers",
-      detailId: "discord:crew",
+      detailId: "telegram",
     });
+    expect(objects.find((object) => object.id === "messengers")?.children[1]?.route).toEqual({
+      kind: "messengers",
+      detailId: "discord",
+    });
+    expect(objects.find((object) => object.id === "messengers")?.children[0]?.statusLabel).toBe("NOT ENABLED");
+    expect(objects.find((object) => object.id === "messengers")?.children[1]?.statusLabel).toBe("CONNECTED");
     expect(objects.find((object) => object.id === "integrations")?.children[0]?.route).toEqual({
       kind: "integrations",
       detailId: "custom-mcp",

--- a/web/src/app/features/gsv-shell/domain/desktopObjects.ts
+++ b/web/src/app/features/gsv-shell/domain/desktopObjects.ts
@@ -102,7 +102,7 @@ export function buildDesktopObjectsFromConsole(data: ConsoleOverviewData | null 
     },
     messengers: {
       id: "messengers",
-      children: messengerFamilies(safeArray(data?.adapters)).map(familyToChild),
+      children: messengerFamilies(safeArray(data?.adapters), safeArray(data?.adapterInventory)).map(familyToChild),
     },
     integrations: {
       id: "integrations",

--- a/web/src/app/features/gsv-shell/domain/desktopObjects.ts
+++ b/web/src/app/features/gsv-shell/domain/desktopObjects.ts
@@ -1,5 +1,4 @@
 import type {
-  ConsoleAdapterAccount,
   ConsoleMcpServer,
   ConsoleOverviewData,
   ConsolePackage,
@@ -14,6 +13,10 @@ import type {
   ShellStatus,
 } from "./shellModel";
 import { isNativeWebPackageName } from "../../packages/nativePackages";
+import {
+  messengerFamilies,
+  type MessengerFamily,
+} from "../../gsv-console/messengers/messengerPresentation";
 
 type DesktopObjectSpec = {
   id: DesktopObjectId;
@@ -55,8 +58,8 @@ const SPECS: Record<DesktopObjectId, DesktopObjectSpec> = {
     id: "messengers",
     label: "MESSENGERS",
     glyph: "messengers",
-    singular: "adapter account",
-    plural: "adapter accounts",
+    singular: "messenger",
+    plural: "messengers",
     x: 67,
     y: 25,
   },
@@ -99,7 +102,7 @@ export function buildDesktopObjectsFromConsole(data: ConsoleOverviewData | null 
     },
     messengers: {
       id: "messengers",
-      children: safeArray(data?.adapters).map(adapterToChild).sort(compareChildren),
+      children: messengerFamilies(safeArray(data?.adapters)).map(familyToChild),
     },
     integrations: {
       id: "integrations",
@@ -154,26 +157,35 @@ function targetToChild(target: ConsoleTarget): DesktopChildObject {
   };
 }
 
-function adapterToChild(adapter: ConsoleAdapterAccount): DesktopChildObject {
-  const adapterLabel = formatTokenLabel(adapter.adapter) || "Adapter";
-  const accountLabel = firstNonEmpty(adapter.accountId) ?? "default";
-  const modeLabel = formatTokenLabel(adapter.mode).toUpperCase();
-  const error = firstNonEmpty(adapter.error);
-  const status = adapterStatus(adapter);
-
+function familyToChild(family: MessengerFamily): DesktopChildObject {
   return {
-    id: stableId("adapter", [adapter.adapter, adapter.accountId], "default"),
-    label: `${adapterLabel} · ${accountLabel}`,
-    type: modeLabel ? `MESSENGER · ${modeLabel}` : "MESSENGER",
-    blurb: error ?? `${adapterLabel} adapter account.`,
-    status: status.status,
-    statusLabel: status.label,
+    id: stableId("messenger", [family.adapter], family.adapter),
+    label: formatTokenLabel(family.adapter),
+    type: "MESSENGER",
+    blurb: familyBlurb(family),
+    status: family.status.tone as ShellStatus,
+    statusLabel: family.status.label,
     glyph: "messengers",
     route: {
       kind: "messengers",
-      detailId: `${adapter.adapter}:${adapter.accountId}`,
+      detailId: family.adapter,
     },
   };
+}
+
+function familyBlurb(family: MessengerFamily): string {
+  switch (family.status.status) {
+    case "not-enabled":
+      return "Not enabled. Connect a bot to start messaging.";
+    case "connected":
+      return `${family.status.connectedCount} connected.`;
+    case "disconnected":
+      return "Disconnected.";
+    case "attention":
+      return family.status.tooltip ?? "Needs attention.";
+    default:
+      return "Messenger.";
+  }
 }
 
 function packageToChild(pkg: ConsolePackage, branchId: PackageBranchId): DesktopChildObject {
@@ -289,19 +301,6 @@ function isApplicationPackage(pkg: ConsolePackage): boolean {
 
 function isNativeConsolePackage(pkg: ConsolePackage): boolean {
   return isNativeWebPackageName(pkg.name) || isNativeWebPackageName(pkg.packageId);
-}
-
-function adapterStatus(adapter: ConsoleAdapterAccount): { status: ShellStatus; label: string } {
-  if (firstNonEmpty(adapter.error)) {
-    return { status: "error", label: "ERROR" };
-  }
-  if (adapter.connected === true && adapter.authenticated === true) {
-    return { status: "online", label: "CONNECTED" };
-  }
-  if (adapter.connected === true && adapter.authenticated !== true) {
-    return { status: "warn", label: "AUTH REQUIRED" };
-  }
-  return { status: "idle", label: "DISCONNECTED" };
 }
 
 function packageStatus(pkg: ConsolePackage): { status: ShellStatus; label: string } {

--- a/web/src/design-system/catalog.tsx
+++ b/web/src/design-system/catalog.tsx
@@ -57,6 +57,7 @@ import agentCard from "./stories/AgentCard.story";
 import crewTile from "./stories/CrewTile.story";
 import agentEditor from "./stories/AgentEditor.story";
 import authLayout from "./stories/AuthLayout.story";
+import link from "./stories/Link.story";
 
 const STORIES: Story[] = [
   // Foundations
@@ -106,6 +107,7 @@ const STORIES: Story[] = [
   systemMessage,
   tabs,
   authLayout,
+  link,
   // Composite
   confirmModal,
   agentCard,

--- a/web/src/design-system/stories/Link.story.tsx
+++ b/web/src/design-system/stories/Link.story.tsx
@@ -1,0 +1,40 @@
+import { Link } from "../../app/components/ui/Link";
+import type { Story } from "../story";
+
+const story: Story = {
+  title: "Link",
+  group: "Chrome",
+  blurb: "text link · real <a href> · external / internal · arrow variant",
+  render: () => (
+    <div class="ds-col">
+      <div class="ds-cell">
+        <div class="ds-label">External (opens in new tab)</div>
+        <div class="ds-row">
+          <Link href="https://example.com">Open BotFather</Link>
+        </div>
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">With arrow</div>
+        <div class="ds-row">
+          <Link href="https://example.com" arrow>Read the docs</Link>
+        </div>
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Internal route</div>
+        <div class="ds-row">
+          <Link href="/settings" external={false}>Go to settings</Link>
+        </div>
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Inline in prose</div>
+        <div class="ds-row" style={{ maxWidth: "420px", lineHeight: 1.7 }}>
+          Generate a token, then{" "}
+          <Link href="https://example.com" arrow>find help here</Link>{" "}
+          if you get stuck.
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/styles/gsv-tokens.css
+++ b/web/src/styles/gsv-tokens.css
@@ -16,6 +16,7 @@
   --frame-hi:      #161240;  /* render-bay glow               */
   --field-deep:    #070612;  /* deep input / code / image bay */
   --shadow-deep:   #060414;  /* inset shadow + panel-mix tint */
+  --frame-inset:   #060414;  /* panel inset-frame shadow ring */
 
   /* — borders & rules — */
   --border:        #322e74;  /* primary hairline              */
@@ -37,9 +38,13 @@
   --text-title:    #e2dfff;  /* section title                 */
   --accent:        #b3aeff;  /* chevron / accent dot          */
   --accent-bright: #cbc7ff;  /* icons / selected accent       */
+  --link:          #8fb6ff;  /* hyperlink (bluer, stands out) */
+  --link-hover:    #b8d2ff;  /* hyperlink hover               */
   --label:         #b3aee2;  /* sub-label                     */
   --node-label:    #c4bfee;  /* node text                     */
   --text-muted:    #8c86c8;  /* muted body / secondary copy   */
+  --prose-dim:     #9089d4;  /* dim prose / blurb body        */
+  --meta:          #7d78b8;  /* eyebrow / meta / counts       */
   --text-dim:      #565199;  /* meta / dimmest                */
 
   /* — status — */

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,5 +1,20 @@
 import { defineConfig } from "vite";
 
+// In dev, the SPA derives the gateway URL from its own origin (e.g. ws://localhost:5173/ws),
+// so the dev server must forward gateway traffic to the running gateway worker. Without this,
+// login fails with "WebSocket connect timed out". Override the target with GSV_GATEWAY_URL.
+const gatewayTarget = process.env.GSV_GATEWAY_URL || "http://localhost:8787";
+
+// Paths owned by the gateway worker (everything else is served by Vite).
+const gatewayPaths = ["/ws", "/oauth", "/health", "/runtime", "/public", "/.well-known"];
+
+const proxy = Object.fromEntries(
+  gatewayPaths.map((path) => [
+    path,
+    { target: gatewayTarget, changeOrigin: true, ws: path === "/ws" },
+  ]),
+);
+
 export default defineConfig({
   root: ".",
   publicDir: "public",
@@ -14,5 +29,6 @@ export default defineConfig({
   server: {
     port: 5173,
     open: true,
+    proxy,
   },
 });


### PR DESCRIPTION
## Summary
End-to-end redesign of the Messengers surface (branched off `web-redesign`). GSV supports exactly **two** messengers — Telegram and Discord — and users connect one or more bots per platform to talk to GSV remotely.

- **Card-grid page** (Crew-style), one card per platform. WhatsApp removed from the surface.
- **Family status everywhere** — Not enabled / Connected / Disconnected / Attention (+ "N connected / M disconnected" tooltip). No "NO MESSENGERS"/"NO OBJECTS" empty state on the page, the settings overview, or the desktop object map (always renders Telegram + Discord).
- **Simplified connect flow**: a single bot-token input → existing `adapter.connect`. Progressive-disclosure wizard (one step at a time), standard object-detail header, platform-specific titles ("Connect Telegram bot" / "Connect Discord bot"), an attention `Alert` on the steps performed off-GSV, and "Open BotFather" / "Open Discord Developer Portal" + documentation links. Adapter/account/webhook fields are hidden.
- **Cards cap at 2 bots** with a "N more messengers" affordance → a dedicated per-platform page (built on `ConsoleDetailPage`) listing every bot, with a connect-another action.
- **Deep-link**: a not-enabled platform entry (desktop/overview) opens "Connect <platform>" directly; a platform with bots opens the full-list page.
- **New DS primitives/tokens**: `Link` (a real `<a href>` — `Button variant="link"` is button-only), `ConsoleDetailHeader` (extracted from `ConsoleDetailPage`, now shared), and tokens `--link`/`--link-hover`/`--frame-inset`/`--meta`/`--prose-dim`.
- **Responsiveness** via CSS container queries + `min-width:0` — the Messengers surface lives in a console column whose width is decoupled from the viewport (ChatDock + nav rail), so viewport media queries weren't firing.

### Backend / dev
- Gateway binds `CHANNEL_TELEGRAM` (`gsv-channel-telegram` / `TelegramChannel`) and **drops** `CHANNEL_WHATSAPP`; `scripts/dev-stack.sh` runs the Telegram adapter instead of WhatsApp.
- `web/vite.config.ts` adds a dev proxy forwarding gateway paths (`/ws` WS + `/oauth`/`/health`/`/runtime`/`/public`/`/.well-known`) to `:8787`, so you can log in on the `:5173` dev server with HMR.

## ⚠️ Testing — needs real bots
Both connect flows (Telegram **and** Discord) have only been verified **end-to-end with mock data** in the design catalog. They still need testing with **real bots**: local dev can't complete an actual connect — Telegram's `setWebhook` requires a publicly reachable `TELEGRAM_WEBHOOK_BASE_URL`, and Discord needs a live gateway connection. **Please create + connect a real bot on each platform before merging** to confirm the token → `adapter.connect` path and the resulting status states.

## Deferred (flagged for the product-wide DS audit)
- Tokenize the decorative alpha washes (glows / grid texture / translucent fills) — no alpha-token system exists yet.
- The same `minmax(312px,1fr)` → `minmax(min(312px,100%),1fr)` overflow fix applies to `ConsoleCrewPage.css`.
