### PR TITLE
Desktop child objects: hover preview, scroll/pin, restyled cards

### DIFF
--- a/web/src/app/components/ui/AddAction.tsx
+++ b/web/src/app/components/ui/AddAction.tsx
@@ -6,6 +6,8 @@ export type AddActionVariant = "row" | "tile";
 export interface AddActionProps {
   variant?: AddActionVariant;
   label?: string;
+  /** Tile width in px. Omitted → fills its container (the object strip sets it). */
+  width?: number;
   onClick?: () => void;
 }
 
@@ -20,7 +22,7 @@ const PlusGlyph = () => (
 
 /** AddAction — ported from AddAction.dc.html. Dashed "add new" affordance in two
  *  variants: a full-width row (with hover + chevron) and a stacked tile. */
-export function AddAction({ variant = "row", label, onClick }: AddActionProps) {
+export function AddAction({ variant = "row", label, width, onClick }: AddActionProps) {
   const text = label ?? (variant === "tile" ? "NEW AGENT" : "CONNECT NEW MACHINE");
   const rowStyle: JSX.CSSProperties = {
     width: "100%",
@@ -40,20 +42,24 @@ export function AddAction({ variant = "row", label, onClick }: AddActionProps) {
     textAlign: "left",
     transition: "background .12s",
   };
+  // Tile mirrors the ObjectCard head: a dashed "+" box on the left, label inline,
+  // sized to match the object cards (the strip stretches it to the grid cell).
   const tileStyle: JSX.CSSProperties = {
     appearance: "none",
+    boxSizing: "border-box",
+    ...(width != null ? { width: `${width}px` } : {}),
     border: "1px dashed var(--dashed)",
     background: "var(--panel)",
     color: "inherit",
-    display: "inline-flex",
-    flexDirection: "column",
+    display: "flex",
     alignItems: "center",
-    gap: "9px",
-    padding: "18px 26px",
+    gap: "11px",
+    padding: "12px 13px",
     cursor: onClick ? "pointer" : "default",
     font: "inherit",
     fontFamily: "var(--gsv-font-mono)",
-    textAlign: "center",
+    textAlign: "left",
+    transition: "background .12s, border-color .12s",
   };
   const rowContent = (
     <>
@@ -70,10 +76,11 @@ export function AddAction({ variant = "row", label, onClick }: AddActionProps) {
   );
   const tileContent = (
     <>
-      <div
+      <span
         style={{
-          width: "30px",
-          height: "30px",
+          flex: "none",
+          width: "26px",
+          height: "26px",
           border: "1px dashed var(--dashed)",
           display: "flex",
           alignItems: "center",
@@ -82,8 +89,8 @@ export function AddAction({ variant = "row", label, onClick }: AddActionProps) {
         }}
       >
         <PlusGlyph />
-      </div>
-      <div style={{ fontSize: "10px", letterSpacing: ".06em", color: "var(--text-title)" }}>{text}</div>
+      </span>
+      <span style={{ fontSize: "11px", letterSpacing: ".06em", color: "var(--text-title)" }}>{text}</span>
     </>
   );
 

--- a/web/src/app/components/ui/IconMenu.tsx
+++ b/web/src/app/components/ui/IconMenu.tsx
@@ -6,6 +6,9 @@ export interface IconMenuProps {
   title?: string;
   /** Popover width in px (280–480). */
   width?: number;
+  /** Move focus to the first action on mount. Disable for hover previews so the
+   *  menu doesn't steal focus from another control just by being shown. */
+  autoFocus?: boolean;
   onClose?: () => void;
   onFiles?: () => void;
   onLibrary?: () => void;
@@ -18,6 +21,7 @@ export interface IconMenuProps {
 export function IconMenu({
   title = "GSV // CONTROL",
   width = 386,
+  autoFocus = true,
   onClose,
   onFiles,
   onLibrary,
@@ -26,14 +30,17 @@ export function IconMenu({
 }: IconMenuProps) {
   const rootRef = useRef<HTMLDivElement>(null);
 
-  // On mount: move focus to the first enabled action button (or the close button).
+  // Move focus to the first enabled action button (or the close button) once the
+  // menu is genuinely opened. Keyed on autoFocus so a hover preview that later
+  // becomes a real open (without remounting) still pulls focus at that point.
   useEffect(() => {
+    if (!autoFocus) return;
     const root = rootRef.current;
     if (!root) return;
     const firstEnabledCell = root.querySelector<HTMLButtonElement>(".gsv-im-cell:not(:disabled)");
     const closeButton = root.querySelector<HTMLButtonElement>(".gsv-im-close");
     (firstEnabledCell ?? closeButton)?.focus();
-  }, []);
+  }, [autoFocus]);
 
   // Escape closes the menu.
   useEffect(() => {

--- a/web/src/app/components/ui/ObjectCard.css
+++ b/web/src/app/components/ui/ObjectCard.css
@@ -1,6 +1,91 @@
-/* ObjectCard — hover state ported from ObjectCard.dc.html <helmet><style>. */
-.gsv-objcard:hover {
-  border-color: #9a94ff !important;
-  box-shadow: 0 0 18px rgba(150, 140, 255, 0.3), 0 12px 30px rgba(0, 0, 0, 0.55) !important;
-  background: linear-gradient(180deg, var(--hover), var(--panel)) !important;
+/* ObjectCard — compact category + name head, description revealed on hover.
+   Visual language follows the desktop Tile (panel base, accent lift on hover). */
+.gsv-objcard {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(180deg, #100e2a, var(--node-bg));
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  cursor: pointer;
+  font-family: var(--gsv-font-mono);
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.2s, background 0.15s;
+}
+
+.gsv-objcard:hover,
+.gsv-objcard:focus-within {
+  border-color: #a9a4ff;
+  box-shadow: 0 0 18px rgba(150, 140, 255, 0.3), 0 12px 30px rgba(0, 0, 0, 0.55);
+  background: linear-gradient(180deg, var(--hover), var(--panel));
+  transform: translateY(-2px);
+}
+
+.gsv-objcard-head {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 12px 13px;
+}
+
+.gsv-objcard-icon {
+  display: flex;
+  flex: none;
+  color: var(--accent-bright);
+}
+
+.gsv-objcard-label {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
+}
+
+.gsv-objcard-cat {
+  font-size: 8px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.gsv-objcard-name {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  font-weight: 500;
+  color: var(--accent-bright);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gsv-objcard-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+/* Description — collapsed by default, revealed on hover (kept in the DOM so it
+   stays available to assistive tech). */
+.gsv-objcard-desc {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  border-top: 1px solid transparent;
+  transition: max-height 0.22s ease, opacity 0.18s ease, border-color 0.22s ease;
+}
+
+.gsv-objcard:hover .gsv-objcard-desc,
+.gsv-objcard:focus-within .gsv-objcard-desc {
+  max-height: 140px;
+  opacity: 1;
+  border-top-color: var(--border);
+}
+
+.gsv-objcard-desc p {
+  margin: 0;
+  padding: 11px 13px;
+  font-size: 10px;
+  line-height: 1.55;
+  color: #9089d4;
+  text-wrap: pretty;
 }

--- a/web/src/app/components/ui/ObjectCard.tsx
+++ b/web/src/app/components/ui/ObjectCard.tsx
@@ -9,7 +9,9 @@ export type ObjectCardStatus = "online" | "error" | "idle" | "warn" | "live";
 export interface ObjectCardProps {
   /** Object name (the source calls this `label`, NOT `name`). */
   label?: string;
+  /** Small category shown above the name (e.g. MESSENGER, COMPUTE HOST). */
   type?: string;
+  /** Description — revealed on hover. */
   blurb?: string;
   glyph?: ObjectCardGlyph;
   /** Pre-built icon node; falls back to an Icon for `glyph`. */
@@ -35,7 +37,8 @@ const GLYPH_ICON: Record<ObjectCardGlyph, string> = {
   applications: "satellite",
 };
 
-/** ObjectCard — object dialog card with icon, status, type, and blurb. */
+/** ObjectCard — object card with a compact category + name head and a status
+ *  dot. The description is revealed on hover. */
 export function ObjectCard({
   label = "Object",
   type = "OBJECT",
@@ -51,49 +54,22 @@ export function ObjectCard({
   const iconEl = hasIcon ? icon : <Icon name={GLYPH_ICON[glyph] ?? GLYPH_ICON.machines} size={20} color="var(--accent-bright)" />;
 
   const dotStyle: JSX.CSSProperties = {
-    width: "7px",
-    height: "7px",
-    borderRadius: "50%",
-    flex: "none",
     background: dc,
     ...(status === "idle" ? {} : { boxShadow: `0 0 7px ${dc}` }),
   };
 
   return (
-    <div
-      onClick={onClick}
-      class="gsv-objcard"
-      style={{
-        width: `${width}px`,
-        position: "relative",
-        background: "linear-gradient(180deg,#100e2a,var(--node-bg))",
-        border: "1px solid var(--border)",
-        overflow: "hidden",
-        boxShadow: "0 12px 30px rgba(0,0,0,.55)",
-        cursor: "pointer",
-        transition: "border-color .15s,box-shadow .15s,background .15s",
-        fontFamily: "var(--gsv-font-mono)",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "9px",
-          padding: "10px 13px",
-          background: "var(--header-bar)",
-          borderBottom: "1px solid var(--border)",
-        }}
-      >
-        <span style={{ display: "flex", flex: "none", color: "var(--accent-bright)" }}>{iconEl}</span>
-        <span style={{ fontSize: "11px", letterSpacing: ".1em", color: "var(--accent-bright)", fontWeight: 500, flex: 1, minWidth: 0 }}>
-          {label}
+    <div class="gsv-objcard" style={{ width: `${width}px` }} onClick={onClick}>
+      <div class="gsv-objcard-head">
+        <span class="gsv-objcard-icon">{iconEl}</span>
+        <span class="gsv-objcard-label">
+          <span class="gsv-objcard-cat">{type}</span>
+          <span class="gsv-objcard-name">{label}</span>
         </span>
-        <span style={dotStyle} />
+        <span class="gsv-objcard-dot" style={dotStyle} />
       </div>
-      <div style={{ padding: "12px 13px" }}>
-        <div style={{ fontSize: "8px", letterSpacing: ".22em", color: "var(--text-dim)", marginBottom: "8px" }}>{type}</div>
-        <div style={{ fontSize: "10px", lineHeight: 1.55, color: "#9089d4", textWrap: "pretty" }}>{blurb}</div>
+      <div class="gsv-objcard-desc">
+        <p>{blurb}</p>
       </div>
     </div>
   );

--- a/web/src/app/features/gsv-shell/GsvShell.tsx
+++ b/web/src/app/features/gsv-shell/GsvShell.tsx
@@ -477,6 +477,7 @@ export function GsvShell({
                     shell.setGsvOpen((value) => !value);
                     shell.setSelectedObjectId(null);
                   }}
+                  onCloseGsv={() => shell.setGsvOpen(false)}
                   onCreateObject={(id) => {
                     shell.openSettingsRoute({ view: "list", kind: id, createNew: true });
                   }}

--- a/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
+++ b/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
@@ -28,6 +28,7 @@ type GsvDesktopProps = {
   gsvOpen: boolean;
   onSelectObject: (id: DesktopObjectId | null) => void;
   onToggleGsv: () => void;
+  onCloseGsv: () => void;
   onCreateObject: (id: DesktopObjectId) => void;
   onOpenObject: (child: DesktopChildObject) => void;
   onOpenSurface: (surface: ShellSurfaceId) => void;
@@ -112,6 +113,7 @@ export function GsvDesktop({
   gsvOpen,
   onSelectObject,
   onToggleGsv,
+  onCloseGsv,
   onCreateObject,
   onOpenObject,
   onOpenSurface,
@@ -150,7 +152,10 @@ export function GsvDesktop({
   const closeGsvControls = () => {
     if (gsvHoverTimer.current) clearTimeout(gsvHoverTimer.current);
     setGsvHovered(false);
-    if (gsvOpen) onToggleGsv();
+    // Idempotent close — not the functional toggle. Outside-click also calls
+    // onSelectObject(null), which already clears gsvOpen in the parent; a toggle
+    // here would flip it back open within the same batched update.
+    if (gsvOpen) onCloseGsv();
   };
   useEffect(() => () => {
     if (gsvHoverTimer.current) clearTimeout(gsvHoverTimer.current);
@@ -210,8 +215,11 @@ export function GsvDesktop({
       sec.scrollTo({ top: target });
 
       if (cards) {
-        const cardsTop = cards.getBoundingClientRect().top - secTop + scrollTop;
-        const avail = viewportH - (cardsTop - target) - bottomGap;
+        // Measure after the scroll settled, in viewport coords (no scrollTop):
+        // scrollTo may have moved us from the pre-scroll `scrollTop`, so reusing
+        // it here would overestimate `avail` and let the grid clip below the fold.
+        const cardsViewportTop = cards.getBoundingClientRect().top - secTop;
+        const avail = viewportH - cardsViewportTop - bottomGap;
         if (cards.scrollHeight > avail + 1 && avail > 120) {
           cards.style.maxHeight = `${Math.floor(avail)}px`;
           cards.style.overflowY = "auto";

--- a/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
+++ b/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "preact";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { AddAction } from "../../../components/ui/AddAction";
 import { GsvMark } from "../../../components/ui/GsvMark";
 import { DesktopHint } from "./DesktopHint";
@@ -74,15 +75,15 @@ function SpaceGlyphs() {
 }
 
 function canCreateObject(id: DesktopObjectId): boolean {
-  return id === "machines" || id === "messengers" || id === "integrations" || id === "applications";
+  // Messengers are intentionally absent — they always list Telegram + Discord,
+  // and connecting one is done from its platform card, not a generic "connect
+  // new" card (matches the rail drawer convention).
+  return id === "machines" || id === "integrations" || id === "applications";
 }
 
 function addObjectLabel(id: DesktopObjectId): string {
   if (id === "machines") {
     return "CONNECT NEW MACHINE";
-  }
-  if (id === "messengers") {
-    return "CONNECT MESSENGER";
   }
   if (id === "integrations") {
     return "NEW INTEGRATION";
@@ -118,9 +119,44 @@ export function GsvDesktop({
   hintToken,
   onHintShown,
 }: GsvDesktopProps) {
+  const [hoveredObjectId, setHoveredObjectId] = useState<DesktopObjectId | null>(null);
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const tilesRef = useRef<HTMLDivElement>(null);
+  const stripRef = useRef<HTMLElement>(null);
+  const cardsRef = useRef<HTMLDivElement>(null);
+
   const selectedObject = selectedObjectId
     ? desktopObjects.find((object) => object.id === selectedObjectId) ?? null
     : null;
+  // Hovering a tile previews its children; selection persists them. Hover takes
+  // precedence so you can peek at other nodes while one is selected.
+  const activeObjectId = hoveredObjectId ?? selectedObjectId;
+  const activeObject = activeObjectId
+    ? desktopObjects.find((object) => object.id === activeObjectId) ?? null
+    : null;
+
+  // Hovering the GSV mark previews the controls; clicking persists them. A short
+  // grace delay lets the pointer travel from the mark into the popover.
+  const [gsvHovered, setGsvHovered] = useState(false);
+  const gsvHoverTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const openGsvHover = () => {
+    if (gsvHoverTimer.current) clearTimeout(gsvHoverTimer.current);
+    setGsvHovered(true);
+  };
+  const closeGsvHover = () => {
+    if (gsvHoverTimer.current) clearTimeout(gsvHoverTimer.current);
+    gsvHoverTimer.current = setTimeout(() => setGsvHovered(false), 140);
+  };
+  const closeGsvControls = () => {
+    if (gsvHoverTimer.current) clearTimeout(gsvHoverTimer.current);
+    setGsvHovered(false);
+    if (gsvOpen) onToggleGsv();
+  };
+  useEffect(() => () => {
+    if (gsvHoverTimer.current) clearTimeout(gsvHoverTimer.current);
+  }, []);
+  const gsvActive = gsvOpen || gsvHovered;
+
   const branchCount = Math.max(desktopObjects.length, 1);
   const totalObjects = desktopObjects.reduce((sum, object) => sum + object.children.length, 0);
   const desktopStateClass = `${selectedObject ? " has-selected-object" : ""}${gsvOpen ? " has-gsv-open" : ""}`;
@@ -133,12 +169,83 @@ export function GsvDesktop({
         ? "SYSTEM MAP"
         : inventoryState.toUpperCase();
 
+  // When a node is selected, settle the view so its objects are readable: scroll
+  // up to centre the strip, but never past the point where the tiles row sits at
+  // the top. If the strip still overflows, pin the tiles and let the card grid
+  // scroll on its own. Driven by selection (not hover) so previews don't scroll.
+  const selectedChildCount = selectedObject?.children.length ?? 0;
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) return;
+
+    function position() {
+      const sec = sectionRef.current;
+      if (!sec) return;
+      const strip = stripRef.current;
+      const tiles = tilesRef.current;
+      const cards = cardsRef.current;
+      // Reset any prior inner-scroll cap + outer lock so we measure natural heights.
+      sec.style.overflowY = "";
+      if (cards) {
+        cards.style.maxHeight = "";
+        cards.style.overflowY = "";
+      }
+      if (!selectedObjectId || !strip || !tiles) {
+        sec.scrollTo({ top: 0 });
+        return;
+      }
+
+      const viewportH = sec.clientHeight;
+      const scrollTop = sec.scrollTop;
+      const secTop = sec.getBoundingClientRect().top;
+      const tilesTop = tiles.getBoundingClientRect().top - secTop + scrollTop;
+      const stripRect = strip.getBoundingClientRect();
+      const stripTop = stripRect.top - secTop + scrollTop;
+
+      const topGap = 28;
+      const bottomGap = 28;
+      const centreScroll = stripTop + stripRect.height / 2 - viewportH / 2;
+      const pinScroll = Math.max(0, tilesTop - topGap);
+      const target = Math.max(0, Math.min(centreScroll, pinScroll));
+      sec.scrollTo({ top: target });
+
+      if (cards) {
+        const cardsTop = cards.getBoundingClientRect().top - secTop + scrollTop;
+        const avail = viewportH - (cardsTop - target) - bottomGap;
+        if (cards.scrollHeight > avail + 1 && avail > 120) {
+          cards.style.maxHeight = `${Math.floor(avail)}px`;
+          cards.style.overflowY = "auto";
+          // Pinned: lock the outer scroll so only the card grid scrolls (no
+          // double scrollbar). scrollTop stays at the pin we just set.
+          sec.style.overflowY = "hidden";
+        }
+      }
+    }
+
+    // Run now (layout is committed; getBoundingClientRect forces sync reflow) and
+    // once more after a tick to catch late layout shifts (e.g. web fonts). Avoid
+    // requestAnimationFrame — it's paused while the tab is hidden.
+    position();
+    const timer = setTimeout(position, 60);
+    // Observe only the section (viewport). Observing the strip would refire when
+    // we cap the card grid's height, creating a feedback loop.
+    const observer = new ResizeObserver(() => position());
+    observer.observe(section);
+    window.addEventListener("resize", position);
+    return () => {
+      clearTimeout(timer);
+      observer.disconnect();
+      window.removeEventListener("resize", position);
+    };
+  }, [selectedObjectId, selectedChildCount]);
+
   return (
     <section
       class={`gsv-space${desktopStateClass}`}
       aria-label="GSV desktop"
       onClick={() => {
         onSelectObject(null);
+        closeGsvControls();
       }}
     >
       <div class="gsv-space-grid" aria-hidden="true" />
@@ -159,131 +266,141 @@ export function GsvDesktop({
         <p>{hudStatus}</p>
       </header>
 
-      {/* The tree fills the desktop; clicks on its empty space intentionally
-          bubble to the section handler to deselect. Interactive children below
-          stop propagation so they don't trigger a deselect. */}
-      <div class="gsv-space-tree">
-        <div class="gsv-space-gsv">
-          <button
-            type="button"
-            class={`gsv-space-gsv-button${gsvOpen ? " is-open" : ""}`}
-            onClick={(event) => {
-              event.stopPropagation();
-              onToggleGsv();
-            }}
+      <div class="gsv-space-scroll" ref={sectionRef}>
+        {/* The tree fills the desktop; clicks on its empty space intentionally
+            bubble to the section handler to deselect. Interactive children below
+            stop propagation so they don't trigger a deselect. */}
+        <div class="gsv-space-tree">
+          <div
+            class="gsv-space-gsv"
+            onMouseEnter={openGsvHover}
+            onMouseLeave={closeGsvHover}
           >
-            <span class="gsv-space-gsv-cross" aria-hidden="true" />
-            <GsvMark variant="master" size={50} />
-          </button>
-          <div class="gsv-space-gsv-label">GSV</div>
-        </div>
+            <button
+              type="button"
+              class={`gsv-space-gsv-button${gsvActive ? " is-open" : ""}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onToggleGsv();
+              }}
+            >
+              <span class="gsv-space-gsv-cross" aria-hidden="true" />
+              <GsvMark variant="master" size={50} />
+            </button>
+            <div class="gsv-space-gsv-label">GSV</div>
+          </div>
 
-        {gsvOpen ? (
-          <>
-            <span class="gsv-space-control-line" aria-hidden="true" />
-            <div
-              class="gsv-space-control-popover"
-              aria-label="GSV controls"
+          {gsvActive ? (
+            <>
+              <span class="gsv-space-control-line" aria-hidden="true" />
+              <div
+                class="gsv-space-control-popover"
+                aria-label="GSV controls"
+                onMouseEnter={openGsvHover}
+                onMouseLeave={closeGsvHover}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <IconMenu
+                  title="GSV // CONTROL"
+                  width={386}
+                  onClose={closeGsvControls}
+                  onFiles={() => onOpenSurface("files")}
+                  onLibrary={() => onOpenSurface("library")}
+                  onTerminal={() => onOpenSurface("terminal")}
+                  onSettings={() => onOpenSurface("settings")}
+                />
+              </div>
+            </>
+          ) : null}
+
+          {inventoryReady ? (
+            <>
+              <div
+                class={`gsv-space-connectors${gsvOpen ? " is-control-open" : ""}`}
+                style={branchCountStyle(branchCount)}
+                aria-hidden="true"
+              >
+                <span />
+                <i />
+                {desktopObjects.map((object, index) => (
+                  <b key={object.id} style={branchStyle(index, branchCount)} />
+                ))}
+              </div>
+
+              <div ref={tilesRef} class="gsv-space-tiles" style={branchCountStyle(branchCount)}>
+                {desktopObjects.map((object) => (
+                  <button
+                    key={object.id}
+                    type="button"
+                    class={`gsv-space-tile-button${selectedObjectId === object.id ? " is-selected" : ""}${activeObjectId === object.id ? " is-active" : ""}`}
+                    aria-pressed={selectedObjectId === object.id ? "true" : "false"}
+                    title={`${object.label}: ${object.meta}, ${object.statusLabel}`}
+                    onMouseEnter={() => setHoveredObjectId(object.id)}
+                    onMouseLeave={() => setHoveredObjectId((current) => (current === object.id ? null : current))}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onSelectObject(selectedObjectId === object.id ? null : object.id);
+                    }}
+                  >
+                    <Tile
+                      label={object.label}
+                      glyph={object.glyph}
+                      status={object.status}
+                      selected={selectedObjectId === object.id}
+                    />
+                  </button>
+                ))}
+              </div>
+            </>
+          ) : (
+            <div class={`gsv-space-inventory-state is-${inventoryState}`}>
+              <StatusDot tone={inventoryState === "error" ? "error" : inventoryState === "offline" ? "idle" : "warn"} size={8} />
+              <span>{inventoryMessage}</span>
+            </div>
+          )}
+
+          {activeObject ? (
+            <aside
+              ref={stripRef}
+              class={`gsv-object-strip${selectedObject ? " is-selected" : " is-preview"}`}
+              aria-label={`${activeObject.label} objects`}
               onClick={(event) => event.stopPropagation()}
             >
-              <IconMenu
-                title="GSV // CONTROL"
-                width={386}
-                onClose={onToggleGsv}
-                onFiles={() => onOpenSurface("files")}
-                onLibrary={() => onOpenSurface("library")}
-                onTerminal={() => onOpenSurface("terminal")}
-                onSettings={() => onOpenSurface("settings")}
-              />
-            </div>
-          </>
-        ) : null}
-
-        {inventoryReady ? (
-          <>
-            <div
-              class={`gsv-space-connectors${gsvOpen ? " is-control-open" : ""}`}
-              style={branchCountStyle(branchCount)}
-              aria-hidden="true"
-            >
-              <span />
-              <i />
-              {desktopObjects.map((object, index) => (
-                <b key={object.id} style={branchStyle(index, branchCount)} />
-              ))}
-            </div>
-
-            <div class="gsv-space-tiles" style={branchCountStyle(branchCount)}>
-              {desktopObjects.map((object) => (
-                <button
-                  key={object.id}
-                  type="button"
-                  class={`gsv-space-tile-button${selectedObjectId === object.id ? " is-selected" : ""}`}
-                  aria-pressed={selectedObjectId === object.id ? "true" : "false"}
-                  title={`${object.label}: ${object.meta}, ${object.statusLabel}`}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onSelectObject(selectedObjectId === object.id ? null : object.id);
-                  }}
-                >
-                  <Tile
-                    label={object.label}
-                    glyph={object.glyph}
-                    status={object.status}
-                    selected={selectedObjectId === object.id}
+              <header>
+                <strong>
+                  <StatusDot tone={activeObject.status} size={7} />
+                  {activeObject.statusLabel}
+                </strong>
+              </header>
+              <div ref={cardsRef}>
+                {/* No empty state: an object with no children simply shows the
+                    "connect new" card below. Messengers always lists Telegram
+                    and Discord, so it is never empty. */}
+                {activeObject.children.map((child) => (
+                  <ObjectCard
+                    key={child.id}
+                    label={child.label}
+                    type={child.type}
+                    blurb={child.blurb}
+                    glyph={child.glyph}
+                    status={objectCardStatus(child.status)}
+                    width={236}
+                    onClick={() => onOpenObject(child)}
                   />
-                </button>
-              ))}
-            </div>
-          </>
-        ) : (
-          <div class={`gsv-space-inventory-state is-${inventoryState}`}>
-            <StatusDot tone={inventoryState === "error" ? "error" : inventoryState === "offline" ? "idle" : "warn"} size={8} />
-            <span>{inventoryMessage}</span>
-          </div>
-        )}
-
-        {selectedObject ? (
-          <aside
-            class="gsv-object-strip"
-            aria-label={`${selectedObject.label} objects`}
-            onClick={(event) => event.stopPropagation()}
-          >
-            <header>
-              <span>{selectedObject.label} · OBJECTS</span>
-              <small>{selectedObject.meta}</small>
-              <strong>
-                <StatusDot tone={selectedObject.status} size={7} />
-                {selectedObject.statusLabel}
-              </strong>
-            </header>
-            <div>
-              {selectedObject.children.length === 0 ? (
-                <div class="gsv-object-strip-empty">NO OBJECTS</div>
-              ) : selectedObject.children.map((child) => (
-                <ObjectCard
-                  key={child.id}
-                  label={child.label}
-                  type={child.type}
-                  blurb={child.blurb}
-                  glyph={child.glyph}
-                  status={objectCardStatus(child.status)}
-                  width={236}
-                  onClick={() => onOpenObject(child)}
-                />
-              ))}
-              {canCreateObject(selectedObject.id) ? (
-                <div class="gsv-object-strip-add">
-                  <AddAction
-                    variant="tile"
-                    label={addObjectLabel(selectedObject.id)}
-                    onClick={() => onCreateObject(selectedObject.id)}
-                  />
-                </div>
-              ) : null}
-            </div>
-          </aside>
-        ) : null}
+                ))}
+                {canCreateObject(activeObject.id) ? (
+                  <div class="gsv-object-strip-add">
+                    <AddAction
+                      variant="tile"
+                      label={addObjectLabel(activeObject.id)}
+                      onClick={() => onCreateObject(activeObject.id)}
+                    />
+                  </div>
+                ) : null}
+              </div>
+            </aside>
+          ) : null}
+        </div>
       </div>
 
       <DesktopHint

--- a/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
+++ b/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
@@ -311,6 +311,7 @@ export function GsvDesktop({
                 <IconMenu
                   title="GSV // CONTROL"
                   width={386}
+                  autoFocus={gsvOpen}
                   onClose={closeGsvControls}
                   onFiles={() => onOpenSurface("files")}
                   onLibrary={() => onOpenSurface("library")}

--- a/web/src/app/features/gsv-shell/styles/gsvShell.css
+++ b/web/src/app/features/gsv-shell/styles/gsvShell.css
@@ -119,6 +119,16 @@
     radial-gradient(1100px 720px at 50% -4%, rgba(150, 140, 255, 0.07), transparent 58%),
     var(--void);
   font-family: var(--gsv-font-mono);
+}
+
+/* The tree scrolls inside here; the section stays a fixed viewport so the HUD,
+   hint, and background layers remain pinned while many child objects scroll. */
+.gsv-space-scroll {
+  position: relative;
+  z-index: 2;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--rule-section) #0c0a22;
 }
@@ -636,18 +646,6 @@
   text-align: center;
 }
 
-.gsv-object-strip header span {
-  font-size: 10px;
-  letter-spacing: 0.26em;
-}
-
-.gsv-object-strip header small {
-  color: var(--text-dim);
-  font-size: 9px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
 .gsv-object-strip header strong {
   display: inline-flex;
   align-items: center;
@@ -665,29 +663,30 @@
   grid-template-columns: repeat(auto-fit, minmax(220px, 236px));
   justify-content: center;
   gap: 18px;
+  /* When the strip is pinned and the cards overflow, JS caps max-height and
+     turns this into the lone scroll region (see GsvDesktop position effect). */
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule-section) transparent;
+}
+
+.gsv-object-strip > div[style*="overflow"] {
+  padding: 2px 6px 2px 2px;
 }
 
 .gsv-object-strip-add {
   width: 236px;
-  min-height: 118px;
   display: flex;
 }
 
-.gsv-object-strip-add > div,
-.gsv-object-strip-add .aa {
+/* Stretch the connect card to the grid row height so it matches the object
+   cards sitting beside it. */
+.gsv-object-strip-add > div {
+  display: flex;
   width: 100%;
-  min-height: 118px;
 }
 
-.gsv-object-strip-empty {
-  min-width: 238px;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  color: var(--text-dim);
-  padding: 18px;
-  text-align: center;
-  font-size: 10px;
-  letter-spacing: 0.18em;
+.gsv-object-strip-add .aa {
+  width: 100%;
 }
 
 /* .gsv-space-hint styles live with the DesktopHint component (DesktopHint.css). */

--- a/web/src/design-system/stories/AddAction.story.tsx
+++ b/web/src/design-system/stories/AddAction.story.tsx
@@ -14,9 +14,9 @@ const story: Story = {
         </div>
       </div>
       <div class="ds-cell">
-        <div class="ds-label">Tile</div>
+        <div class="ds-label">Tile · matches the object cards ("+" left, label inline)</div>
         <div class="ds-row">
-          <AddAction variant="tile" label="NEW AGENT" />
+          <AddAction variant="tile" label="CONNECT NEW MACHINE" width={238} />
         </div>
       </div>
     </div>

--- a/web/src/design-system/stories/ObjectCard.story.tsx
+++ b/web/src/design-system/stories/ObjectCard.story.tsx
@@ -5,7 +5,7 @@ import type { Story } from "../story";
 const story: Story = {
   title: "ObjectCard",
   group: "Data Display",
-  blurb: "object dialog card · header icon + name + status · type · blurb",
+  blurb: "object card · icon + category + name + status · description on hover",
   render: () => (
     <div class="ds-col">
       <div class="ds-cell">


### PR DESCRIPTION
Behavior + styling work on the desktop child objects (the object strip shown when a desktop node is selected).

## Object strip
- **No empty state** — an object with no children just shows its "connect new" card. **Messengers** omit that card (they always list Telegram + Discord, each its own connect entry — matching the rail convention).
- **Header** shows only the status dot + label (removed the `MACHINES · OBJECTS` and `0 COMPUTE TARGETS` labels). Applies to all categories.

## ObjectCard / AddAction (design-system, all object types)
- **ObjectCard** leads with a small **category** eyebrow then the **object name**, and reveals its **description on hover** (kept in the DOM for a11y). Adopts the desktop Tile hover (accent border + lift).
- **AddAction** `tile` variant is now horizontal — a dashed **"+" box on the left, label inline** — sized to match the object cards.

## Desktop interaction
- **Hover preview**: hovering a tile (or the **GSV mark**) previews its children/controls; clicking persists. Hover previews other nodes while one is selected (reverts on mouse-out). GSV hover has a grace delay so the pointer can travel into the popover.
- **Scroll / pin for many children**: selecting a node scrolls up to centre the strip, clamped so the tiles row stays at the top; if the cards still overflow, the tiles pin and **only the card grid scrolls** (outer scroll locked — no double scrollbar). The tree scrolls inside a new `.gsv-space-scroll` container so the HUD, hint, and background stay pinned.
- **Click-out**: clicking empty space deselects the object and closes the GSV menu; `stopPropagation` is scoped to the interactive children (tiles, GSV button, popover, strip).

## Verification
- `tsc --noEmit` passes.
- ObjectCard + AddAction verified in the design-system catalog (`/design`). The desktop hover/scroll/click-out behaviors were verified via a temporary in-catalog harness rendering the real `GsvDesktop` with mock data (incl. a 12-child overflow case), since the live desktop is behind login — the harness was removed before commit.
- Note: a couple of fixes here (click-out deselect, the GSV mark) overlap with [#155](https://github.com/deathbyknowledge/gsv/pull/155); expect a small merge reconciliation depending on merge order.
