### PR TITLE
Library + config breadcrumbs; Library page redesign

### DIFF
--- a/web/src/app/features/gsv-console/components/GsvConsole.tsx
+++ b/web/src/app/features/gsv-console/components/GsvConsole.tsx
@@ -352,9 +352,13 @@ export function GsvConsole({
   const libraryDetail = libraryDetailLabel(libraryRoute);
   const inLibrary = activeSurface === "library"
     || (activeSurface === "settings" && settingsRoute.view === "list" && settingsRoute.kind === "library");
-  const goLibraryIndex = () => onLibraryRouteChange?.(
+  // Route through the unsaved guard: leaving a dirty page editor / capture /
+  // build form via the LIBRARY crumb or header back-arrow must prompt first,
+  // the same as Library's own in-page BACK controls (which go through
+  // useLibraryWorkspace's guarded navigate).
+  const goLibraryIndex = () => requestLeave(() => onLibraryRouteChange?.(
     libraryRoute.db ? { view: "index", db: libraryRoute.db } : { view: "index" },
-  );
+  ));
   const crumbs: ConsoleCrumb[] = activeSurface === "settings"
     ? [
         { label: "GSV", onClick: onBackToDesktop, notLast: true },

--- a/web/src/app/features/gsv-console/components/GsvConsole.tsx
+++ b/web/src/app/features/gsv-console/components/GsvConsole.tsx
@@ -151,6 +151,22 @@ function hasSettingsListDetail(route: SettingsRoute): route is Extract<SettingsR
   return route.view === "list" && (Boolean(route.detailId) || route.createNew === true);
 }
 
+/** The breadcrumb label for a non-index library view, or null on the index.
+ *  Library runs its own internal route, so the shell maps it to a detail crumb
+ *  (GSV → LIBRARY → [page/view]) the same way other surfaces show their detail. */
+function libraryDetailLabel(route: ShellLibraryRoute): string | null {
+  if (route.view === "reader") return libraryPageName(route.path);
+  if (route.view === "editor") return route.path ? libraryPageName(route.path) : "NEW PAGE";
+  if (route.view === "capture") return "NEW PAGE";
+  if (route.view === "build") return "BUILD";
+  return null;
+}
+
+function libraryPageName(path: string): string {
+  const base = path.split("/").pop() || path;
+  return base.replace(/\.[^.]+$/, "").toUpperCase();
+}
+
 function settingsRouteTail(route: SettingsRoute): string {
   if (route.view === "overview") {
     return "GSV · CONTROL";
@@ -330,6 +346,15 @@ export function GsvConsole({
 
   const inNestedSettings = activeSurface === "settings" && settingsRoute.view !== "overview";
   const inSettingsListDetail = activeSurface === "settings" && hasSettingsListDetail(settingsRoute);
+  // Library drives its own internal route; surface its non-index views as a
+  // detail crumb so the breadcrumb (and header back-arrow) own the path back to
+  // the index, instead of leaving the trail stuck at LIBRARY.
+  const libraryDetail = libraryDetailLabel(libraryRoute);
+  const inLibrary = activeSurface === "library"
+    || (activeSurface === "settings" && settingsRoute.view === "list" && settingsRoute.kind === "library");
+  const goLibraryIndex = () => onLibraryRouteChange?.(
+    libraryRoute.db ? { view: "index", db: libraryRoute.db } : { view: "index" },
+  );
   const crumbs: ConsoleCrumb[] = activeSurface === "settings"
     ? [
         { label: "GSV", onClick: onBackToDesktop, notLast: true },
@@ -356,6 +381,10 @@ export function GsvConsole({
           // back, so the detail renders no in-page back button.
           { label: settingsRouteLabel(settingsRoute), onClick: settingsConfigDetail.onExit, notLast: true },
           { label: settingsConfigDetail.label },
+        ] : settingsRoute.view === "list" && settingsRoute.kind === "library" && libraryDetail ? [
+          // Library sub-view inside settings: LIBRARY (→ index) → [page/view].
+          { label: shellSurfaceLabel("library"), onClick: goLibraryIndex, notLast: true },
+          { label: libraryDetail },
         ] : inNestedSettings ? [{ label: settingsRouteLabel(settingsRoute) }] : []),
       ]
     : activeSurface === "agent"
@@ -365,6 +394,13 @@ export function GsvConsole({
         { label: "GSV", onClick: onBackToDesktop, notLast: true },
         { label: "CREW", onClick: backToCrew, notLast: true },
         { label: shellSurfaceLabel(activeSurface) },
+      ]
+    : activeSurface === "library" && libraryDetail
+    ? [
+        // Top-level Library: GSV → LIBRARY (→ index) → [page/view].
+        { label: "GSV", onClick: onBackToDesktop, notLast: true },
+        { label: shellSurfaceLabel(activeSurface), onClick: goLibraryIndex, notLast: true },
+        { label: libraryDetail },
       ]
     : surfaceDetail
     ? [
@@ -390,8 +426,14 @@ export function GsvConsole({
           settingsConfigDetail.onExit();
           return;
         }
+        if (settingsRoute.view === "list" && settingsRoute.kind === "library" && libraryDetail) {
+          goLibraryIndex();
+          return;
+        }
         guardedSettingsNavigate({ view: "overview" });
       }
+    : activeSurface === "library" && libraryDetail
+    ? goLibraryIndex
     : activeSurface === "agent"
     ? backToCrew
     : surfaceDetail

--- a/web/src/app/features/gsv-console/components/GsvConsole.tsx
+++ b/web/src/app/features/gsv-console/components/GsvConsole.tsx
@@ -18,7 +18,7 @@ import { MachinesPage } from "../machines/MachinesPage";
 import { MessengersPage } from "../messengers/MessengersPage";
 import { PackageListPage } from "../packages/PackageListPage";
 import { ConsoleAgentPage } from "../pages/ConsoleAgentPage";
-import { ConsoleConfigPage } from "../pages/ConsoleConfigPage";
+import { ConsoleConfigPage, type ConsoleConfigDetail } from "../pages/ConsoleConfigPage";
 import { ConsoleCrewPage } from "../pages/ConsoleCrewPage";
 import { ConsoleOverviewPage, type ConsoleOverviewTarget } from "../pages/ConsoleOverviewPage";
 import { RuntimePage } from "../runtime/RuntimePage";
@@ -190,6 +190,10 @@ export function GsvConsole({
   // list and the header back jumps all the way to the desktop.
   const [surfaceDetail, setSurfaceDetail] = useState<ConsoleListSelection | null>(null);
   const [surfaceDetailSeq, setSurfaceDetailSeq] = useState(0);
+  // The open model/runtime config detail (reported by ConsoleConfigPage), so the
+  // breadcrumb shows SETTINGS → MODELS → [detail] and the header back-arrow exits
+  // the detail — replacing the in-page back button.
+  const [settingsConfigDetail, setSettingsConfigDetail] = useState<ConsoleConfigDetail | null>(null);
   useEffect(() => {
     setSurfaceDetail(null);
   }, [activeSurface]);
@@ -346,6 +350,12 @@ export function GsvConsole({
           // the editor no longer renders its own breadcrumb.
           { label: "CREW", onClick: () => guardedSettingsNavigate({ view: "crew" }), notLast: true },
           { label: settingsRouteLabel(settingsRoute) },
+        ] : settingsRoute.view === "config" && settingsConfigDetail ? [
+          // Config detail: SETTINGS → MODELS/RUNTIME → [detail]. The parent crumb
+          // exits the detail (back to the list); the breadcrumb owns the path
+          // back, so the detail renders no in-page back button.
+          { label: settingsRouteLabel(settingsRoute), onClick: settingsConfigDetail.onExit, notLast: true },
+          { label: settingsConfigDetail.label },
         ] : inNestedSettings ? [{ label: settingsRouteLabel(settingsRoute) }] : []),
       ]
     : activeSurface === "agent"
@@ -374,6 +384,10 @@ export function GsvConsole({
         }
         if (inSettingsListDetail && settingsRoute.view === "list") {
           guardedSettingsNavigate({ view: "list", kind: settingsRoute.kind });
+          return;
+        }
+        if (settingsRoute.view === "config" && settingsConfigDetail) {
+          settingsConfigDetail.onExit();
           return;
         }
         guardedSettingsNavigate({ view: "overview" });
@@ -418,6 +432,7 @@ export function GsvConsole({
               kind={settingsRoute.kind}
               select={settingsRoute.select}
               onClearSelect={() => navigateSettingsRoute({ view: "config", kind: settingsRoute.kind })}
+              onDetailChange={setSettingsConfigDetail}
             />
           ) : settingsRoute.view === "crew" ? (
             <ConsoleCrewPage onManageAgent={openSettingsAgent} onCreateAgent={openSettingsNewAgent} />

--- a/web/src/app/features/gsv-console/integrations/IntegrationOnboardingFlow.tsx
+++ b/web/src/app/features/gsv-console/integrations/IntegrationOnboardingFlow.tsx
@@ -1,5 +1,5 @@
 import { useState } from "preact/hooks";
-import { useUnsavedGuard, useUnsavedGuardLeave } from "../../gsv-shell/unsaved/unsavedGuard";
+import { useUnsavedGuard } from "../../gsv-shell/unsaved/unsavedGuard";
 import { Button } from "../../../components/ui/Button";
 import { Icon } from "../../../components/ui/Icon";
 import { Select } from "../../../components/ui/Select";
@@ -128,10 +128,6 @@ export function IntegrationOnboardingFlow({ onBack, onCreated }: IntegrationOnbo
       transportIndex !== 0 ||
       headers.some((row) => row.key.trim().length > 0 || row.value.trim().length > 0))
   );
-  // The flow's own back controls unmount it like shell nav does, so route them
-  // through the guard to prompt before discarding the in-progress connection.
-  const requestLeave = useUnsavedGuardLeave();
-  const guardedBack = () => requestLeave(onBack);
 
   const submit = async () => {
     if (!canSubmit) {
@@ -253,7 +249,6 @@ export function IntegrationOnboardingFlow({ onBack, onCreated }: IntegrationOnbo
             ) : null}
 
             <div class="gsv-cf-footer">
-              <Button variant="secondary" label="BACK" disabled={addServer.isPending} onClick={guardedBack} />
               <span class="gsv-cf-footer-spacer" />
               <Button
                 variant="primary"
@@ -290,7 +285,6 @@ export function IntegrationOnboardingFlow({ onBack, onCreated }: IntegrationOnbo
             ) : null}
 
             <div class="gsv-cf-footer">
-              <Button variant="secondary" label="BACK" onClick={guardedBack} />
               <span class="gsv-cf-footer-spacer" />
               {created ? (
                 <Button variant="primary" label="VIEW INTEGRATION" onClick={() => onCreated(created)} />

--- a/web/src/app/features/gsv-console/library/LibraryPage.css
+++ b/web/src/app/features/gsv-console/library/LibraryPage.css
@@ -183,9 +183,7 @@
 }
 
 .gsv-library-outline-scroll {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow: auto;
+  flex: 0 0 auto;
   padding: 6px 0;
 }
 

--- a/web/src/app/features/gsv-console/library/LibraryPage.css
+++ b/web/src/app/features/gsv-console/library/LibraryPage.css
@@ -38,8 +38,8 @@
 
 .gsv-library-page-head span,
 .gsv-library-page-head p {
-  color: var(--text-dim);
-  font-size: 9px;
+  color: var(--meta);
+  font-size: 10px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
@@ -47,8 +47,8 @@
 .gsv-library-page-head h2 {
   margin: 6px 0 0;
   overflow: hidden;
-  color: var(--text);
-  font-size: 17px;
+  color: var(--text-hi);
+  font-size: 19px;
   letter-spacing: 0.1em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -91,6 +91,85 @@
   min-height: 0;
   padding: 14px;
   overflow: hidden;
+}
+
+/* Collection bar — top strip mirroring the FILES machine bar (collection level). */
+.gsv-library-collection-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
+  padding: 14px;
+  border-bottom: 1px solid var(--rule-section, var(--line));
+  background: color-mix(in srgb, var(--panel) 92%, var(--shadow-deep, #000));
+}
+
+.gsv-library-collection-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 9px;
+  color: var(--meta);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.gsv-library-collection-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+/* Body — left action panel (page level) + page browser (FILES folder drill). */
+.gsv-library-workspace {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+}
+
+.gsv-library-action {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-right: 1px solid var(--rule-section, var(--line));
+}
+
+.gsv-library-browser {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.gsv-library-browser-crumbs {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 48px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--rule-inner, var(--line-soft));
+}
+
+.gsv-library-browser-label {
+  color: var(--meta);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.gsv-library-browser-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
 }
 
 .gsv-library-panel {
@@ -319,8 +398,8 @@
 .gsv-library-source-ref-head span,
 .gsv-library-source-ref > div:last-child {
   overflow: hidden;
-  color: var(--text-dim);
-  font-size: 9px;
+  color: var(--meta);
+  font-size: 10px;
   letter-spacing: 0.12em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -338,7 +417,7 @@
   padding: 11px 14px;
   border-bottom: 1px solid var(--line-soft);
   color: var(--text);
-  font-size: 10px;
+  font-size: 11px;
   letter-spacing: 0.08em;
   text-decoration: none;
 }
@@ -454,8 +533,8 @@
   min-height: 34px;
   padding: 0 10px 0 12px;
   border-bottom: 1px solid var(--line);
-  color: var(--text-dim);
-  font-size: 9px;
+  color: var(--meta);
+  font-size: 10px;
   letter-spacing: 0.16em;
 }
 

--- a/web/src/app/features/gsv-console/library/LibraryPage.css
+++ b/web/src/app/features/gsv-console/library/LibraryPage.css
@@ -166,6 +166,37 @@
   text-transform: uppercase;
 }
 
+/* Reader: the EDIT action sits at the right of the breadcrumb row. */
+.gsv-library-crumbs-action {
+  margin-left: auto;
+  display: inline-flex;
+}
+
+/* Reader OUTLINE — occupies the left panel (the action-bar slot on the index). */
+.gsv-library-outline-panel {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-right: 1px solid var(--rule-section, var(--line));
+}
+
+.gsv-library-outline-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 6px 0;
+}
+
+/* Reader body — markdown content fills the main pane below the breadcrumb. */
+.gsv-library-reader-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  padding: 14px;
+}
+
 .gsv-library-browser-list {
   flex: 1 1 auto;
   min-height: 0;
@@ -262,6 +293,8 @@
 }
 
 .gsv-library-reader {
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -414,22 +447,28 @@
 
 .gsv-library-outline-row {
   display: block;
-  padding: 11px 14px;
-  border-bottom: 1px solid var(--line-soft);
-  color: var(--text);
+  padding: 9px 14px;
+  color: var(--warn);
   font-size: 11px;
   letter-spacing: 0.08em;
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: color-mix(in srgb, var(--warn) 50%, transparent);
+}
+
+.gsv-library-outline-row:hover,
+.gsv-library-outline-row:focus-visible {
+  filter: brightness(1.18);
+  text-decoration-color: var(--warn);
+  outline: none;
 }
 
 .gsv-library-outline-row.level-3 {
   padding-left: 24px;
-  color: var(--text-dim);
 }
 
 .gsv-library-outline-row.level-4 {
   padding-left: 34px;
-  color: var(--text-dim);
 }
 
 .gsv-library-editor,

--- a/web/src/app/features/gsv-console/library/LibraryPage.css
+++ b/web/src/app/features/gsv-console/library/LibraryPage.css
@@ -195,6 +195,80 @@
   padding: 14px;
 }
 
+/* Narrow panel (chat dragged wide or a small window): stack the workspace so
+   the left panel moves to the top — the action bar becomes a horizontal row
+   (index) and the outline becomes a top dropdown (reader). Driven by the
+   ResizeObserver on the library root, so it tracks the panel, not the viewport. */
+.gsv-library.is-narrow .gsv-library-workspace {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.gsv-library.is-narrow .gsv-library-action {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  border-right: 0;
+  border-bottom: 1px solid var(--rule-section, var(--line));
+}
+
+.gsv-library.is-narrow .gsv-library-action > :first-child {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
+.gsv-library.is-narrow .gsv-library-outline-panel {
+  border-right: 0;
+  border-bottom: 1px solid var(--rule-section, var(--line));
+}
+
+/* Reader outline as a dropdown (narrow only). */
+.gsv-library-outline-dd > summary {
+  list-style: none;
+}
+
+.gsv-library-outline-summary {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-height: 44px;
+  padding: 12px 16px;
+  cursor: pointer;
+  color: var(--text-title);
+  font-family: var(--gsv-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.gsv-library-outline-summary::-webkit-details-marker {
+  display: none;
+}
+
+.gsv-library-outline-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--accent);
+}
+
+.gsv-library-outline-count {
+  color: var(--meta);
+}
+
+.gsv-library-outline-summary::after {
+  content: "";
+  margin-left: auto;
+  border-left: 6px solid var(--accent);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 0.15s ease;
+}
+
+.gsv-library-outline-dd[open] .gsv-library-outline-summary::after {
+  transform: rotate(90deg);
+}
+
 .gsv-library-browser-list {
   flex: 1 1 auto;
   min-height: 0;

--- a/web/src/app/features/gsv-console/library/LibraryPage.css
+++ b/web/src/app/features/gsv-console/library/LibraryPage.css
@@ -73,7 +73,6 @@
 }
 
 .gsv-library-index,
-.gsv-library-reader-page,
 .gsv-library-editor-page,
 .gsv-library-form-page {
   flex: 1 1 auto;
@@ -83,20 +82,11 @@
   overflow: hidden;
 }
 
-.gsv-library-index-grid {
-  flex: 1 1 auto;
-  display: grid;
-  grid-template-columns: minmax(240px, 300px) minmax(360px, 1fr) minmax(260px, 340px);
-  gap: 14px;
-  min-height: 0;
-  padding: 14px;
-  overflow: hidden;
-}
-
 /* Collection bar — top strip mirroring the FILES machine bar (collection level). */
 .gsv-library-collection-bar {
   flex: 0 0 auto;
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
   gap: 14px;
   padding: 14px;
@@ -275,20 +265,6 @@
   overflow: auto;
 }
 
-.gsv-library-panel {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  overflow: hidden;
-}
-
-.gsv-library-panel-body,
-.gsv-library-tree-scroll {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow: auto;
-}
-
 .gsv-library-empty-row {
   padding: 16px 18px;
   color: var(--text-dim);
@@ -305,59 +281,12 @@
   padding: 14px;
 }
 
-.gsv-library-search-zone {
-  flex: 0 0 auto;
-  border-bottom: 1px solid var(--line-soft);
-}
-
-.gsv-library-search {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px;
-  padding: 12px;
-}
-
-.gsv-library-search .gsv-btn-link {
-  grid-column: 1 / -1;
-  justify-self: start;
-}
-
 .gsv-library-search-results {
   display: flex;
   flex-direction: column;
 }
 
-.gsv-library-tree {
-  padding: 4px 0 12px;
-}
-
-.gsv-library-tree-row {
-  padding-left: calc(var(--library-tree-depth, 0) * 18px);
-}
-
-.gsv-library-tree-folder [role="group"] {
-  border-left: 1px solid color-mix(in srgb, var(--line-soft) 70%, transparent);
-  margin-left: calc((var(--library-tree-depth, 0) * 18px) + 19px);
-}
-
-.gsv-library-authoring-stack {
-  display: grid;
-  gap: 14px;
-  padding: 16px;
-}
-
-.gsv-library-reader-grid {
-  flex: 1 1 auto;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(200px, 270px);
-  gap: 14px;
-  min-height: 0;
-  padding: 14px;
-  overflow: hidden;
-}
-
 .gsv-library-reader,
-.gsv-library-outline,
 .gsv-library-editor,
 .gsv-library-form-panel,
 .gsv-library-empty-state {
@@ -509,12 +438,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   text-transform: uppercase;
-}
-
-.gsv-library-outline {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
 }
 
 .gsv-library-outline-row {
@@ -682,12 +605,6 @@
 }
 
 @media (max-width: 1040px) {
-  .gsv-library-index-grid,
-  .gsv-library-reader-grid {
-    grid-template-columns: 1fr;
-    overflow: auto;
-  }
-
   .gsv-library-page-head {
     grid-template-columns: 1fr;
     align-items: start;

--- a/web/src/app/features/gsv-console/library/LibraryPage.tsx
+++ b/web/src/app/features/gsv-console/library/LibraryPage.tsx
@@ -50,9 +50,32 @@ type PreviewState = {
   request: LibraryPreviewRequest;
 };
 
+const LIBRARY_NARROW_WIDTH = 720;
+
 export function LibraryPage({ route = { view: "index" }, onRouteChange }: LibraryPageProps) {
   const requestLeave = useUnsavedGuardLeave();
   const library = useLibraryWorkspace(route, onRouteChange, requestLeave);
+
+  // Respond to the PANEL width (chat resize + window resize), not the viewport:
+  // observe the library root so the workspace can stack and the action bar /
+  // outline move to the top when the panel is narrow. A callback ref attaches
+  // the observer once the root mounts (after the loading/error gates).
+  const [narrow, setNarrow] = useState(false);
+  const narrowObserverRef = useRef<ResizeObserver | null>(null);
+  const rootRef = useCallback((node: HTMLDivElement | null) => {
+    narrowObserverRef.current?.disconnect();
+    narrowObserverRef.current = null;
+    if (!node) {
+      return;
+    }
+    const measure = () => setNarrow(node.getBoundingClientRect().width < LIBRARY_NARROW_WIDTH);
+    measure();
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(measure);
+      observer.observe(node);
+      narrowObserverRef.current = observer;
+    }
+  }, []);
 
   useUnsavedGuard(() => {
     const editorNote = library.state.selectedNote;
@@ -109,11 +132,11 @@ export function LibraryPage({ route = { view: "index" }, onRouteChange }: Librar
 
   return (
     <ConsolePage flush>
-      <div class="gsv-library" aria-label="GSV library">
+      <div class={`gsv-library${narrow ? " is-narrow" : ""}`} aria-label="GSV library" ref={rootRef}>
         {library.error ? <StatusBanner tone="error" label={library.error} /> : null}
         {!library.error && library.notice ? <StatusBanner tone="live" label={library.notice} /> : null}
         {library.activeRoute.view === "reader" ? (
-          <LibraryReader library={library} />
+          <LibraryReader library={library} narrow={narrow} />
         ) : library.activeRoute.view === "editor" ? (
           <LibraryEditor library={library} />
         ) : library.activeRoute.view === "capture" ? (
@@ -373,8 +396,10 @@ function SearchResults({
   );
 }
 
-function LibraryReader({ library }: { library: LibraryRuntime }) {
+function LibraryReader({ library, narrow }: { library: LibraryRuntime; narrow: boolean }) {
   const note = library.state.selectedNote;
+  // When narrow, the outline collapses into a top dropdown (closed by default).
+  const [outlineOpen, setOutlineOpen] = useState(false);
   const [previewState, setPreviewState] = useState<PreviewState | null>(null);
   const [previewPayload, setPreviewPayload] = useState<LibraryPreviewPayload | null>(null);
   const [previewLoadingKey, setPreviewLoadingKey] = useState<string | null>(null);
@@ -516,26 +541,44 @@ function LibraryReader({ library }: { library: LibraryRuntime }) {
   ];
   const backFolder = belowBase.length ? belowBase[belowBase.length - 1].path : "";
 
+  const outlineRows = library.pageHeadings.length === 0 ? (
+    <div class="gsv-library-empty-row">NO HEADINGS</div>
+  ) : library.pageHeadings.map((heading) => (
+    <a
+      class={`gsv-library-outline-row level-${heading.level}`}
+      href={`#${heading.id}`}
+      key={heading.id}
+    >
+      {heading.text}
+    </a>
+  ));
+
   return (
     <div class="gsv-library-index">
       <LibraryCollectionBar library={library} />
       <div class="gsv-library-workspace">
-        {/* OUTLINE takes the left panel (the action-bar slot on the index). */}
+        {/* OUTLINE takes the left panel on wide screens; when narrow it moves to
+            the top and collapses into a dropdown. */}
         <section class="gsv-library-outline-panel">
-          <SectionHeader title="OUTLINE" meta={`${library.pageHeadings.length}`} divider />
-          <div class="gsv-library-outline-scroll">
-            {library.pageHeadings.length === 0 ? (
-              <div class="gsv-library-empty-row">NO HEADINGS</div>
-            ) : library.pageHeadings.map((heading) => (
-              <a
-                class={`gsv-library-outline-row level-${heading.level}`}
-                href={`#${heading.id}`}
-                key={heading.id}
-              >
-                {heading.text}
-              </a>
-            ))}
-          </div>
+          {narrow ? (
+            <details
+              class="gsv-library-outline-dd"
+              open={outlineOpen}
+              onToggle={(event) => setOutlineOpen((event.currentTarget as HTMLDetailsElement).open)}
+            >
+              <summary class="gsv-library-outline-summary">
+                <span class="gsv-library-outline-dot" aria-hidden="true" />
+                OUTLINE
+                <span class="gsv-library-outline-count">{library.pageHeadings.length}</span>
+              </summary>
+              <div class="gsv-library-outline-scroll">{outlineRows}</div>
+            </details>
+          ) : (
+            <>
+              <SectionHeader title="OUTLINE" meta={`${library.pageHeadings.length}`} divider />
+              <div class="gsv-library-outline-scroll">{outlineRows}</div>
+            </>
+          )}
         </section>
         <section class="gsv-library-browser">
           <div class="gsv-library-browser-crumbs">

--- a/web/src/app/features/gsv-console/library/LibraryPage.tsx
+++ b/web/src/app/features/gsv-console/library/LibraryPage.tsx
@@ -128,23 +128,20 @@ export function LibraryPage({ route = { view: "index" }, onRouteChange }: Librar
   );
 }
 
-function LibraryIndex({ library }: { library: LibraryRuntime }) {
+/** Collection bar — every collection-level control (mirrors the FILES machine
+ *  bar). Shared by the index and the reader so all views share one shell. */
+function LibraryCollectionBar({ library }: { library: LibraryRuntime }) {
   const { dbs } = library.state;
   const selectedDb = library.state.selectedDb;
   const selectedCollection = dbs.find((collection) => collection.id === selectedDb) ?? null;
-  const searching = library.state.searchQuery.trim().length > 0;
-  const searchResults = sortLibraryEntries(library.state.searchMatches ?? []);
   const pageCount = library.state.pages.length;
-  const collectionLabel = selectedCollection ? selectedCollection.title : "LIBRARY";
   const collectionOptions = dbs.length
     ? dbs.map((collection) => collection.title.toUpperCase())
     : ["NO COLLECTIONS"];
   const selectedIndex = Math.max(0, dbs.findIndex((collection) => collection.id === selectedDb));
 
   return (
-    <div class="gsv-library-index">
-      {/* Collection bar — every collection-level control lives here (mirrors the
-          FILES machine bar): pick a collection, see its status, create / build one. */}
+    <>
       <header class="gsv-library-collection-bar">
         <Select
           label="COLLECTION"
@@ -180,6 +177,19 @@ function LibraryIndex({ library }: { library: LibraryRuntime }) {
         </div>
       </header>
       {library.createCollectionOpen ? <CreateCollectionBox library={library} /> : null}
+    </>
+  );
+}
+
+function LibraryIndex({ library }: { library: LibraryRuntime }) {
+  const selectedDb = library.state.selectedDb;
+  const searching = library.state.searchQuery.trim().length > 0;
+  const searchResults = sortLibraryEntries(library.state.searchMatches ?? []);
+  const collectionLabel = library.state.dbs.find((collection) => collection.id === selectedDb)?.title ?? "LIBRARY";
+
+  return (
+    <div class="gsv-library-index">
+      <LibraryCollectionBar library={library} />
 
       {/* Body — left action panel (page-level: search + create inside the
           collection) beside a FILES-style page browser. */}
@@ -229,6 +239,8 @@ function LibraryIndex({ library }: { library: LibraryRuntime }) {
               collectionLabel={collectionLabel}
               db={selectedDb}
               entries={library.state.pages}
+              folder={library.browserFolder}
+              onFolderChange={library.setBrowserFolder}
               onOpenPage={library.openPage}
             />
           )}
@@ -244,11 +256,16 @@ function FolderBrowser({
   collectionLabel,
   db,
   entries,
+  folder,
+  onFolderChange,
   onOpenPage,
 }: {
   collectionLabel: string;
   db: string;
   entries: readonly LibraryEntry[];
+  /** Current folder (local page path, or "" for the content root). Controlled. */
+  folder: string;
+  onFolderChange: (folder: string) => void;
   onOpenPage: (path: string) => void;
 }) {
   const tree = useMemo(() => buildLibraryTree(entries, db), [db, entries]);
@@ -258,10 +275,8 @@ function FolderBrowser({
   const overview = tree.children.find((child) => child.kind === "file" && child.path === "index.md") ?? null;
   const contentRoot = tree.children.find((child) => child.kind === "folder" && child.name === "pages") ?? tree;
   const basePath = contentRoot.path;
-  const [folderPath, setFolderPath] = useState(basePath);
-  useEffect(() => {
-    setFolderPath(basePath);
-  }, [db, basePath]);
+  // "" (the default / reset value) resolves to the content root.
+  const folderPath = folder || basePath;
 
   // Walk from the tree root to the current folder.
   const chain: LibraryTreeNode[] = [];
@@ -279,11 +294,11 @@ function FolderBrowser({
   const baseDepth = basePath ? basePath.split("/").filter(Boolean).length : 0;
   const belowBase = chain.slice(baseDepth);
   const crumbs: Crumb[] = [
-    { label: collectionLabel, onClick: () => setFolderPath(basePath) },
-    ...belowBase.map((folder) => ({ label: folder.title, onClick: () => setFolderPath(folder.path) })),
+    { label: collectionLabel, onClick: () => onFolderChange("") },
+    ...belowBase.map((node) => ({ label: node.title, onClick: () => onFolderChange(node.path) })),
   ];
   const goUp = folderPath !== basePath
-    ? () => setFolderPath(belowBase.length > 1 ? belowBase[belowBase.length - 2].path : basePath)
+    ? () => onFolderChange(belowBase.length > 1 ? belowBase[belowBase.length - 2].path : "")
     : undefined;
 
   const atBase = folderPath === basePath;
@@ -318,7 +333,7 @@ function FolderBrowser({
             icon="folder"
             key={child.id}
             label={child.title}
-            onClick={() => setFolderPath(child.path)}
+            onClick={() => onFolderChange(child.path)}
             status="none"
             sub={`${child.count} ${child.count === 1 ? "page" : "pages"}`}
             tag="DIR"
@@ -470,51 +485,87 @@ function LibraryReader({ library }: { library: LibraryRuntime }) {
   }
   const db = library.activeRoute.db;
 
+  // Continue the browser trail into the open page — collection / <folders> /
+  // <page> — deriving the folders from the page path so Back and the folder
+  // crumbs return to the right place in the browser (same shell as the index).
+  const tree = buildLibraryTree(library.state.pages, db);
+  const localPath = localLibraryPath(note.path, db);
+  const contentRoot = tree.children.find((child) => child.kind === "folder" && child.name === "pages") ?? tree;
+  const basePath = contentRoot.path;
+  const baseDepth = basePath ? basePath.split("/").filter(Boolean).length : 0;
+  const folderChain: LibraryTreeNode[] = [];
+  let node = tree;
+  for (const part of localPath.split("/").filter(Boolean).slice(0, -1)) {
+    const next = node.children.find((child) => child.kind !== "file" && child.name === part);
+    if (!next) {
+      break;
+    }
+    folderChain.push(next);
+    node = next;
+  }
+  const belowBase = folderChain.slice(baseDepth);
+  const collectionLabel = library.state.dbs.find((collection) => collection.id === db)?.title ?? "LIBRARY";
+  const openFolder = (folderPath: string) => {
+    library.setBrowserFolder(folderPath);
+    library.navigate({ view: "index", db });
+  };
+  const crumbs: Crumb[] = [
+    { label: collectionLabel, onClick: () => openFolder("") },
+    ...belowBase.map((folder) => ({ label: folder.title, onClick: () => openFolder(folder.path) })),
+    { label: note.title },
+  ];
+  const backFolder = belowBase.length ? belowBase[belowBase.length - 1].path : "";
+
   return (
-    <div class="gsv-library-reader-page">
-      <LibraryPageHeader
-        eyebrow={library.activeRoute.db}
-        title={note.title}
-        meta={note.path}
-        actions={(
-          <>
-            {/* Back to the library index is owned by the breadcrumb now. */}
-            <Button
-              variant="primary"
-              label="EDIT"
-              onClick={() => library.navigate({
-                view: "editor",
-                db,
-                path: localLibraryPath(note.path, db),
-              })}
-            />
-          </>
-        )}
-      />
-      <div class="gsv-library-reader-grid">
-        <Surface class="gsv-library-reader" level={2}>
-          <LibraryMarkdownView
-            note={note}
-            selectedDb={db}
-            onOpenPage={openPage}
-            onPreviewClose={closePreview}
-            onPreviewOpen={openPreview}
-          />
-        </Surface>
-        <Surface class="gsv-library-outline" level={1}>
+    <div class="gsv-library-index">
+      <LibraryCollectionBar library={library} />
+      <div class="gsv-library-workspace">
+        {/* OUTLINE takes the left panel (the action-bar slot on the index). */}
+        <section class="gsv-library-outline-panel">
           <SectionHeader title="OUTLINE" meta={`${library.pageHeadings.length}`} divider />
-          {library.pageHeadings.length === 0 ? (
-            <div class="gsv-library-empty-row">NO HEADINGS</div>
-          ) : library.pageHeadings.map((heading) => (
-            <a
-              class={`gsv-library-outline-row level-${heading.level}`}
-              href={`#${heading.id}`}
-              key={heading.id}
-            >
-              {heading.text}
-            </a>
-          ))}
-        </Surface>
+          <div class="gsv-library-outline-scroll">
+            {library.pageHeadings.length === 0 ? (
+              <div class="gsv-library-empty-row">NO HEADINGS</div>
+            ) : library.pageHeadings.map((heading) => (
+              <a
+                class={`gsv-library-outline-row level-${heading.level}`}
+                href={`#${heading.id}`}
+                key={heading.id}
+              >
+                {heading.text}
+              </a>
+            ))}
+          </div>
+        </section>
+        <section class="gsv-library-browser">
+          <div class="gsv-library-browser-crumbs">
+            <Breadcrumbs
+              items={crumbs}
+              size="medium"
+              maxVisible={4}
+              onBack={() => openFolder(backFolder)}
+              currentAriaCurrent="location"
+            />
+            <span class="gsv-library-crumbs-action">
+              <Button
+                variant="primary"
+                label="EDIT"
+                onClick={() => library.navigate({ view: "editor", db, path: localLibraryPath(note.path, db) })}
+              />
+            </span>
+          </div>
+          <div class="gsv-library-reader-body">
+            <Surface class="gsv-library-reader" level={2}>
+              <LibraryMarkdownView
+                note={note}
+                selectedDb={db}
+                onOpenPage={openPage}
+                onPreviewClose={closePreview}
+                onPreviewOpen={openPreview}
+              />
+            </Surface>
+          </div>
+        </section>
       </div>
       <LibraryPreviewLayer
         data={previewPayload}

--- a/web/src/app/features/gsv-console/library/LibraryPage.tsx
+++ b/web/src/app/features/gsv-console/library/LibraryPage.tsx
@@ -96,9 +96,17 @@ export function LibraryPage({ route = { view: "index" }, onRouteChange }: Librar
       library.activeRoute.view === "build" &&
       (library.buildPath.trim().length > 0 ||
         library.buildDbTitle.trim().length > 0 ||
-        library.buildTarget !== "gsv");
+        library.buildTarget !== "gsv" ||
+        // DESTINATION ID is auto-seeded to the collection id, so a length check
+        // can't tell "untouched" from "typed". Dirty only when it diverges from
+        // that seed (activeRoute.db, falling back to the selected collection).
+        (library.buildDbId.trim().length > 0 &&
+          library.buildDbId !== (library.activeRoute.db ?? library.state.selectedDb ?? "")));
     const collectionDirty =
-      library.activeRoute.view === "index" &&
+      // The collection bar (NEW COLLECTION draft) renders on both the index and
+      // the reader, so a draft typed from either view must register as dirty —
+      // guarding only the index dropped reader-opened drafts without a prompt.
+      (library.activeRoute.view === "index" || library.activeRoute.view === "reader") &&
       library.createCollectionOpen &&
       (library.newCollectionTitle.trim().length > 0 ||
         library.newCollectionId.trim().length > 0);
@@ -190,12 +198,14 @@ function LibraryCollectionBar({ library }: { library: LibraryRuntime }) {
           <Button
             variant="primary"
             label={library.createCollectionOpen ? "CLOSE" : "NEW COLLECTION"}
-            onClick={() => library.setCreateCollectionOpen((open) => !open)}
+            onClick={() => library.createCollectionOpen
+              ? library.closeCreateCollection()
+              : library.setCreateCollectionOpen(true)}
           />
           <Button
             variant="secondary"
             label="BUILD"
-            onClick={() => library.navigate({ view: "build", ...(selectedDb ? { db: selectedDb } : {}) })}
+            onClick={() => library.openBuild()}
           />
         </div>
       </header>
@@ -239,7 +249,7 @@ function LibraryIndex({ library }: { library: LibraryRuntime }) {
             variant="secondary"
             label="CAPTURE SOURCE"
             disabled={!selectedDb}
-            onClick={() => selectedDb ? library.navigate({ view: "capture", db: selectedDb }) : undefined}
+            onClick={() => library.openCapture()}
           />
         </section>
 
@@ -819,7 +829,7 @@ function CreateCollectionBox({ library }: { library: LibraryRuntime }) {
           variant="secondary"
           label="CANCEL"
           disabled={library.mutating}
-          onClick={() => library.setCreateCollectionOpen(false)}
+          onClick={() => library.closeCreateCollection()}
         />
         <Button
           variant="primary"

--- a/web/src/app/features/gsv-console/library/LibraryPage.tsx
+++ b/web/src/app/features/gsv-console/library/LibraryPage.tsx
@@ -1,11 +1,13 @@
-import type { ComponentChildren, JSX } from "preact";
+import type { ComponentChildren } from "preact";
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 import type { ShellLibraryRoute } from "../../gsv-shell/domain/shellModel";
-import { AddAction } from "../../../components/ui/AddAction";
+import { Breadcrumbs, type Crumb } from "../../../components/ui/Breadcrumbs";
 import { Button } from "../../../components/ui/Button";
 import { Icon } from "../../../components/ui/Icon";
 import { ListRow } from "../../../components/ui/ListRow";
+import { Search } from "../../../components/ui/Search";
 import { SectionHeader } from "../../../components/ui/SectionHeader";
+import { Select } from "../../../components/ui/Select";
 import { StatusDot } from "../../../components/ui/StatusDot";
 import { Surface } from "../../../components/ui/Surface";
 import { TextArea } from "../../../components/ui/TextArea";
@@ -15,7 +17,6 @@ import {
   ConsolePageState,
 } from "../components/ConsolePageTemplate";
 import {
-  ancestorFolderPaths,
   buildLibraryTree,
   libraryEntrySub,
   localLibraryPath,
@@ -28,7 +29,6 @@ import {
 import { useLibraryWorkspace } from "./useLibraryWorkspace";
 import { useUnsavedGuard, useUnsavedGuardLeave } from "../../gsv-shell/unsaved/unsavedGuard";
 import type {
-  LibraryCollection,
   LibraryEntry,
   LibraryPreviewPayload,
   LibraryPreviewRequest,
@@ -129,152 +129,190 @@ export function LibraryPage({ route = { view: "index" }, onRouteChange }: Librar
 }
 
 function LibraryIndex({ library }: { library: LibraryRuntime }) {
+  const { dbs } = library.state;
   const selectedDb = library.state.selectedDb;
-  const pages = sortLibraryEntries(library.state.searchMatches ?? library.state.pages);
+  const selectedCollection = dbs.find((collection) => collection.id === selectedDb) ?? null;
   const searching = library.state.searchQuery.trim().length > 0;
+  const searchResults = sortLibraryEntries(library.state.searchMatches ?? []);
+  const pageCount = library.state.pages.length;
+  const collectionLabel = selectedCollection ? selectedCollection.title : "LIBRARY";
+  const collectionOptions = dbs.length
+    ? dbs.map((collection) => collection.title.toUpperCase())
+    : ["NO COLLECTIONS"];
+  const selectedIndex = Math.max(0, dbs.findIndex((collection) => collection.id === selectedDb));
 
   return (
     <div class="gsv-library-index">
-      <LibraryPageHeader
-        eyebrow="LIBRARY"
-        title={selectedDb ? collectionTitle(library.state.dbs, selectedDb) : "Knowledge Library"}
-        meta={selectedDb ? selectedDb : "SELECT COLLECTION"}
-        actions={(
-          <>
-            <Button
-              variant="secondary"
-              label="BUILD"
-              onClick={() => library.navigate({ view: "build", ...(selectedDb ? { db: selectedDb } : {}) })}
-            />
-            <Button
-              variant="primary"
-              label="NEW PAGE"
-              disabled={!selectedDb}
-              onClick={() => selectedDb ? library.navigate({ view: "editor", db: selectedDb }) : undefined}
-            />
-          </>
-        )}
-      />
-
-      <div class="gsv-library-index-grid">
-        <Surface class="gsv-library-panel gsv-library-collections" level={2}>
-          <SectionHeader title="COLLECTIONS" meta={`${library.state.dbs.length}`} divider />
-          <div class="gsv-library-panel-body">
-            {library.state.dbs.length === 0 ? (
-              <div class="gsv-library-empty-row">NO COLLECTIONS</div>
-            ) : library.state.dbs.map((collection) => (
-              <CollectionRow
-                collection={collection}
-                key={collection.id}
-                selected={collection.id === selectedDb}
-                onOpen={() => library.openCollection(collection.id)}
-              />
-            ))}
-            <AddAction
-              variant="row"
-              label={library.createCollectionOpen ? "CLOSE CREATOR" : "NEW COLLECTION"}
-              onClick={() => library.setCreateCollectionOpen((open) => !open)}
-            />
-          </div>
-          {library.createCollectionOpen ? <CreateCollectionBox library={library} /> : null}
-        </Surface>
-
-        <Surface class="gsv-library-panel gsv-library-tree-panel" level={2}>
-          <SectionHeader
-            title={searching ? "SEARCH RESULTS" : "PAGES"}
-            meta={searching ? `${pages.length} MATCHES` : `${pages.length}`}
-            divider
+      {/* Collection bar — every collection-level control lives here (mirrors the
+          FILES machine bar): pick a collection, see its status, create / build one. */}
+      <header class="gsv-library-collection-bar">
+        <Select
+          label="COLLECTION"
+          size="medium"
+          width={280}
+          disabled={dbs.length === 0}
+          options={collectionOptions}
+          value={selectedIndex}
+          onChange={(index) => {
+            const next = dbs[index];
+            if (next) {
+              library.openCollection(next.id);
+            }
+          }}
+        />
+        {selectedCollection ? (
+          <span class="gsv-library-collection-meta">
+            <StatusDot tone={selectedCollection.writable ? "online" : "idle"} size={7} />
+            {selectedCollection.writable ? "WRITE" : "READ"} · {pageCount} {pageCount === 1 ? "PAGE" : "PAGES"}
+          </span>
+        ) : null}
+        <div class="gsv-library-collection-actions">
+          <Button
+            variant="primary"
+            label={library.createCollectionOpen ? "CLOSE" : "NEW COLLECTION"}
+            onClick={() => library.setCreateCollectionOpen((open) => !open)}
           />
-          <div class="gsv-library-search-zone">
-            <form
-              class="gsv-library-search"
-              onSubmit={(event) => {
-                event.preventDefault();
-                library.applySearch();
-              }}
-            >
-              <TextInput
-                label=""
-                placeholder="Search pages"
-                clearable
-                size="small"
-                value={library.searchDraft}
-                onChange={library.setSearchDraft}
-              />
-              <Button variant="secondary" label="SEARCH" type="submit" />
-              {searching ? <Button variant="link" label="CLEAR" onClick={library.clearSearch} /> : null}
-            </form>
-          </div>
-          <div class="gsv-library-tree-scroll">
-            {!selectedDb ? (
-              <div class="gsv-library-empty-row">SELECT COLLECTION</div>
-            ) : searching ? (
-              <SearchResults db={selectedDb} entries={pages} onOpenPage={library.openPage} />
-            ) : (
-              <LibraryTree
-                db={selectedDb}
-                entries={pages}
-                selectedPath=""
-                onOpenPage={library.openPage}
-              />
-            )}
-          </div>
-        </Surface>
+          <Button
+            variant="secondary"
+            label="BUILD"
+            onClick={() => library.navigate({ view: "build", ...(selectedDb ? { db: selectedDb } : {}) })}
+          />
+        </div>
+      </header>
+      {library.createCollectionOpen ? <CreateCollectionBox library={library} /> : null}
 
-        <Surface class="gsv-library-panel gsv-library-actions-panel" level={2}>
-          <SectionHeader title="AUTHORING" meta={selectedDb || "IDLE"} divider />
-          <div class="gsv-library-authoring-stack">
-            <TextInput
-              label="PAGE TITLE"
-              placeholder="New page title"
-              value={library.newPageTitle}
-              onChange={library.setNewPageTitle}
+      {/* Body — left action panel (page-level: search + create inside the
+          collection) beside a FILES-style page browser. */}
+      <div class="gsv-library-workspace">
+        <section class="gsv-library-action">
+          <Search
+            block
+            placeholder="Search pages"
+            disabled={!selectedDb}
+            value={library.searchDraft}
+            onChange={library.setSearchDraft}
+            onSearch={() => library.applySearch()}
+          />
+          {searching ? (
+            <Button variant="link" label="CLEAR SEARCH" onClick={library.clearSearch} />
+          ) : null}
+          <Button
+            variant="primary"
+            label="WRITE PAGE"
+            disabled={!selectedDb || library.mutating}
+            onClick={() => library.openEditor()}
+          />
+          <Button
+            variant="secondary"
+            label="CAPTURE SOURCE"
+            disabled={!selectedDb}
+            onClick={() => selectedDb ? library.navigate({ view: "capture", db: selectedDb }) : undefined}
+          />
+        </section>
+
+        <section class="gsv-library-browser">
+          {!selectedDb ? (
+            <div class="gsv-library-empty-row">SELECT COLLECTION</div>
+          ) : searching ? (
+            <>
+              <div class="gsv-library-browser-crumbs">
+                <span class="gsv-library-browser-label">
+                  SEARCH RESULTS · {searchResults.length} {searchResults.length === 1 ? "MATCH" : "MATCHES"}
+                </span>
+              </div>
+              <div class="gsv-library-browser-list">
+                <SearchResults db={selectedDb} entries={searchResults} onOpenPage={library.openPage} />
+              </div>
+            </>
+          ) : (
+            <FolderBrowser
+              collectionLabel={collectionLabel}
+              db={selectedDb}
+              entries={library.state.pages}
+              onOpenPage={library.openPage}
             />
-            <Button
-              variant="primary"
-              label="WRITE PAGE"
-              disabled={!selectedDb || library.mutating}
-              onClick={library.createPageDraft}
-            />
-            <Button
-              variant="secondary"
-              label="CAPTURE SOURCE"
-              disabled={!selectedDb}
-              onClick={() => selectedDb ? library.navigate({ view: "capture", db: selectedDb }) : undefined}
-            />
-            <Button
-              variant="secondary"
-              label="BUILD FROM DIRECTORY"
-              onClick={() => library.navigate({ view: "build", ...(selectedDb ? { db: selectedDb } : {}) })}
-            />
-          </div>
-        </Surface>
+          )}
+        </section>
       </div>
     </div>
   );
 }
 
-function CollectionRow({
-  collection,
-  onOpen,
-  selected,
+/** FILES-style page browser: drill through the collection's folder tree with a
+ *  breadcrumb trail. Folders synthesize from the flat page paths (buildLibraryTree). */
+function FolderBrowser({
+  collectionLabel,
+  db,
+  entries,
+  onOpenPage,
 }: {
-  collection: LibraryCollection;
-  onOpen: () => void;
-  selected: boolean;
+  collectionLabel: string;
+  db: string;
+  entries: readonly LibraryEntry[];
+  onOpenPage: (path: string) => void;
 }) {
+  const tree = useMemo(() => buildLibraryTree(entries, db), [db, entries]);
+  const [folderPath, setFolderPath] = useState("");
+  useEffect(() => {
+    setFolderPath("");
+  }, [db]);
+
+  // Walk to the current folder, collecting ancestors for the breadcrumb trail.
+  const ancestors: LibraryTreeNode[] = [];
+  let current = tree;
+  for (const part of folderPath.split("/").filter(Boolean)) {
+    const next = current.children.find((child) => child.kind !== "file" && child.name === part);
+    if (!next) {
+      break;
+    }
+    ancestors.push(next);
+    current = next;
+  }
+
+  const crumbs: Crumb[] = [
+    { label: collectionLabel, onClick: () => setFolderPath("") },
+    ...ancestors.map((folder) => ({ label: folder.title, onClick: () => setFolderPath(folder.path) })),
+  ];
+  const goUp = folderPath
+    ? () => setFolderPath(ancestors.length > 1 ? ancestors[ancestors.length - 2].path : "")
+    : undefined;
+
+  const children = [...current.children].sort((left, right) =>
+    (left.kind === "file" ? 1 : 0) - (right.kind === "file" ? 1 : 0)
+    || left.title.localeCompare(right.title));
+
   return (
-    <ListRow
-      active={selected}
-      chevron
-      icon="pencil"
-      label={collection.title}
-      onClick={onOpen}
-      status={collection.writable ? "online" : "idle"}
-      statusDotPlacement="trailing"
-      statusLabel={collection.writable ? "WRITE" : "READ"}
-      sub={collection.id}
-    />
+    <>
+      <div class="gsv-library-browser-crumbs">
+        <Breadcrumbs items={crumbs} size="medium" maxVisible={4} onBack={goUp} currentAriaCurrent="location" />
+      </div>
+      <div class="gsv-library-browser-list">
+        {children.length === 0 ? (
+          <div class="gsv-library-empty-row">NO PAGES</div>
+        ) : children.map((child) => child.kind === "file" ? (
+          <ListRow
+            chevron
+            icon={child.path === "index.md" ? "pencil" : "doticons/file"}
+            key={child.id}
+            label={child.title}
+            onClick={() => child.entry ? onOpenPage(child.entry.path) : undefined}
+            status="none"
+            sub={child.entry ? libraryEntrySub(child.entry, db) : child.path}
+          />
+        ) : (
+          <ListRow
+            chevron
+            icon="folder"
+            key={child.id}
+            label={child.title}
+            onClick={() => setFolderPath(child.path)}
+            status="none"
+            sub={`${child.count} ${child.count === 1 ? "page" : "pages"}`}
+            tag="DIR"
+          />
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -303,122 +341,6 @@ function SearchResults({
           sub={entry.snippet || libraryEntrySub(entry, db)}
         />
       ))}
-    </div>
-  );
-}
-
-function LibraryTree({
-  db,
-  entries,
-  onOpenPage,
-  selectedPath,
-}: {
-  db: string;
-  entries: readonly LibraryEntry[];
-  onOpenPage: (path: string) => void;
-  selectedPath: string;
-}) {
-  const tree = useMemo(() => buildLibraryTree(entries, db), [db, entries]);
-  const selectedLocalPath = selectedPath ? localLibraryPath(selectedPath, db) : "";
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(ancestorFolderPaths(selectedLocalPath)));
-
-  const toggle = (path: string) => {
-    setExpanded((current) => {
-      const next = new Set(current);
-      if (next.has(path)) {
-        next.delete(path);
-      } else {
-        next.add(path);
-      }
-      return next;
-    });
-  };
-
-  if (tree.children.length === 0) {
-    return <div class="gsv-library-empty-row">NO PAGES</div>;
-  }
-
-  return (
-    <div class="gsv-library-tree" role="tree">
-      {tree.children.map((node) => (
-        <LibraryTreeNodeView
-          db={db}
-          expanded={expanded}
-          key={node.id}
-          node={node}
-          onOpenPage={onOpenPage}
-          onToggle={toggle}
-          selectedLocalPath={selectedLocalPath}
-          depth={0}
-        />
-      ))}
-    </div>
-  );
-}
-
-function LibraryTreeNodeView({
-  db,
-  depth,
-  expanded,
-  node,
-  onOpenPage,
-  onToggle,
-  selectedLocalPath,
-}: {
-  db: string;
-  depth: number;
-  expanded: Set<string>;
-  node: LibraryTreeNode;
-  onOpenPage: (path: string) => void;
-  onToggle: (path: string) => void;
-  selectedLocalPath: string;
-}) {
-  if (node.kind === "file") {
-    return (
-      <div class="gsv-library-tree-row" style={{ "--library-tree-depth": depth } as JSX.CSSProperties}>
-        <ListRow
-          active={Boolean(selectedLocalPath && selectedLocalPath === node.path)}
-          chevron
-          icon={node.path === "index.md" ? "pencil" : "doticons/file"}
-          label={node.title}
-          onClick={() => node.entry ? onOpenPage(node.entry.path) : undefined}
-          status="none"
-          sub={node.entry ? libraryEntrySub(node.entry, db) : node.path}
-        />
-      </div>
-    );
-  }
-
-  const open = expanded.has(node.path);
-  return (
-    <div class="gsv-library-tree-folder" role="treeitem" aria-expanded={open}>
-      <div class="gsv-library-tree-row" style={{ "--library-tree-depth": depth } as JSX.CSSProperties}>
-        <ListRow
-          chevron
-          icon="folder"
-          label={node.title}
-          onClick={() => onToggle(node.path)}
-          status="none"
-          sub={`${node.count} ${node.count === 1 ? "page" : "pages"}`}
-          tag={open ? "OPEN" : undefined}
-        />
-      </div>
-      {open ? (
-        <div role="group">
-          {node.children.map((child) => (
-            <LibraryTreeNodeView
-              db={db}
-              depth={depth + 1}
-              expanded={expanded}
-              key={child.id}
-              node={child}
-              onOpenPage={onOpenPage}
-              onToggle={onToggle}
-              selectedLocalPath={selectedLocalPath}
-            />
-          ))}
-        </div>
-      ) : null}
     </div>
   );
 }
@@ -866,9 +788,6 @@ function StatusBanner({
   );
 }
 
-function collectionTitle(collections: readonly LibraryCollection[], db: string): string {
-  return collections.find((collection) => collection.id === db)?.title || db;
-}
 
 function previewRequestKey(request: LibraryPreviewRequest): string {
   if (request.kind === "page") {

--- a/web/src/app/features/gsv-console/library/LibraryPage.tsx
+++ b/web/src/app/features/gsv-console/library/LibraryPage.tsx
@@ -252,34 +252,47 @@ function FolderBrowser({
   onOpenPage: (path: string) => void;
 }) {
   const tree = useMemo(() => buildLibraryTree(entries, db), [db, entries]);
-  const [folderPath, setFolderPath] = useState("");
+  // `pages/` is the content root and `index.md` is the collection home: start
+  // the browser INSIDE pages/ (so the real section folders show at the top
+  // instead of a "Pages" wrapper) and pin Overview at the top.
+  const overview = tree.children.find((child) => child.kind === "file" && child.path === "index.md") ?? null;
+  const contentRoot = tree.children.find((child) => child.kind === "folder" && child.name === "pages") ?? tree;
+  const basePath = contentRoot.path;
+  const [folderPath, setFolderPath] = useState(basePath);
   useEffect(() => {
-    setFolderPath("");
-  }, [db]);
+    setFolderPath(basePath);
+  }, [db, basePath]);
 
-  // Walk to the current folder, collecting ancestors for the breadcrumb trail.
-  const ancestors: LibraryTreeNode[] = [];
+  // Walk from the tree root to the current folder.
+  const chain: LibraryTreeNode[] = [];
   let current = tree;
   for (const part of folderPath.split("/").filter(Boolean)) {
     const next = current.children.find((child) => child.kind !== "file" && child.name === part);
     if (!next) {
       break;
     }
-    ancestors.push(next);
+    chain.push(next);
     current = next;
   }
 
+  // Breadcrumb: the collection IS the content root; only show folders below it.
+  const baseDepth = basePath ? basePath.split("/").filter(Boolean).length : 0;
+  const belowBase = chain.slice(baseDepth);
   const crumbs: Crumb[] = [
-    { label: collectionLabel, onClick: () => setFolderPath("") },
-    ...ancestors.map((folder) => ({ label: folder.title, onClick: () => setFolderPath(folder.path) })),
+    { label: collectionLabel, onClick: () => setFolderPath(basePath) },
+    ...belowBase.map((folder) => ({ label: folder.title, onClick: () => setFolderPath(folder.path) })),
   ];
-  const goUp = folderPath
-    ? () => setFolderPath(ancestors.length > 1 ? ancestors[ancestors.length - 2].path : "")
+  const goUp = folderPath !== basePath
+    ? () => setFolderPath(belowBase.length > 1 ? belowBase[belowBase.length - 2].path : basePath)
     : undefined;
 
-  const children = [...current.children].sort((left, right) =>
-    (left.kind === "file" ? 1 : 0) - (right.kind === "file" ? 1 : 0)
-    || left.title.localeCompare(right.title));
+  const atBase = folderPath === basePath;
+  const byTitle = (left: LibraryTreeNode, right: LibraryTreeNode) => left.title.localeCompare(right.title);
+  const folders = current.children.filter((child) => child.kind === "folder").sort(byTitle);
+  const files = current.children
+    .filter((child) => child.kind === "file" && child.path !== "index.md")
+    .sort(byTitle);
+  const rows: LibraryTreeNode[] = [...(atBase && overview ? [overview] : []), ...folders, ...files];
 
   return (
     <>
@@ -287,9 +300,9 @@ function FolderBrowser({
         <Breadcrumbs items={crumbs} size="medium" maxVisible={4} onBack={goUp} currentAriaCurrent="location" />
       </div>
       <div class="gsv-library-browser-list">
-        {children.length === 0 ? (
+        {rows.length === 0 ? (
           <div class="gsv-library-empty-row">NO PAGES</div>
-        ) : children.map((child) => child.kind === "file" ? (
+        ) : rows.map((child) => child.kind === "file" ? (
           <ListRow
             chevron
             icon={child.path === "index.md" ? "pencil" : "doticons/file"}

--- a/web/src/app/features/gsv-console/library/LibraryPage.tsx
+++ b/web/src/app/features/gsv-console/library/LibraryPage.tsx
@@ -543,11 +543,7 @@ function LibraryReader({ library }: { library: LibraryRuntime }) {
         meta={note.path}
         actions={(
           <>
-            <Button
-              variant="secondary"
-              label="LIBRARY"
-              onClick={() => library.navigate({ view: "index", db })}
-            />
+            {/* Back to the library index is owned by the breadcrumb now. */}
             <Button
               variant="primary"
               label="EDIT"
@@ -602,17 +598,11 @@ function LibraryEditor({ library }: { library: LibraryRuntime }) {
   const editingExisting = library.activeRoute.view === "editor" && Boolean(library.activeRoute.path);
   return (
     <div class="gsv-library-editor-page">
+      {/* Back to the library index is owned by the breadcrumb now. */}
       <LibraryPageHeader
         eyebrow={db || "LIBRARY"}
         title={editingExisting ? "Edit Page" : "Write Page"}
         meta={library.editorPath || "NEW PAGE"}
-        actions={(
-          <Button
-            variant="secondary"
-            label="BACK"
-            onClick={() => db ? library.navigate({ view: "index", db }) : library.navigate({ view: "index" })}
-          />
-        )}
       />
       <Surface class="gsv-library-editor" level={2}>
         <div class="gsv-library-editor-meta">
@@ -657,7 +647,6 @@ function LibraryCapture({ library }: { library: LibraryRuntime }) {
         eyebrow={db || "LIBRARY"}
         title="Capture Source"
         meta="CREATE SOURCE-BACKED PAGE"
-        actions={<Button variant="secondary" label="BACK" onClick={() => db ? library.navigate({ view: "index", db }) : library.navigate({ view: "index" })} />}
       />
       <Surface class="gsv-library-form-panel" level={2}>
         <div class="gsv-library-form-grid">
@@ -711,7 +700,6 @@ function LibraryBuild({ library }: { library: LibraryRuntime }) {
         eyebrow={db || "LIBRARY"}
         title="Build From Directory"
         meta="BACKGROUND AGENT"
-        actions={<Button variant="secondary" label="BACK" onClick={() => db ? library.navigate({ view: "index", db }) : library.navigate({ view: "index" })} />}
       />
       <Surface class="gsv-library-form-panel" level={2}>
         <div class="gsv-library-form-grid">

--- a/web/src/app/features/gsv-console/library/libraryService.ts
+++ b/web/src/app/features/gsv-console/library/libraryService.ts
@@ -42,7 +42,7 @@ const WIKI_MANIFEST_KIND = "gsv.wiki";
 
 export async function loadLibraryWorkspace(
   client: LibraryClient,
-  args: { db?: string; path?: string; q?: string },
+  args: { db?: string; path?: string; q?: string; newPage?: boolean },
 ): Promise<LibraryWorkspaceState> {
   let errorText = "";
   let selectedDb = String(args.db ?? "").trim();
@@ -70,15 +70,22 @@ export async function loadLibraryWorkspace(
       errorText ||= formatError(error);
     }
 
-    selectedPath = normalizeDbScopedLibraryPath(args.path ?? "", selectedDb) || `${selectedDb}/index.md`;
-    try {
-      selectedNote = await readLibraryNote(client, collection, selectedPath);
-      if (!selectedNote && !args.path && pages.length > 0) {
-        selectedPath = pages[0].path;
+    // A new-page editor route carries no path. Without this guard the loader
+    // defaults the path to `${db}/index.md` and returns the collection Overview
+    // as the selected note, so the blank editor would bind to (and overwrite)
+    // index.md on save. Leave the note unselected; the editor generates a fresh
+    // page path of its own.
+    if (!args.newPage) {
+      selectedPath = normalizeDbScopedLibraryPath(args.path ?? "", selectedDb) || `${selectedDb}/index.md`;
+      try {
         selectedNote = await readLibraryNote(client, collection, selectedPath);
+        if (!selectedNote && !args.path && pages.length > 0) {
+          selectedPath = pages[0].path;
+          selectedNote = await readLibraryNote(client, collection, selectedPath);
+        }
+      } catch (error) {
+        errorText ||= formatError(error);
       }
-    } catch (error) {
-      errorText ||= formatError(error);
     }
 
     if (searchQuery) {

--- a/web/src/app/features/gsv-console/library/useLibraryWorkspace.ts
+++ b/web/src/app/features/gsv-console/library/useLibraryWorkspace.ts
@@ -92,6 +92,11 @@ export function useLibraryWorkspace(
   const [editorMarkdown, setEditorMarkdown] = useState("");
   const [newPageTitle, setNewPageTitle] = useState("");
   const [createCollectionOpen, setCreateCollectionOpen] = useState(false);
+  // Which folder the page browser is showing (a local page path like
+  // "pages/accounts-access", or "" for the collection's content root). Lifted
+  // here so it survives opening a page — the reader's breadcrumb and Back reuse
+  // it to return to the right folder. Resets when the collection changes.
+  const [browserFolder, setBrowserFolder] = useState("");
   const [newCollectionTitle, setNewCollectionTitle] = useState("");
   const [newCollectionId, setNewCollectionId] = useState("");
   const [ingestTarget, setIngestTarget] = useState("gsv");
@@ -106,6 +111,10 @@ export function useLibraryWorkspace(
   useEffect(() => {
     setSearchDraft(loadArgs.q ?? "");
   }, [loadArgs.q]);
+
+  useEffect(() => {
+    setBrowserFolder("");
+  }, [selectedDb]);
 
   useEffect(() => {
     if (activeRoute.view !== "editor") {
@@ -198,6 +207,8 @@ export function useLibraryWorkspace(
 
   return {
     activeRoute,
+    browserFolder,
+    setBrowserFolder,
     connected,
     createCollectionOpen,
     editorMarkdown,

--- a/web/src/app/features/gsv-console/library/useLibraryWorkspace.ts
+++ b/web/src/app/features/gsv-console/library/useLibraryWorkspace.ts
@@ -278,8 +278,79 @@ export function useLibraryWorkspace(
     navigate: guardedNavigate,
     openCollection: (db: string) => guardedNavigate({ view: "index", db }),
     openEditor: (path?: string) => {
-      if (selectedDb) {
-        guardedNavigate({ view: "editor", db: selectedDb, ...(path ? { path: localLibraryPath(path, selectedDb) } : {}) });
+      if (!selectedDb) {
+        return;
+      }
+      const target: ShellLibraryRoute = path
+        ? { view: "editor", db: selectedDb, path: localLibraryPath(path, selectedDb) }
+        : { view: "editor", db: selectedDb };
+      const proceed = () => {
+        // Opening a fresh blank page: clear any leftover editor draft so the
+        // initializer rebuilds it from scratch. Without this, the `!editorPath`
+        // guard in the editor effect skips re-init and a previously-discarded
+        // draft reappears (and could be saved by accident). Editing an existing
+        // page passes a path; selectedNote then repopulates the editor.
+        if (!path) {
+          setEditorPath("");
+          setEditorMarkdown("");
+        }
+        navigate(target);
+      };
+      if (requestLeave) {
+        requestLeave(proceed);
+      } else {
+        proceed();
+      }
+    },
+    openBuild: () => {
+      const proceed = () => {
+        // Fresh build draft: clear leftover fields so a previously-discarded
+        // build doesn't reappear (and can't be submitted by accident). buildDbId
+        // is re-seeded from the collection by the effect once cleared.
+        setBuildPath("");
+        setBuildDbTitle("");
+        setBuildTarget("gsv");
+        setBuildDbId("");
+        navigate({ view: "build", ...(selectedDb ? { db: selectedDb } : {}) });
+      };
+      if (requestLeave) {
+        requestLeave(proceed);
+      } else {
+        proceed();
+      }
+    },
+    openCapture: () => {
+      if (!selectedDb) {
+        return;
+      }
+      const proceed = () => {
+        // Fresh capture draft: clear leftover ingest fields for the same reason.
+        setIngestPath("");
+        setIngestTitle("");
+        setIngestSummary("");
+        setIngestTarget("gsv");
+        navigate({ view: "capture", db: selectedDb });
+      };
+      if (requestLeave) {
+        requestLeave(proceed);
+      } else {
+        proceed();
+      }
+    },
+    closeCreateCollection: () => {
+      // Closing the NEW COLLECTION box discards its draft. Route through the
+      // guard (the collection probe is still live on index/reader) so a typed
+      // title/id prompts first, then clear the draft once the close goes through
+      // — otherwise the abandoned text silently reappears on the next open.
+      const proceed = () => {
+        setCreateCollectionOpen(false);
+        setNewCollectionTitle("");
+        setNewCollectionId("");
+      };
+      if (requestLeave) {
+        requestLeave(proceed);
+      } else {
+        proceed();
       }
     },
     openPage: (path: string) => {

--- a/web/src/app/features/gsv-console/library/useLibraryWorkspace.ts
+++ b/web/src/app/features/gsv-console/library/useLibraryWorkspace.ts
@@ -392,8 +392,13 @@ export function useLibraryWorkspace(
   };
 }
 
-function loadArgsForRoute(route: ShellLibraryRoute): { db?: string; path?: string; q?: string } {
-  if (route.view === "reader" || route.view === "editor") {
+function loadArgsForRoute(route: ShellLibraryRoute): { db?: string; path?: string; q?: string; newPage?: boolean } {
+  if (route.view === "editor") {
+    // A path-less editor route is a brand-new page: tell the loader not to fall
+    // back to the collection index.md (which the editor would then overwrite).
+    return route.path ? { db: route.db, path: route.path } : { db: route.db, newPage: true };
+  }
+  if (route.view === "reader") {
     return {
       db: route.db,
       path: route.path,

--- a/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
+++ b/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "preact/hooks";
-import { useUnsavedGuard, useUnsavedGuardLeave } from "../../gsv-shell/unsaved/unsavedGuard";
+import { useUnsavedGuard } from "../../gsv-shell/unsaved/unsavedGuard";
 import { Button } from "../../../components/ui/Button";
 import { Icon } from "../../../components/ui/Icon";
 import { ListRow } from "../../../components/ui/ListRow";
@@ -202,10 +202,6 @@ export function MachineProvisionFlow({
       deviceIdTouched ||
       expiresDays.trim() !== "30")
   );
-  // The flow's own back controls unmount the wizard like shell nav does, so
-  // route them through the guard to prompt before discarding the draft.
-  const requestLeave = useUnsavedGuardLeave();
-  const guardedBack = () => requestLeave(onBack);
 
   useEffect(() => {
     if (!issuedToken || step !== "connect") {
@@ -351,7 +347,6 @@ export function MachineProvisionFlow({
               ))}
             </div>
             <div class="gsv-cf-footer">
-              <Button variant="secondary" label="BACK TO MACHINES" onClick={guardedBack} />
               <span class="gsv-cf-footer-spacer" />
               <Button variant="primary" label="CONTINUE" onClick={() => setStep("details")} />
             </div>
@@ -642,7 +637,6 @@ export function MachineProvisionFlow({
               )}
             </div>
             <div class="gsv-cf-footer">
-              <Button variant="secondary" label="BACK TO MACHINES" onClick={guardedBack} />
               <span class="gsv-cf-footer-spacer" />
               <Button
                 variant="primary"

--- a/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerOnboardingFlow.tsx
@@ -192,7 +192,6 @@ export function MessengerOnboardingFlow({
               <Link href={docUrl} arrow>Need help? Documentation</Link>
             </div>
             <div class="gsv-cf-footer">
-              <Button variant="secondary" label="CANCEL" onClick={goBack} />
               <span class="gsv-cf-footer-spacer" />
               <Button variant="primary" label="NEXT" onClick={goNext} />
             </div>

--- a/web/src/app/features/gsv-console/packages/ApplicationImportFlow.tsx
+++ b/web/src/app/features/gsv-console/packages/ApplicationImportFlow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "preact/hooks";
-import { useUnsavedGuard, useUnsavedGuardLeave } from "../../gsv-shell/unsaved/unsavedGuard";
+import { useUnsavedGuard } from "../../gsv-shell/unsaved/unsavedGuard";
 import { Button } from "../../../components/ui/Button";
 import { Checkbox } from "../../../components/ui/Checkbox";
 import { Icon } from "../../../components/ui/Icon";
@@ -157,11 +157,6 @@ export function ApplicationImportFlow({
     return () => window.clearInterval(timer);
   }, [reviewPid, reviewHistory.refetch]);
 
-  // The wizard's own back controls unmount it like shell nav does, so route
-  // them through the guard to prompt before discarding the import draft.
-  const requestLeave = useUnsavedGuardLeave();
-  const guardedBack = () => requestLeave(onBack);
-
   const openImportedPackage = (pkg: ConsolePackage | null) => {
     if (pkg && onOpenPackage) {
       onOpenPackage(pkg);
@@ -246,7 +241,6 @@ export function ApplicationImportFlow({
       {importError ? <div class="application-import-inline-error" role="alert">{importError}</div> : null}
       {footnote}
       <div class="gsv-cf-footer">
-        <Button variant="secondary" label="BACK TO APPLICATIONS" disabled={flow.importMutation.isPending} onClick={guardedBack} />
         <span class="gsv-cf-footer-spacer" />
         <Button
           variant="primary"

--- a/web/src/app/features/gsv-console/pages/ConsoleConfigPage.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleConfigPage.tsx
@@ -59,6 +59,11 @@ import "./ConsoleConfigPage.css";
 
 export type ConsoleConfigKind = "models" | "overrides";
 
+/** The open config detail, reported up so the shell can render the breadcrumb
+ *  trail (SETTINGS → MODELS → [detail]) and route the back-arrow. `onExit` runs
+ *  the same guarded back as the detail's own controls. */
+export type ConsoleConfigDetail = { label: string; onExit: () => void };
+
 type ConsoleConfigPageProps = {
   kind: ConsoleConfigKind;
   /** Optional model selection to open immediately (e.g. "default" deep-links to
@@ -68,6 +73,9 @@ type ConsoleConfigPageProps = {
    *  `select`-opened detail navigates back, so the URL doesn't stay pinned to
    *  the detail (which would reopen it on reload). */
   onClearSelect?: () => void;
+  /** Reports the open detail (or null on the list) so the breadcrumb owns the
+   *  path back — replaces the in-page back button. */
+  onDetailChange?: (detail: ConsoleConfigDetail | null) => void;
 };
 
 function modelSelectionFromParam(select: string | undefined): ModelSelection | null {
@@ -112,7 +120,7 @@ type SettingsFieldGroupProps = {
 
 type ClearedProfileSecretKeys = ReadonlyMap<string, ReadonlySet<string>>;
 
-export function ConsoleConfigPage({ kind, select, onClearSelect }: ConsoleConfigPageProps) {
+export function ConsoleConfigPage({ kind, select, onClearSelect, onDetailChange }: ConsoleConfigPageProps) {
   const config = useConsoleConfig();
   const accounts = useConsoleAccounts();
 
@@ -129,6 +137,7 @@ export function ConsoleConfigPage({ kind, select, onClearSelect }: ConsoleConfig
             kind={kind}
             select={select}
             onClearSelect={onClearSelect}
+            onDetailChange={onDetailChange}
           />
         )}
       />
@@ -142,12 +151,14 @@ function ConsoleSettingsPanel({
   kind,
   select,
   onClearSelect,
+  onDetailChange,
 }: {
   accounts: readonly ConsoleAccount[];
   config: readonly ConsoleConfigEntry[];
   kind: ConsoleConfigKind;
   select?: string;
   onClearSelect?: () => void;
+  onDetailChange?: (detail: ConsoleConfigDetail | null) => void;
 }) {
   const viewerAccount = viewerAccountForSettings(accounts);
   const viewer: SettingsViewer = {
@@ -157,9 +168,9 @@ function ConsoleSettingsPanel({
   };
 
   if (kind === "models") {
-    return <ModelSettingsPage config={config} viewer={viewer} select={select} onClearSelect={onClearSelect} />;
+    return <ModelSettingsPage config={config} viewer={viewer} select={select} onClearSelect={onClearSelect} onDetailChange={onDetailChange} />;
   }
-  return <RuntimeSettingsPage config={config} viewer={viewer} />;
+  return <RuntimeSettingsPage config={config} viewer={viewer} onDetailChange={onDetailChange} />;
 }
 
 function ModelSettingsPage({
@@ -167,11 +178,13 @@ function ModelSettingsPage({
   viewer,
   select,
   onClearSelect,
+  onDetailChange,
 }: {
   config: readonly ConsoleConfigEntry[];
   viewer: SettingsViewer;
   select?: string;
   onClearSelect?: () => void;
+  onDetailChange?: (detail: ConsoleConfigDetail | null) => void;
 }) {
   const saveConfig = useSaveConsoleConfigEntries();
   const validateModelConfig = useValidateConsoleModelConfig();
@@ -217,6 +230,23 @@ function ModelSettingsPage({
       onClearSelect?.();
     }
   };
+
+  // Report the open detail to the shell so the breadcrumb shows the trail and
+  // owns the path back (no in-page back button). The label mirrors the detail's
+  // own title.
+  const detailLabel = !selection
+    ? null
+    : selection.kind === "default"
+    ? "DEFAULT AGENT MODEL"
+    : selection.kind === "new-profile"
+    ? "NEW MODEL PRESET"
+    : selection.kind === "tool"
+    ? (TOOL_MODEL_GROUPS.find((group) => group.id === selection.id)?.title ?? "TOOL MODEL").toUpperCase()
+    : (profiles.find((profile) => profile.id === selection.id)?.name ?? "MODEL PRESET").toUpperCase();
+  useEffect(() => {
+    onDetailChange?.(detailLabel ? { label: detailLabel, onExit: () => requestLeave(exitDetail) } : null);
+  }, [detailLabel]);
+  useEffect(() => () => onDetailChange?.(null), []);
 
   if (selection) {
     return (
@@ -308,7 +338,6 @@ function ModelSettingsDetail({
         tone={editable ? "online" : "idle"}
         blurb="Fallback model stack used when an agent inherits model behavior."
         parentLabel="MODELS"
-        showBack
         onBack={onBack}
       >
         <SettingsFieldGroup
@@ -342,7 +371,6 @@ function ModelSettingsDetail({
         tone={editable ? "online" : "idle"}
         blurb={group.description}
         parentLabel="MODELS"
-        showBack
         onBack={onBack}
       >
         <SettingsFieldGroup
@@ -376,7 +404,6 @@ function ModelSettingsDetail({
       tone={profile ? "online" : "idle"}
       blurb="Reusable named model stack for agents, including provider credentials when a preset needs its own key."
       parentLabel="MODELS"
-      showBack
       onBack={onBack}
     >
       <ModelProfileForm
@@ -412,14 +439,26 @@ function ModelSettingsDetail({
 function RuntimeSettingsPage({
   config,
   viewer,
+  onDetailChange,
 }: {
   config: readonly ConsoleConfigEntry[];
   viewer: SettingsViewer;
+  onDetailChange?: (detail: ConsoleConfigDetail | null) => void;
 }) {
   const saveConfig = useSaveConsoleConfigEntries();
   const requestLeave = useUnsavedGuardLeave();
   const [selection, setSelection] = useState<RuntimeSelection | null>(null);
   const canEditRuntime = viewer.isRoot;
+
+  // Report the open detail so the breadcrumb owns the path back (no in-page
+  // back button) — same trail as the model config: SETTINGS → RUNTIME → [detail].
+  const detailLabel = selection
+    ? (RUNTIME_SETTING_GROUPS.find((group) => group.id === selection.id)?.title ?? "RUNTIME").toUpperCase()
+    : null;
+  useEffect(() => {
+    onDetailChange?.(detailLabel ? { label: detailLabel, onExit: () => requestLeave(() => setSelection(null)) } : null);
+  }, [detailLabel]);
+  useEffect(() => () => onDetailChange?.(null), []);
 
   const saveEntries = async (entries: readonly SaveConsoleConfigInput[]) => {
     if (entries.length === 0) {
@@ -439,7 +478,6 @@ function RuntimeSettingsPage({
         tone={canEditRuntime ? "online" : "idle"}
         blurb={group.description}
         parentLabel="RUNTIME"
-        showBack
         onBack={() => requestLeave(() => setSelection(null))}
       >
         <SettingsFieldGroup

--- a/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
+++ b/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
@@ -293,7 +293,7 @@ export function GsvDesktop({
               }}
             >
               <span class="gsv-space-gsv-cross" aria-hidden="true" />
-              <GsvMark variant="master" size={50} />
+              <GsvMark variant="white" size={50} />
             </button>
             <div class="gsv-space-gsv-label">GSV</div>
           </div>


### PR DESCRIPTION
Two breadcrumb threads plus a Library page redesign, all on one branch (8 commits off `main`).

## Breadcrumbs
- **Config** — `SETTINGS → MODELS/RUNTIME → [detail]`; dropped the duplicate `showBack` button.
- **Library** — `GSV → LIBRARY → [page/view]`; header back-arrow returns to the index.

## Library page redesign
- Collection bar on top (FILES-style) + left action panel + FILES folder-drill browser (rooted inside `pages/`, Overview pinned).
- Reader unified onto the same shell: continued breadcrumb + Back, OUTLINE in the left panel as `--warn` hyperlinks (non-scrolling).
- **Panel-aware** responsiveness via `ResizeObserver` → `.is-narrow` at 720px (action bar to top, outline to a top dropdown) — tracks the panel width (chat resize + window), not the viewport.

## Final audit pass (this branch's last commit)
- **Fix:** the collection bar was the one strip that never reflowed — `flex` with no wrap collided the COLLECTION select, meta, and action buttons on a single line at narrow widths (root clips via `overflow:hidden`). Added `flex-wrap`.
- **Cleanup:** removed ~11 orphaned rule blocks from the old three-column index/reader and trimmed the viewport `@media` to its still-live targets.

## Verification
`tsc --noEmit` clean, `vite build` green, full CSS class-reference cross-check (no live class lost a definition). The Library page sits behind real auth the sandbox can't reach, so visual confirmation is done locally.

## Notes for review / merge
- **Branch conflict:** overlaps `responsiveness-audit` on `LibraryPage.tsx/.css`. This redesign supersedes that branch's Library changes — on merge, take this branch's Library wholesale; keep `responsiveness-audit`'s changes only for the `AgentEditor` portal.
- **Known follow-ups (out of scope):** editor/capture/build views still use the old `LibraryPageHeader` (not yet unified onto the shell); `WRITE PAGE` opens a blank editor rather than targeting the browsed folder.
