### PR TITLE
FAQ overhaul, browse-web guide, README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # GSV
 
-![gsv](https://github.com/user-attachments/assets/fd40032c-d551-44e4-ba77-7808d29cc0a1)
+![gsv](https://github.com/user-attachments/assets/e50a394b-e568-4306-bb48-e3b532c01eda)
 
-> ***A mind for your machines, by [Humans & Machines, Inc.](https://humansandmachin.es)***
+> ***a mind for your machines***
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Release](https://img.shields.io/github/v/release/deathbyknowledge/gsv)](https://github.com/deathbyknowledge/gsv/releases)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/hy9ExJJFvn)
-[![X](https://img.shields.io/badge/X-@humachinesinc-000?logo=x&logoColor=white)](https://x.com/humachinesinc)
+[![X](https://img.shields.io/badge/X-@gsvspace-000?logo=x&logoColor=white)](https://x.com/gsvspace)
 [![Docs](https://img.shields.io/badge/docs-gsv.space-111)](https://gsv.space)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/deathbyknowledge/gsv)
 
@@ -15,41 +15,46 @@
 
 Most personal AI agents run on one host you pick and keep alive — a laptop, a VPS, a container. GSV turns all your devices into a single computer. It spans your laptop, server, and phone at once, lets an agent act on whichever one fits, and runs on the edge in your own Cloudflare account; your keys, your data, no host to provision or babysit. From ~$5/mo infra plus your own model costs.
 
+
 ## What you can do
 
 - Run things across all your machines from one agent — kick off a job on your home server while your laptop's shut.
-- Keep agents working while your devices sleep — they live on the edge, not your hardware.
-- Reach it from anywhere — web UI, CLI, or Whatsapp / Discord / Telegram.
-- Spawn durable agents with their own memory, permissions, and the ability to start sub-agents.
+- Keep agents working while your devices sleep — they live on the edge, not on your hardware.
+- Reach it from anywhere — web UI, CLI, or WhatsApp / Discord / Telegram.
+- Spawn durable agents with their own memory and permissions, that can start sub-agents of their own.
 - Host your own packages and share apps between GSV instances through a built-in git remote.
+- Hand your agent the browser. The web extension lets it drive your real browser — your tabs and logged-in sessions — so it works the sites you already use, not just the public web.
 
 Under the hood it's a distributed OS: agents are durable processes with identities, history, permissions, and a syscall surface, plus an SDK for building apps. Named after the sentient ships from Iain M. Banks' Culture series, GSV (General Systems Vehicle) is a foundation for personal AI that lives across the edge.
 
 ## Quick Start
 
-Prerequisite: a [Cloudflare account](https://dash.cloudflare.com/sign-up) on the Workers Paid plan ($5/month).
+**Prerequisites:** a [Cloudflare account](https://dash.cloudflare.com/sign-up) on the Workers Paid plan ($5/mo), and an API key for whatever model provider you want to run. Your model usage is billed separately by that provider.
 
-<!-- DROP-IN once the web deploy is verified & working end-to-end. Make this the
-     recommended path and move the CLI block below it under "Or, from the terminal".
+### 1. Deploy
 
-**Easiest — deploy from the web.** Head to [gsv.space/deploy](https://gsv.space/deploy),
-connect your Cloudflare account, and GSV sets everything up for you. No terminal needed.
+**From the web (easiest, no terminal).** Go to [deploy.gsv.space](https://deploy.gsv.space/), connect your Cloudflare account, and GSV deploys itself into it.
 
-### Or, from the terminal
--->
+**Or from the terminal:**
 
 ```bash
-# Install CLI
+# Install the CLI
 curl -sSL https://install.gsv.space | bash
-# Deploy all components to your Cloudflare account
+# Deploy all components into your own Cloudflare account
 gsv infra deploy --api-token <CLOUDFLARE-API-TOKEN>
 ```
 
-Open the URL it prints to finish onboarding in the Web UI. Then chat from the UI, a connected adapter (Discord/Telegram/Whatsapp), or the CLI:
+Either way, open the URL it prints to finish onboarding in the web UI.
+
+### 2. Start using it
+
+Chat from the web UI right away, or from the CLI:
 
 ```bash
 gsv chat "Hello, what can you help me with?"
 ```
+
+To connect a messenger (Discord / Telegram / WhatsApp), add more devices, and see what to do next, follow the full guide at [docs.gsv.space/get-started](https://docs.gsv.space/get-started).
 
 ## Connect a Device
 
@@ -71,7 +76,7 @@ Linux-like by design, so agents can reason with familiar patterns (mental model,
 - **Kernel** — the Gateway runs on Cloudflare, exposing authenticated syscalls (`proc.*`, `pkg.*`, `sys.*`).
 - **Processes** — agents are durable processes with PIDs (`gsv proc list|spawn|send|kill`).
 - **Devices** — connected machines act as execution nodes, scoped to a workspace.
-- **Adapters** — Discord/Telegram/Whatsapp workers act like device drivers for external chat.
+- **Messengers** — Discord/Telegram/Whatsapp workers act like device drivers for external chat.
 
 ## Development
 
@@ -90,7 +95,7 @@ Whether you want to submit a pull request, share a wild idea, or just say hi, pl
 
 - **Join the Community:** Come hang out, talk shop, and share ideas on our [Discord Server](https://discord.gg/hy9ExJJFvn).
 - **Found a bug or have a feature request?** [Open an issue](https://github.com/deathbyknowledge/gsv/issues).
-- **Follow Updates:** Reach out directly on Twitter/X [@humachinesinc](https://x.com/humachinesinc)
+- **Follow Updates:** Reach out directly on Twitter/X [@gsvspace](https://x.com/gsvspace)
 
 ## License
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -128,6 +128,7 @@ export default defineConfig({
             { text: "Connect a Messenger", link: "/how-to/messengers" },
             { text: "Bring Your Own Model", link: "/how-to/bring-your-own-model" },
             { text: "Integrations (MCP)", link: "/how-to/integrations" },
+            { text: "Browse the Web", link: "/how-to/browse-web" },
             { text: "Applications", link: "/how-to/applications" },
           ],
         },

--- a/docs/get-started/faq.md
+++ b/docs/get-started/faq.md
@@ -1,44 +1,96 @@
-# FAQ
+# Frequently Asked Questions
 
-## What is GSV?
+## What this is
 
-GSV is a personal AI computer that runs across all your devices. It keeps a single agent alive as a long-lived process in the cloud, so your agent persists between conversations, across machines, and while your devices are off.
+### What is GSV?
 
-## Do I need a server?
+GSV is a personal AI computer, or for technical readers, a distributed OS with AI in the kernel. It runs across the devices you already own and treats them as one machine, with the "brain" living on Cloudflare's edge rather than on any single box. It isn't a chatbot and isn't a single-box agent. It's a computer you talk to that can act on your laptop, your server, and your phone as one system.
 
-No. GSV runs entirely on your own Cloudflare account using Cloudflare Workers and Durable Objects. There is no server to manage.
+### How is this different from a single-box agent?
 
-## Is it free to run?
+Most self-hosted assistants run as one agent on one host you pick and keep running: a laptop, a VPS, a container. That's one brain in one place. GSV is distributed, so it's one mind across every device you own, not stuck on any single one. The brain runs on the edge and stays awake, so it's reachable even when your machines are asleep, and it can act across all of them at once. Where the brain runs is the core difference.
 
-GSV itself is open-source. You pay only for Cloudflare usage and your LLM.
+See [Architecture Overview](/architecture/) for a deeper look at how the pieces fit together.
 
-## What do I need to get started?
+### Who is this for right now?
 
-A Cloudflare account and about five minutes. See [Deploy GSV](/how-to/deploy).
+Today, GSV is for people who run more than one machine and want an AI that spans all of them: the privacy-conscious, multi-machine, self-hosting crowd. The longer-term goal is a personal AI computer anyone can use with no setup skills, but that's the direction, not where we are at launch. If you're comfortable connecting a Cloudflare account and a couple of devices, you're in the right place today.
 
-## What is an adapter?
+## Cost and requirements
 
-Adapters are how you reach GSV from different surfaces — the CLI, a chat app like WhatsApp or Discord, or a custom client. They route into the same agent process and shared state. See [Connect a Messenger](/how-to/messengers).
+### What does it cost?
 
-## What is a device?
+About $5/month for infrastructure (a Cloudflare Workers Paid plan), plus your own model costs. You can bring your own API keys, so you pay your model provider directly for what you use. You can also use models through Cloudflare. There's no GSV subscription on top of that today.
 
-A device is any machine running the GSV daemon (`gsvd`). Devices register with the cloud and expose their local tools — filesystem, processes, hardware — to the agent. See [Connect Devices](/how-to/connect-devices).
+### Why do I need a paid Cloudflare plan?
 
-## What is a package?
+GSV's brain runs as an always-on process on Cloudflare's edge, which requires the Workers Paid plan (~$5/mo). We'd rather tell you this upfront than surprise you. It's the one hard requirement, and it's what makes the always-on, runs-in-your-own-account model work.
 
-Packages are installable extensions that add capabilities to GSV: browser apps, backend logic, CLI commands, and package-scoped storage. See [Applications](/how-to/applications).
+### What do I need to run it?
 
-## Can I run multiple agents?
+A Cloudflare account on the Workers Paid plan and at least one device to connect. If you don't want to go through Cloudflares Workers AI, you can also bring your own API keys.
 
-Yes. GSV supports multiple named processes. Each is a durable agent with its own context and lifecycle.
+## Open, private, yours
 
-## Where does the agent's memory live?
+### Is it really open source?
 
-Context is stored in Cloudflare Durable Objects. See [Context and Knowledge](/architecture/context-and-knowledge) and [Context Compaction](/architecture/context-compaction) for how long-running memory is managed.
+Yes. GSV is MIT-licensed and the full source is public at [github.com/deathbyknowledge/gsv](https://github.com/deathbyknowledge/gsv). Don't take our word for any of this. Read every line.
 
-## Is GSV open-source?
+### Can I self-host it off Cloudflare?
 
-Yes. The source is on [GitHub](https://github.com/deathbyknowledge/gsv).
+Not yet, to be exact: GSV is open source today (MIT, all the code is there) and runs in your own Cloudflare account today (your keys, your data). Running it fully off Cloudflare, on your own metal, is on the roadmap. It's technically possible, but not supported or recommended yet.
+
+### Where does my data go?
+
+Into your own Cloudflare account. Your keys, your data, never routed through us. We don't host your instance and we're not in the path of your data.
+
+### Is anything exposed to the internet?
+
+No open ports, no VPN, no box sitting exposed. Your devices connect outbound through the gateway using tokens, so nothing comes inbound to your machines. Only your GSV URL is public, everything else is private.
+
+See [Security Model](/architecture/security-model) for the full picture.
+
+## How it works
+
+### How do I connect a device?
+
+Connecting a device is a quick per-device step. See the [Connect Devices](/how-to/connect-devices) guide.
+
+### Does it keep running when my devices are off?
+
+The brain stays awake on the edge even when every device is asleep, so it's always reachable and can act on anything that doesn't need an offline machine. Work that requires a specific device, say a file that only lives on your sleeping laptop, waits until that device is back online. So it's always awake, not magically able to use hardware that's powered down.
+
+### Which models can I use?
+
+Bring your own. You can connect your own model provider with your own API key, or use the built-in Cloudflare Workers AI one.
+
+See [Bring Your Own Model](/how-to/bring-your-own-model) for setup instructions.
+
+### Can I use it from WhatsApp, Telegram, or Discord?
+
+GSV is designed to be reachable from the messengers you already use, so you can talk to it from wherever you are.
+
+See [Messengers](/how-to/messengers) for how to connect each one.
+
+### What can it actually do today?
+
+GSV runs agents as real OS processes and is programmable, so you can write, run, and share your own applications between GSV instances. It's early, so expect a focused set of capabilities now and more arriving in the open.
+
+See [Examples](/examples/) for more.
+
+## Status and trust
+
+### Is this production-ready? What's the catch?
+
+GSV is early. We're launching in the open, at the ground floor. The honest catch: it's the newest of its kind, so there's less polish and no big ecosystem yet. What you get in exchange is an architecture nobody else has and a chance to shape it. If you want something finished and hands-off, we're not there yet. If you want to be early on the right design, you're in the right place.
+
+### How do I get help, report a bug, or contribute?
+
+Join the [Discord](https://discord.gg/hy9ExJJFvn) for help and community, and file issues or PRs on GitHub at [github.com/deathbyknowledge/gsv](https://github.com/deathbyknowledge/gsv). Contributions welcome. It's open from the ground up.
+
+### Why "GSV"?
+
+It's named for the General Systems Vehicles in Iain M. Banks' Culture novels, vast ship-Minds that look after their crew. GSV is the Mind on the edge; your devices are the crew.
 
 ## See also
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -54,5 +54,7 @@ Now that GSV is running:
 - [Bring your own model](/how-to/bring-your-own-model) — use a provider key instead of the Cloudflare default.
 - [Connect a messenger](/how-to/messengers) — talk to GSV from Telegram or Discord.
 - [Add integrations](/how-to/integrations) — wire in MCP servers.
+- [Web access](/how-to/browse-web) — let your agent browse your web like you can.
 - [Install an application](/how-to/applications)
+- [Examples](/examples/index) — see some examples on how to use GSV.
 - [FAQ](/get-started/faq) — common questions about cost, devices, memory, and more.

--- a/docs/how-to/browse-web.md
+++ b/docs/how-to/browse-web.md
@@ -5,7 +5,7 @@ The browser extension gives GSV control over your browser — navigate, read pag
 ## Connect your browser
 
 1. In GSV, open **Machines → Connect new machine** and select **Browser.** Give it a name or leave the default.
-2. Follow the instructions on that screen. The extension download is also available directly here: [in the releases](https://github.com/deathbyknowledge/gsv/releases). Click **Next.**
+2. Follow the instructions on that screen. Click **Next.**
 3. Open the extension, go to **Settings**, and paste in the values shown in the GSV web UI.
 4. Click **Check connection** to confirm it's live.
 

--- a/docs/how-to/browse-web.md
+++ b/docs/how-to/browse-web.md
@@ -5,7 +5,7 @@ The browser extension gives GSV control over your browser — navigate, read pag
 ## Connect your browser
 
 1. In GSV, open **Machines → Connect new machine** and select **Browser.** Give it a name or leave the default.
-2. Follow the instructions on that screen. The extension download is also available directly here: [gsv-browser-extension.zip](https://github.com/deathbyknowledge/gsv/releases/download/dev/gsv-browser-extension.zip). Click **Next.**
+2. Follow the instructions on that screen. The extension download is also available directly here: [gsv-browser-extension.zip](https://github.com/deathbyknowledge/gsv/releases/download/v0.2.9/gsv-browser-extension.zip). Click **Next.**
 3. Open the extension, go to **Settings**, and paste in the values shown in the GSV web UI.
 4. Click **Check connection** to confirm it's live.
 

--- a/docs/how-to/browse-web.md
+++ b/docs/how-to/browse-web.md
@@ -5,7 +5,7 @@ The browser extension gives GSV control over your browser — navigate, read pag
 ## Connect your browser
 
 1. In GSV, open **Machines → Connect new machine** and select **Browser.** Give it a name or leave the default.
-2. Follow the instructions on that screen. The extension download is also available directly here: [gsv-browser-extension.zip](https://github.com/deathbyknowledge/gsv/releases/download/v0.2.9/gsv-browser-extension.zip). Click **Next.**
+2. Follow the instructions on that screen. The extension download is also available directly here: [in the releases](https://github.com/deathbyknowledge/gsv/releases). Click **Next.**
 3. Open the extension, go to **Settings**, and paste in the values shown in the GSV web UI.
 4. Click **Check connection** to confirm it's live.
 

--- a/docs/how-to/browse-web.md
+++ b/docs/how-to/browse-web.md
@@ -1,0 +1,42 @@
+# Browse the web
+
+The browser extension gives GSV control over your browser — navigate, read pages, take screenshots, fill forms — anything you can do on the web, your agent can do too.
+
+## Connect your browser
+
+1. In GSV, open **Machines → Connect new machine** and select **Browser.** Give it a name or leave the default.
+2. Follow the instructions on that screen. The extension download is also available directly here: [gsv-browser-extension.zip](https://github.com/deathbyknowledge/gsv/releases/download/dev/gsv-browser-extension.zip). Click **Next.**
+3. Open the extension, go to **Settings**, and paste in the values shown in the GSV web UI.
+4. Click **Check connection** to confirm it's live.
+
+## Try it
+
+Ask your agent: *What can you do with my browser extension?*
+
+### Cross-device: fire from your phone, act on your laptop
+
+Text GSV from Telegram while you're away from your desk: *Go to my billing portal and grab this month's invoice.* The browser action runs in your logged-in session on your laptop. This is the one that makes it clear this isn't just a browser agent — the browser is one tool a mind on the edge reaches across the machines it spans.
+
+### Sites with no API, behind your login
+
+Most of the web you actually use has no API and no export button. The extension reaches it because it's your authenticated session — something an external integration can never touch.
+
+- *Pull my latest statement from [billing portal] and save it.*
+- *What does the usage number say on my [SaaS] admin dashboard right now?*
+- *Submit this expense entry form with these values.*
+- *Grab that thread from [private forum] and summarize it.*
+
+### Always-on watching
+
+GSV keeps watching on the edge whether or not you're at the machine. Point it at a page and tell it what to wait for.
+
+- *Check [URL] every hour and tell me when the price drops below $X.*
+- *Watch [support ticket] and message me when the status changes.*
+- *Keep an eye on [product page] and let me know when it's back in stock.*
+- *Monitor [scheduling page] and grab the first appointment slot that opens up.*
+
+## See also
+
+- [Connect Devices](/how-to/connect-devices) — connect your machines for broader OS-level access
+- [Examples](/examples/)
+- [Get Started](/get-started/)

--- a/docs/why/index.md
+++ b/docs/why/index.md
@@ -1,6 +1,6 @@
 # Why GSV?
 
-Your AI assistant lives on one box. Your life doesn't.
+An AI assistant lives on one box. Your life doesn't.
 
 You've got a laptop, maybe a home server, a phone. Today's self-hosted agents make you pick *one* of those to run the brain, then keep that machine awake forever. Turn it off and your assistant goes dark. Every other device you own just sits there.
 


### PR DESCRIPTION
## What's in this PR

**FAQ** — rewrote from scratch. The old version was a short Q&A list aimed at people who already understood the architecture. This one is organized by what someone actually wants to know: what it is, what it costs, whether it's private, how it works. Answers are fuller, each question that has a relevant page links to it.

**Browse the web guide** — new how-to for the browser extension. Covers setup (it's UI-guided, kept short), then three concrete use cases: cross-device triggering from your phone into your laptop's logged-in session (the one that makes it clear this isn't just a browser agent), sites with no API behind your login, and always-on watching. Added to the sidebar and the get-started index.

**README** — cleaned up the Quick Start section (web deploy is live, removed the commented-out block), updated the "What you can do" bullet list to include the browser extension, switched X handle to @gsvspace, updated the hero image.