### PR TITLE
Responsiveness: panel-aware reflow + large-screen reading width

### DIFF
--- a/web/src/app/components/ui/AgentEditor.css
+++ b/web/src/app/components/ui/AgentEditor.css
@@ -7,6 +7,13 @@
   color: var(--text-dim);
 }
 
+/* Big screens: the title bar is a full-width strip; only its inner content
+   indents to the centered reading column (!important beats SectionHeader's
+   inline left/right padding; vertical padding is preserved). */
+.gsv-ae-header {
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
+}
+
 /* code editor scrollbar (from source <style> .gsv-ed rules) */
 .gsv-ed::-webkit-scrollbar {
   width: 9px;

--- a/web/src/app/components/ui/AgentEditor.tsx
+++ b/web/src/app/components/ui/AgentEditor.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "preact/compat";
 import { useEffect, useRef, useState } from "preact/hooks";
 import "./AgentEditor.css";
 import { TextInput } from "./TextInput";
@@ -362,11 +363,15 @@ export function AgentEditor(props: AgentEditorProps) {
   const panelStyle =
     "position:relative;z-index:2;display:flex;flex-direction:column;min-height:" +
     (narrow ? "480px" : "560px") + ";";
+  // Big-screen reading width: center tab content into the shared column while
+  // the header/tab strips stay full-width. The gutter is 0 below the cap.
   const genWrapStyle = narrow
-    ? "display:flex;flex-direction:column;padding:22px 16px 30px;gap:20px;"
-    : "display:flex;flex-direction:column;padding:28px 32px 40px;gap:22px;";
+    ? "display:flex;flex-direction:column;padding:22px 16px 30px;gap:20px;padding-inline:max(16px,var(--gsv-gutter));"
+    : "display:flex;flex-direction:column;padding:28px 32px 40px;gap:22px;padding-inline:max(32px,var(--gsv-gutter));";
   const identityStyle = "order:-1;display:flex;flex-direction:row;align-items:center;gap:16px;width:100%;";
-  const secPad = narrow ? "padding:20px 16px 28px;" : "padding:28px 32px 36px;";
+  const secPad = narrow
+    ? "padding:20px 16px 28px;padding-inline:max(16px,var(--gsv-gutter));"
+    : "padding:28px 32px 36px;padding-inline:max(32px,var(--gsv-gutter));";
 
   return (
     <div
@@ -633,8 +638,9 @@ export function AgentEditor(props: AgentEditorProps) {
               </div>
             ) : null}
 
-            {/* DELETE CONFIRM MODAL */}
-            {deleteOpen ? (
+            {/* DELETE CONFIRM MODAL — portaled to <body> so the editor's panel
+                container (container-type) doesn't trap its viewport-fixed scrim. */}
+            {deleteOpen ? createPortal(
               <div class="gsv-ae-modal-scrim" onClick={onCancelDelete}>
                 <div class="gsv-ae-modal-wrap" onClick={(event) => event.stopPropagation()}>
                   <ConfirmModal
@@ -645,7 +651,8 @@ export function AgentEditor(props: AgentEditorProps) {
                     onConfirm={onConfirmDelete}
                   />
                 </div>
-              </div>
+              </div>,
+              document.body,
             ) : null}
           </div>
         </div>

--- a/web/src/app/features/chat/components/ChatDock.css
+++ b/web/src/app/features/chat/components/ChatDock.css
@@ -2915,25 +2915,32 @@ button.gsv-chat-task-row:focus-visible {
   }
 }
 
-@media (max-width: 760px) {
-  .gsv-chat {
-    width: 100% !important;
-    max-width: none;
-    min-width: 0;
-    height: min(var(--gsv-chat-width), calc(100% - 240px));
-    min-height: min(300px, 48%);
-    max-height: calc(100% - 220px);
-    border-top: 1px solid var(--border);
-    border-left: 0;
-  }
+/* Mobile: the chat is a full-height drawer that slides in over the center panel
+   from the right (see the shell's mobile pane handling in gsvShell.css). It only
+   mounts when open, so it animates in on entry; closing simply unmounts it. */
+.gsv-shell-viewport.is-mobile .gsv-chat {
+  position: absolute;
+  z-index: 45;
+  inset: 0;
+  width: 100% !important;
+  max-width: none;
+  min-width: 0;
+  height: 100%;
+  border-left: 0;
+  animation: gsvMobileChatIn 0.24s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
 
-  .gsv-chat-resize {
-    top: -3px;
-    right: 0;
-    bottom: auto;
-    left: 0;
-    width: auto;
-    height: 7px;
-    cursor: ns-resize;
+/* The drag-to-resize handle is desktop-only; mobile drawers are full-bleed. */
+.gsv-shell-viewport.is-mobile .gsv-chat-resize,
+.gsv-shell-viewport.is-mobile .gsv-chat-min {
+  display: none;
+}
+
+@keyframes gsvMobileChatIn {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
   }
 }

--- a/web/src/app/features/gsv-console/card-template/CardListTemplate.css
+++ b/web/src/app/features/gsv-console/card-template/CardListTemplate.css
@@ -1,6 +1,10 @@
 /* CARD list template — one header, a horizontal action bar on top, then a
    full-width card grid. Frame tokens mirror the Settings Overview / table. */
 .gsv-card-template {
+  /* Reflow off the PANEL width (not the viewport) so the bar + grid respond
+     when the chat is dragged wider, not only on small screens. */
+  container-type: inline-size;
+  container-name: panel;
   flex: 1 0 auto;
   min-height: 100%;
   margin-bottom: 88px;
@@ -21,6 +25,9 @@
   gap: 16px;
   padding: 16px;
   border-bottom: 1px solid var(--rule-section);
+  /* Big screens: toolbar strip stays full-width (border spans the panel); its
+     controls align to the centered reading column. */
+  padding-inline: max(16px, var(--gsv-gutter));
 }
 
 .gsv-card-template-search {
@@ -63,11 +70,33 @@
   margin-left: 0;
 }
 
-/* Three controls in a tight bar: search takes the first row. */
-@media (max-width: 720px) {
+/* Three controls in a tight panel: search takes the first row. Keyed to the
+   PANEL container, not the viewport. */
+@container panel (max-width: 720px) {
   .gsv-card-template-action[data-actions="3"] .gsv-card-template-search {
     flex-basis: 100%;
     max-width: none;
+  }
+}
+
+/* Phone-width panel: stack the action bar so controls stay legible. */
+@container panel (max-width: 480px) {
+  .gsv-card-template-action {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .gsv-card-template-search,
+  .gsv-card-template-filters,
+  .gsv-card-template-connect {
+    flex: 0 0 auto;
+    width: 100%;
+    max-width: none;
+    margin-left: 0;
+  }
+
+  .gsv-card-template-connect .gsv-btn {
+    width: 100%;
   }
 }
 
@@ -81,10 +110,20 @@
 
 .gsv-card-template-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  /* min(100%, 300px) keeps a single column from overflowing once the panel is
+     narrower than the 300px card minimum. */
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr));
   align-items: stretch;
   gap: 16px;
   padding: 16px;
+  /* Big screens: center the card grid to the reading column. */
+  padding-inline: max(16px, var(--gsv-gutter));
+}
+
+/* Title bar is a full-width strip; only its inner content indents to the
+   centered column (!important beats SectionHeader's inline left/right padding). */
+.gsv-card-template-header {
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
 }
 
 /* Card shell — a DS Surface (border + panel bg) tuned for bare cards like

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
@@ -15,9 +15,6 @@
 /* Row-2 header: full-width bar, flush under the breadcrumb — like the list pages. */
 .gsv-console-detail-header.gsv-section-header {
   width: 100%;
-  /* Full-width title strip; inner content indents to the centered reading
-     column on big screens (!important beats SectionHeader's inline padding). */
-  padding-inline: max(20px, var(--gsv-gutter)) !important;
 }
 
 /* Opt-in back control for non-route-backed callers (config details), so they
@@ -48,10 +45,6 @@
   flex-direction: column;
   gap: 24px;
   padding: 28px 26px 72px;
-  /* Big screens: center the detail content to the reading column. (The narrow
-     @container rules below re-set padding for small panels, where the gutter is
-     0 anyway, so they take precedence as intended.) */
-  padding-inline: max(26px, var(--gsv-gutter));
 }
 
 .gsv-console-detail-head {
@@ -117,8 +110,6 @@
   gap: 16px;
   padding: 18px 26px;
   border-bottom: 1px solid var(--rule-section);
-  /* Big screens: strip stays full-width; content aligns to the reading column. */
-  padding-inline: max(26px, var(--gsv-gutter));
 }
 
 .gsv-console-detail-bar-lead {

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
@@ -1,4 +1,10 @@
 .gsv-console-detail-page {
+  /* Reflow off the PANEL width (not the viewport) so spacing/typography tighten
+     when the chat is dragged wide, not only on small screens. The confirm
+     overlay is a sibling (not a descendant), so inline-size containment here
+     does not trap its fixed positioning. */
+  container-type: inline-size;
+  container-name: panel;
   flex: 1;
   min-height: 100%;
   display: flex;
@@ -9,6 +15,9 @@
 /* Row-2 header: full-width bar, flush under the breadcrumb — like the list pages. */
 .gsv-console-detail-header.gsv-section-header {
   width: 100%;
+  /* Full-width title strip; inner content indents to the centered reading
+     column on big screens (!important beats SectionHeader's inline padding). */
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
 }
 
 /* Opt-in back control for non-route-backed callers (config details), so they
@@ -39,6 +48,10 @@
   flex-direction: column;
   gap: 24px;
   padding: 28px 26px 72px;
+  /* Big screens: center the detail content to the reading column. (The narrow
+     @container rules below re-set padding for small panels, where the gutter is
+     0 anyway, so they take precedence as intended.) */
+  padding-inline: max(26px, var(--gsv-gutter));
 }
 
 .gsv-console-detail-head {
@@ -104,6 +117,8 @@
   gap: 16px;
   padding: 18px 26px;
   border-bottom: 1px solid var(--rule-section);
+  /* Big screens: strip stays full-width; content aligns to the reading column. */
+  padding-inline: max(26px, var(--gsv-gutter));
 }
 
 .gsv-console-detail-bar-lead {
@@ -245,13 +260,13 @@
   max-width: 100%;
 }
 
-@media (max-width: 720px) {
+@container panel (max-width: 720px) {
   .gsv-console-detail-shell {
     padding: 24px 24px 72px;
   }
 }
 
-@media (max-width: 520px) {
+@container panel (max-width: 520px) {
   .gsv-console-detail-shell {
     padding: 18px 14px 64px;
   }

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
@@ -15,6 +15,9 @@
 /* Row-2 header: full-width bar, flush under the breadcrumb — like the list pages. */
 .gsv-console-detail-header.gsv-section-header {
   width: 100%;
+  /* Full-width title strip; inner content indents to the centered reading
+     column on big screens (!important beats SectionHeader's inline padding). */
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
 }
 
 /* Opt-in back control for non-route-backed callers (config details), so they
@@ -45,6 +48,10 @@
   flex-direction: column;
   gap: 24px;
   padding: 28px 26px 72px;
+  /* Big screens: center the detail content to the reading column. (The narrow
+     @container rules below re-set padding for small panels, where the gutter is
+     0 anyway, so they take precedence as intended.) */
+  padding-inline: max(26px, var(--gsv-gutter));
 }
 
 .gsv-console-detail-head {
@@ -110,6 +117,8 @@
   gap: 16px;
   padding: 18px 26px;
   border-bottom: 1px solid var(--rule-section);
+  /* Big screens: strip stays full-width; content aligns to the reading column. */
+  padding-inline: max(26px, var(--gsv-gutter));
 }
 
 .gsv-console-detail-bar-lead {

--- a/web/src/app/features/gsv-console/components/SettingsListPanel.css
+++ b/web/src/app/features/gsv-console/components/SettingsListPanel.css
@@ -13,6 +13,14 @@
   min-height: 0;
 }
 
+/* Reading-width: the panel header is a full-width SectionHeader strip (DS inline
+   padding 14px 20px) — center its inner content while the bar stays full-width.
+   The panel is a full-width child of the single-column `.gsv-console-settings-index`
+   grid, so `100%` in the gutter resolves to the panel width. */
+.gsv-console-settings-list > .gsv-section-header {
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
+}
+
 .gsv-console-settings-list-body {
   display: grid;
 }
@@ -32,6 +40,8 @@
 .gsv-console-settings-list-row .lr {
   min-height: 43px;
   padding: 13px 16px;
+  /* Reading-width: full-width list rows, align row content to the centered column. */
+  padding-inline: max(16px, var(--gsv-gutter));
 }
 
 .gsv-console-settings-list-row .lr[data-clickable="true"]:hover,
@@ -53,11 +63,15 @@
   border: 0 !important;
   background: transparent !important;
   padding: 13px 16px !important;
+  /* Reading-width: full-width action row; padding is !important here, base 16px. */
+  padding-inline: max(16px, var(--gsv-gutter)) !important;
 }
 
 .gsv-console-settings-empty {
   min-height: 54px;
   padding: 18px;
+  /* Reading-width: full-width empty-state band. */
+  padding-inline: max(18px, var(--gsv-gutter));
   color: var(--text-dim);
   font-size: 10px;
   letter-spacing: 0.08em;

--- a/web/src/app/features/gsv-console/components/SettingsListPanel.css
+++ b/web/src/app/features/gsv-console/components/SettingsListPanel.css
@@ -13,6 +13,14 @@
   min-height: 0;
 }
 
+/* Reading-width: the panel header is a full-width SectionHeader strip (DS inline
+   padding 14px 20px) — center its inner content while the bar stays full-width.
+   The panel is a full-width child of the single-column `.gsv-console-settings-index`
+   grid, so `100%` in the gutter resolves to the panel width. */
+.gsv-console-settings-list > .gsv-section-header {
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
+}
+
 .gsv-console-settings-list-body {
   display: grid;
 }
@@ -32,6 +40,8 @@
 .gsv-console-settings-list-row .lr {
   min-height: 43px;
   padding: 13px 16px;
+  /* Reading-width: full-width list rows, align row content to the centered column. */
+  padding-inline: max(16px, var(--gsv-gutter));
 }
 
 .gsv-console-settings-list-row .lr[data-clickable="true"]:hover,
@@ -53,11 +63,15 @@
   border: 0 !important;
   background: transparent !important;
   padding: 13px 16px !important;
+  /* Reading-width: full-width action row; padding is !important here, base 16px. */
+  padding-inline: max(16px, var(--gsv-gutter)) !important;
 }
 
 .gsv-console-settings-empty {
   min-height: 54px;
   padding: 18px;
+  /* Reading-width: full-width empty-state band. */
+  padding-inline: max(18px, var(--gsv-gutter));
   color: var(--text-dim);
   font-size: 10px;
   letter-spacing: 0.08em;
@@ -67,14 +81,19 @@
   white-space: nowrap;
 }
 
-@media (max-width: 720px) {
+/* Reflow off the PANEL width, not the viewport — so the template responds when
+   the chat is dragged wider. The `panel` container is established by the parent
+   `.gsv-console-settings-index` (whose inline-size equals this panel's width)
+   because the 520px rule below targets `.gsv-console-settings-list` itself, and
+   a container cannot query itself. */
+@container panel (max-width: 720px) {
   .gsv-console-settings-list-row .lr {
     gap: 10px;
     padding: 13px 14px;
   }
 }
 
-@media (max-width: 520px) {
+@container panel (max-width: 520px) {
   .gsv-console-settings-list {
     min-height: calc(100vh - 94px);
   }

--- a/web/src/app/features/gsv-console/components/SettingsListPanel.css
+++ b/web/src/app/features/gsv-console/components/SettingsListPanel.css
@@ -13,14 +13,6 @@
   min-height: 0;
 }
 
-/* Reading-width: the panel header is a full-width SectionHeader strip (DS inline
-   padding 14px 20px) — center its inner content while the bar stays full-width.
-   The panel is a full-width child of the single-column `.gsv-console-settings-index`
-   grid, so `100%` in the gutter resolves to the panel width. */
-.gsv-console-settings-list > .gsv-section-header {
-  padding-inline: max(20px, var(--gsv-gutter)) !important;
-}
-
 .gsv-console-settings-list-body {
   display: grid;
 }
@@ -40,8 +32,6 @@
 .gsv-console-settings-list-row .lr {
   min-height: 43px;
   padding: 13px 16px;
-  /* Reading-width: full-width list rows, align row content to the centered column. */
-  padding-inline: max(16px, var(--gsv-gutter));
 }
 
 .gsv-console-settings-list-row .lr[data-clickable="true"]:hover,
@@ -63,15 +53,11 @@
   border: 0 !important;
   background: transparent !important;
   padding: 13px 16px !important;
-  /* Reading-width: full-width action row; padding is !important here, base 16px. */
-  padding-inline: max(16px, var(--gsv-gutter)) !important;
 }
 
 .gsv-console-settings-empty {
   min-height: 54px;
   padding: 18px;
-  /* Reading-width: full-width empty-state band. */
-  padding-inline: max(18px, var(--gsv-gutter));
   color: var(--text-dim);
   font-size: 10px;
   letter-spacing: 0.08em;

--- a/web/src/app/features/gsv-console/connect-flows/ConnectFlowShell.css
+++ b/web/src/app/features/gsv-console/connect-flows/ConnectFlowShell.css
@@ -20,6 +20,9 @@
   gap: 16px;
   padding: 18px 26px;
   border-bottom: 1px solid var(--rule-section);
+  /* Big screens: strip stays full-width; content aligns to the reading column
+     (matches ConsoleDetailPage so the wizard pages cap like the detail pages). */
+  padding-inline: max(26px, var(--gsv-gutter));
 }
 
 .gsv-cf-bar-lead {
@@ -65,6 +68,8 @@
   flex-direction: column;
   gap: 20px;
   padding: 28px 26px 72px;
+  /* Big screens: center the step content to the reading column. */
+  padding-inline: max(26px, var(--gsv-gutter));
 }
 
 .gsv-cf-step {

--- a/web/src/app/features/gsv-console/connect-flows/ConnectFlowShell.css
+++ b/web/src/app/features/gsv-console/connect-flows/ConnectFlowShell.css
@@ -2,6 +2,10 @@
    Mirrors ConsoleDetailPage rows 2–3 (header + action bar) with the wizard
    stepper as the action, then the current step body. */
 .gsv-cf {
+  /* Reflow off the PANEL width, not the viewport — so the template responds
+     when the chat is dragged wider. */
+  container-type: inline-size;
+  container-name: panel;
   flex: 1;
   min-height: 100%;
   display: flex;
@@ -212,7 +216,7 @@
   background: var(--panel);
 }
 
-@media (max-width: 720px) {
+@container panel (max-width: 720px) {
   .gsv-cf-body {
     padding: 24px 18px 72px;
   }

--- a/web/src/app/features/gsv-console/integrations/IntegrationOnboardingFlow.css
+++ b/web/src/app/features/gsv-console/integrations/IntegrationOnboardingFlow.css
@@ -59,7 +59,10 @@
   color: #9d96d8;
 }
 
-@media (max-width: 520px) {
+/* Reflow off the PANEL width (the shared `.gsv-cf` shell root sets
+   container-type/name: panel), not the viewport — so the template responds
+   when the chat is dragged wider. */
+@container panel (max-width: 520px) {
   .gsv-integration-header-row {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/web/src/app/features/gsv-console/list-template/ListTemplate.css
+++ b/web/src/app/features/gsv-console/list-template/ListTemplate.css
@@ -1,6 +1,10 @@
 /* LIST page template — one header, then a body split into an ACTION column and
    a LIST column. Frame tokens mirror the Settings Overview. */
 .gsv-list-template {
+  /* Drive the body layout off the PANEL width (not the viewport) so the
+     template reflows when the chat is dragged wider, not just on small screens. */
+  container-type: inline-size;
+  container-name: panel;
   flex: 1 0 auto;
   min-height: 100%;
   margin-bottom: 88px;
@@ -18,6 +22,16 @@
   min-height: 0;
   display: grid;
   grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  /* Big screens: center the action+list column to the reading cap; the panel
+     border and the header divider above still span full width. */
+  padding-inline: var(--gsv-gutter);
+}
+
+/* The title bar is a full-width strip — only its inner content indents to the
+   centered column. !important beats SectionHeader's inline padding (left/right
+   only; its vertical padding is preserved). */
+.gsv-list-template-header {
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
 }
 
 .gsv-list-template-action,
@@ -86,9 +100,10 @@
   opacity: 1;
 }
 
-/* iPad and below: action bar stacks ON TOP of the list and lays its controls
-   out horizontally — search + filters left, primary button right. */
-@media (max-width: 1024px) {
+/* Narrow panel (iPad and below, or chat dragged wide): action bar stacks ON TOP
+   of the list and lays its controls out horizontally — search + filters left,
+   primary button right. Keyed to the PANEL container, not the viewport. */
+@container panel (max-width: 1024px) {
   /* Action bar sizes to its content (auto); the list fills the rest (1fr) —
      without this the grid stretches the bar to half the height. */
   .gsv-list-template-body {
@@ -142,5 +157,30 @@
   /* Three controls: search owns the first row, filter + connect the second. */
   .gsv-list-template-action[data-actions="3"] .gsv-list-template-search {
     flex-basis: 100%;
+  }
+}
+
+/* Phone-width panel: the horizontal action bar gets cramped, so stack every
+   control full-width for a readable mobile experience. */
+@container panel (max-width: 480px) {
+  .gsv-list-template-action {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .gsv-list-template-search,
+  .gsv-list-template-filters,
+  .gsv-list-template-connect {
+    flex: 0 0 auto;
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .gsv-list-template-filters {
+    flex-direction: column;
+  }
+
+  .gsv-list-template-connect .gsv-btn {
+    width: 100%;
   }
 }

--- a/web/src/app/features/gsv-console/machines/MachineProvisionFlow.css
+++ b/web/src/app/features/gsv-console/machines/MachineProvisionFlow.css
@@ -233,7 +233,10 @@
   line-height: 1.45;
 }
 
-@media (max-width: 720px) {
+/* Reflow off the PANEL width (the shared `.gsv-cf` shell root sets
+   container-type/name: panel), not the viewport — so the template responds
+   when the chat is dragged wider. */
+@container panel (max-width: 720px) {
   .machine-platform-tile-button {
     min-height: 0;
   }

--- a/web/src/app/features/gsv-console/messengers/MessengerIdentity.css
+++ b/web/src/app/features/gsv-console/messengers/MessengerIdentity.css
@@ -87,7 +87,10 @@
   line-height: 1.5;
 }
 
-@media (max-width: 620px) {
+/* Reflow off the PANEL width (the enclosing `.gsv-console-detail-page` sets
+   container-type/name: panel), not the viewport — so the template responds
+   when the chat is dragged wider. */
+@container panel (max-width: 620px) {
   .gsv-messenger-link-code-body {
     grid-template-columns: minmax(0, 1fr);
     align-items: stretch;

--- a/web/src/app/features/gsv-console/messengers/MessengerIdentityLinks.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerIdentityLinks.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "preact/compat";
 import { useState } from "preact/hooks";
 import { Button } from "../../../components/ui/Button";
 import { ConfirmModal } from "../../../components/ui/ConfirmModal";
@@ -128,18 +129,25 @@ export function MessengerIdentityLinks({
         <p class="gsv-messenger-identity-error">{removeLink.error.message}</p>
       ) : null}
       {confirmUnlink ? (
-        <div class="gsv-console-confirm-layer" onClick={() => setConfirmUnlink(null)}>
-          <div class="gsv-console-confirm-wrap" onClick={(event) => event.stopPropagation()}>
-            <ConfirmModal
-              title="CONFIRM UNLINK"
-              message={`Unlink ${confirmUnlink.actorId} from ${messenger.accountId}?`}
-              note="Future messages from this external identity will not resolve to the linked GSV account."
-              confirmLabel={removeLink.isPending ? "REMOVING" : "UNLINK"}
-              onCancel={() => setConfirmUnlink(null)}
-              onConfirm={() => void unlink(confirmUnlink)}
-            />
-          </div>
-        </div>
+        // Portal to <body>: the parent ConsoleDetailPage sets `container-type`,
+        // which makes it the containing block for fixed descendants — so without
+        // this the scrim resolves against the panel and can't cover the shell
+        // (matching the AgentEditor delete-modal portal).
+        createPortal(
+          <div class="gsv-console-confirm-layer" onClick={() => setConfirmUnlink(null)}>
+            <div class="gsv-console-confirm-wrap" onClick={(event) => event.stopPropagation()}>
+              <ConfirmModal
+                title="CONFIRM UNLINK"
+                message={`Unlink ${confirmUnlink.actorId} from ${messenger.accountId}?`}
+                note="Future messages from this external identity will not resolve to the linked GSV account."
+                confirmLabel={removeLink.isPending ? "REMOVING" : "UNLINK"}
+                onCancel={() => setConfirmUnlink(null)}
+                onConfirm={() => void unlink(confirmUnlink)}
+              />
+            </div>
+          </div>,
+          document.body,
+        )
       ) : null}
     </>
   );

--- a/web/src/app/features/gsv-console/packages/ApplicationImportFlow.css
+++ b/web/src/app/features/gsv-console/packages/ApplicationImportFlow.css
@@ -118,7 +118,9 @@
   padding: 12px 14px;
 }
 
-@media (max-width: 760px) {
+/* Reflow off the PANEL width, not the viewport — these bodies render inside
+   ConnectFlowShell's .gsv-cf, which owns the `panel` container. */
+@container panel (max-width: 760px) {
   .application-import-source-grid {
     grid-template-columns: 1fr;
   }

--- a/web/src/app/features/gsv-console/pages/ConsoleAgentPage.css
+++ b/web/src/app/features/gsv-console/pages/ConsoleAgentPage.css
@@ -1,4 +1,9 @@
 .gsv-console-agent {
+  /* Reflow off the PANEL width, not the viewport — so the editor padding
+     tightens when the chat is dragged wider. The delete-confirm scrim is
+     portaled to <body>, so this container does not trap its fixed positioning. */
+  container-type: inline-size;
+  container-name: panel;
   flex: 1;
   min-height: 100%;
   display: flex;
@@ -23,7 +28,7 @@
   min-height: 100% !important;
 }
 
-@media (max-width: 680px) {
+@container panel (max-width: 680px) {
   .gsv-console-agent-frame {
     padding: 16px;
   }

--- a/web/src/app/features/gsv-console/pages/ConsoleConfigPage.css
+++ b/web/src/app/features/gsv-console/pages/ConsoleConfigPage.css
@@ -16,15 +16,6 @@
   min-height: 0;
 }
 
-/* Reading-width: the index "MODELS"/"RUNTIME" SectionHeader is a full-width
-   strip (DS inline padding 14px 20px) — center its inner content while it stays
-   full-width. The settings panels stack full-width below in a single-column
-   grid, so the gutter is applied per-band (here + in SettingsListPanel.css),
-   not on the grid container. */
-.gsv-console-settings-index > .gsv-section-header {
-  padding-inline: max(20px, var(--gsv-gutter)) !important;
-}
-
 .gsv-console-settings-group,
 .gsv-console-model-form {
   min-width: 0;

--- a/web/src/app/features/gsv-console/pages/ConsoleConfigPage.css
+++ b/web/src/app/features/gsv-console/pages/ConsoleConfigPage.css
@@ -1,4 +1,9 @@
 .gsv-console-settings-index {
+  /* Reflow off the PANEL width, not the viewport — so the template responds when
+     the chat is dragged wider. This also makes the nested SettingsListPanels
+     query against the panel width rather than the screen. */
+  container-type: inline-size;
+  container-name: panel;
   flex: 1;
   min-height: 100%;
   display: grid;
@@ -9,6 +14,15 @@
 
 .gsv-console-settings-index .gsv-console-settings-list {
   min-height: 0;
+}
+
+/* Reading-width: the index "MODELS"/"RUNTIME" SectionHeader is a full-width
+   strip (DS inline padding 14px 20px) — center its inner content while it stays
+   full-width. The settings panels stack full-width below in a single-column
+   grid, so the gutter is applied per-band (here + in SettingsListPanel.css),
+   not on the grid container. */
+.gsv-console-settings-index > .gsv-section-header {
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
 }
 
 .gsv-console-settings-group,
@@ -144,7 +158,11 @@
   gap: 8px;
 }
 
-@media (max-width: 520px) {
+/* `.gsv-console-settings-group` / `.gsv-console-model-form` render inside the
+   detail page, which already establishes the `panel` container; the index
+   section establishes its own (above), so both groups of rules query the panel
+   width rather than the viewport. */
+@container panel (max-width: 520px) {
   .gsv-console-settings-index {
     gap: 14px;
   }

--- a/web/src/app/features/gsv-console/pages/ConsoleConfigPage.css
+++ b/web/src/app/features/gsv-console/pages/ConsoleConfigPage.css
@@ -16,6 +16,15 @@
   min-height: 0;
 }
 
+/* Reading-width: the index "MODELS"/"RUNTIME" SectionHeader is a full-width
+   strip (DS inline padding 14px 20px) — center its inner content while it stays
+   full-width. The settings panels stack full-width below in a single-column
+   grid, so the gutter is applied per-band (here + in SettingsListPanel.css),
+   not on the grid container. */
+.gsv-console-settings-index > .gsv-section-header {
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
+}
+
 .gsv-console-settings-group,
 .gsv-console-model-form {
   min-width: 0;

--- a/web/src/app/features/gsv-console/pages/ConsoleOverviewPage.css
+++ b/web/src/app/features/gsv-console/pages/ConsoleOverviewPage.css
@@ -20,9 +20,6 @@
   border: 1px solid var(--border-raised);
   background: var(--panel);
   box-shadow: inset 0 0 0 1px #060414, 0 0 30px rgba(80, 70, 180, 0.1);
-  /* Big screens: the dashboard frame/border spans the full panel, but the grid
-     columns inside align to the centered reading column. Base padding is 0. */
-  padding-inline: var(--gsv-gutter);
 }
 
 .gsv-settings-left,

--- a/web/src/app/features/gsv-console/pages/ConsoleOverviewPage.css
+++ b/web/src/app/features/gsv-console/pages/ConsoleOverviewPage.css
@@ -1,3 +1,16 @@
+/* Container wrapper: the overview grid resizes itself at the breakpoints below,
+   and an element can't query its own width — so the `panel` container lives on
+   this frame, letting the grid reflow off the PANEL width (not the viewport)
+   when the chat is dragged wider. */
+.gsv-settings-overview-frame {
+  container-type: inline-size;
+  container-name: panel;
+  flex: 1 0 auto;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .gsv-settings-overview {
   flex: 1 0 auto;
   min-height: 100%;
@@ -7,6 +20,9 @@
   border: 1px solid var(--border-raised);
   background: var(--panel);
   box-shadow: inset 0 0 0 1px #060414, 0 0 30px rgba(80, 70, 180, 0.1);
+  /* Big screens: the dashboard frame/border spans the full panel, but the grid
+     columns inside align to the centered reading column. Base padding is 0. */
+  padding-inline: var(--gsv-gutter);
 }
 
 .gsv-settings-left,
@@ -285,7 +301,7 @@
   min-height: 0;
 }
 
-@media (max-width: 760px) {
+@container panel (max-width: 760px) {
   .gsv-settings-overview {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -299,7 +315,7 @@
   }
 }
 
-@media (max-width: 540px) {
+@container panel (max-width: 540px) {
   .gsv-settings-split,
   .gsv-settings-crew-grid {
     grid-template-columns: minmax(0, 1fr);

--- a/web/src/app/features/gsv-console/pages/ConsoleOverviewPanels.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleOverviewPanels.tsx
@@ -800,8 +800,9 @@ export function SettingsOverviewDashboard({
   const applications = visiblePackages.filter(isApplicationPackage);
 
   return (
-    <div class="gsv-settings-overview" aria-label="GSV settings overview">
-      <div class="gsv-settings-left">
+    <div class="gsv-settings-overview-frame">
+      <div class="gsv-settings-overview" aria-label="GSV settings overview">
+        <div class="gsv-settings-left">
         <ShipPanel
           config={data.config}
           data={data}
@@ -838,6 +839,7 @@ export function SettingsOverviewDashboard({
           onOpenListDetail={onOpenListDetail}
           onOpenSurface={onOpenSurface}
         />
+      </div>
       </div>
     </div>
   );

--- a/web/src/app/features/gsv-shell/GsvShell.tsx
+++ b/web/src/app/features/gsv-shell/GsvShell.tsx
@@ -403,7 +403,11 @@ export function GsvShell({
     settingsDetailId: activeSettingsDetailId,
     desktopObjects,
     collapsed: shell.railCollapsed,
-    onToggleCollapsed: shell.toggleRailCollapsed,
+    // On mobile the rail is a full-height drawer (never the collapsed icon rail),
+    // so its "Hide menu" control closes the drawer instead of toggling collapse —
+    // which would be a no-op there. (On the home menu the control is hidden via
+    // CSS, since there is nothing to return to behind it.)
+    onToggleCollapsed: shell.mobileLayout ? shell.closeMobilePanels : shell.toggleRailCollapsed,
     onBackToDesktop: shell.desktopCollapsed ? guardedRevealDesktop : guardedBackToDesktop,
     onOpenControlMenu: shell.openControlMenu,
     onOpenSurface: openShellSurface,

--- a/web/src/app/features/gsv-shell/GsvShell.tsx
+++ b/web/src/app/features/gsv-shell/GsvShell.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "preact";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { IconMenu } from "../../components/ui/IconMenu";
 import { StatusDot } from "../../components/ui/StatusDot";
@@ -393,6 +394,65 @@ export function GsvShell({
     ? shell.activePageTab?.libraryRoute ?? { view: "index" }
     : { view: "index" };
 
+  // Mobile layout: the center panel is the home screen; the menu (rail) and chat
+  // are full-height drawers revealed by swiping (or tapping the edge arrows).
+  const mobilePane: "menu" | "chat" | "center" = shell.mobileMenuOpen
+    ? "menu"
+    : shell.chatOpen
+      ? "chat"
+      : "center";
+
+  // Navigating from the menu drawer returns to the center pane (the new page
+  // sits underneath the open drawer otherwise). Mobile-only so it never closes
+  // the chat on desktop, where navigation and the chat dock coexist.
+  useEffect(() => {
+    if (shell.mobileLayout) {
+      shell.closeMobilePanels();
+    }
+    // closeMobilePanels is recreated each render; depend on the route + layout.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shell.activeSurface, shell.activeTabKey, shell.mobileLayout]);
+
+  const swipeStartRef = useRef<{ x: number; y: number } | null>(null);
+  const handleViewportTouchStart = (event: JSX.TargetedTouchEvent<HTMLDivElement>): void => {
+    if (!shell.mobileLayout || event.touches.length !== 1) {
+      swipeStartRef.current = null;
+      return;
+    }
+    const touch = event.touches[0];
+    swipeStartRef.current = { x: touch.clientX, y: touch.clientY };
+  };
+  const handleViewportTouchEnd = (event: JSX.TargetedTouchEvent<HTMLDivElement>): void => {
+    const start = swipeStartRef.current;
+    swipeStartRef.current = null;
+    if (!start || !shell.mobileLayout) {
+      return;
+    }
+    const touch = event.changedTouches[0];
+    const dx = touch.clientX - start.x;
+    const dy = touch.clientY - start.y;
+    // Require a clear, horizontally-dominant swipe so vertical scrolling and
+    // small taps don't move panes.
+    if (Math.abs(dx) < 56 || Math.abs(dx) < Math.abs(dy) * 1.4) {
+      return;
+    }
+    if (dx < 0) {
+      // Swipe left → reveal chat, or close the menu drawer.
+      if (shell.mobileMenuOpen) {
+        shell.closeMobilePanels();
+      } else if (!shell.chatOpen) {
+        shell.setChatOpen(true);
+      }
+    } else {
+      // Swipe right → reveal menu, or close the chat drawer.
+      if (shell.chatOpen) {
+        shell.setChatOpen(false);
+      } else if (!shell.mobileMenuOpen && shell.showRail) {
+        shell.openMobileMenu();
+      }
+    }
+  };
+
   return (
     <UnsavedGuardProvider value={guard.contextValue}>
     <div
@@ -402,7 +462,9 @@ export function GsvShell({
     >
       <div
         ref={rootRef}
-        class={`gsv-shell-viewport${shell.chatOpen ? " has-chat" : ""}${shell.chatDragging ? " is-chat-dragging" : ""}`}
+        class={`gsv-shell-viewport${shell.chatOpen ? " has-chat" : ""}${shell.chatDragging ? " is-chat-dragging" : ""}${shell.mobileLayout ? ` is-mobile is-pane-${mobilePane}` : ""}`}
+        onTouchStart={handleViewportTouchStart}
+        onTouchEnd={handleViewportTouchEnd}
       >
         <main
           class={`gsv-shell-world${shell.activeSurface !== "desktop" ? " has-page" : ""}${shell.desktopCollapsed ? " is-desktop-collapsed" : ""}${shell.railCollapsed ? " is-rail-collapsed" : ""}`}
@@ -564,6 +626,33 @@ export function GsvShell({
           userLabel={sessionUsername}
           onSelectAgent={selectChatAgent}
         />
+
+        {shell.mobileLayout ? (
+          <>
+            {/* Scrim behind the menu drawer; tap to return to the center pane. */}
+            <div
+              class="gsv-mobile-scrim"
+              onClick={shell.closeMobilePanels}
+              aria-hidden="true"
+            />
+            {/* Discrete edge affordances: chevrons hint the swipe that reveals
+                each full-height drawer (right → menu, left → chat). */}
+            {shell.showRail ? (
+              <button
+                type="button"
+                class="gsv-mobile-edge is-menu"
+                aria-label="Open menu"
+                onClick={shell.openMobileMenu}
+              />
+            ) : null}
+            <button
+              type="button"
+              class="gsv-mobile-edge is-chat"
+              aria-label="Open chat"
+              onClick={() => shell.setChatOpen(true)}
+            />
+          </>
+        ) : null}
       </div>
 
       <ShellStatusBar

--- a/web/src/app/features/gsv-shell/GsvShell.tsx
+++ b/web/src/app/features/gsv-shell/GsvShell.tsx
@@ -394,8 +394,26 @@ export function GsvShell({
     ? shell.activePageTab?.libraryRoute ?? { view: "index" }
     : { view: "index" };
 
+  const railProps = {
+    activeSurface: shell.activeSurface,
+    activeTabKey: shell.activeTabKey,
+    settingsView: activeSettingsRoute.view,
+    createSection: activeCreateSection,
+    settingsKind: activeSettingsKind,
+    settingsDetailId: activeSettingsDetailId,
+    desktopObjects,
+    collapsed: shell.railCollapsed,
+    onToggleCollapsed: shell.toggleRailCollapsed,
+    onBackToDesktop: shell.desktopCollapsed ? guardedRevealDesktop : guardedBackToDesktop,
+    onOpenControlMenu: shell.openControlMenu,
+    onOpenSurface: openShellSurface,
+    onOpenObject: guardedOpenObject,
+    onCreateObject: createSectionObject,
+  };
+
   // Mobile layout: the center panel is the home screen; the menu (rail) and chat
-  // are full-height drawers revealed by swiping (or tapping the edge arrows).
+  // are full-height drawers revealed by swiping (or tapping the edge arrows). On
+  // the home (desktop) surface the node view is replaced by the stacked menu.
   const mobilePane: "menu" | "chat" | "center" = shell.mobileMenuOpen
     ? "menu"
     : shell.chatOpen
@@ -470,24 +488,7 @@ export function GsvShell({
           class={`gsv-shell-world${shell.activeSurface !== "desktop" ? " has-page" : ""}${shell.desktopCollapsed ? " is-desktop-collapsed" : ""}${shell.railCollapsed ? " is-rail-collapsed" : ""}`}
           style={{ "--gsv-rail-width": `${shell.showRail ? (shell.railCollapsed ? 64 : 262) : 0}px` }}
         >
-          {shell.showRail ? (
-            <ShellRail
-              activeSurface={shell.activeSurface}
-              activeTabKey={shell.activeTabKey}
-              settingsView={activeSettingsRoute.view}
-              createSection={activeCreateSection}
-              settingsKind={activeSettingsKind}
-              settingsDetailId={activeSettingsDetailId}
-              desktopObjects={desktopObjects}
-              collapsed={shell.railCollapsed}
-              onToggleCollapsed={shell.toggleRailCollapsed}
-              onBackToDesktop={shell.desktopCollapsed ? guardedRevealDesktop : guardedBackToDesktop}
-              onOpenControlMenu={shell.openControlMenu}
-              onOpenSurface={openShellSurface}
-              onOpenObject={guardedOpenObject}
-              onCreateObject={createSectionObject}
-            />
-          ) : null}
+          {shell.showRail ? <ShellRail {...railProps} /> : null}
 
           <section class="gsv-shell-canvas" aria-label={shellSurfaceLabel(shell.activeSurface)}>
             {shell.activeSurface !== "desktop" ? (
@@ -533,6 +534,11 @@ export function GsvShell({
               </>
             ) : shell.desktopCollapsed ? (
               <CollapsedDesktop />
+            ) : shell.mobileLayout ? (
+              // Mobile home: the stacked menu replaces the desktop node view.
+              <div class="gsv-mobile-menu-home">
+                <ShellRail {...railProps} />
+              </div>
             ) : (
               <>
                 <GsvDesktop

--- a/web/src/app/features/gsv-shell/hooks/useGsvShellState.ts
+++ b/web/src/app/features/gsv-shell/hooks/useGsvShellState.ts
@@ -32,6 +32,11 @@ const DEFAULT_CHAT_WIDTH = 460;
 const EXPANDED_RAIL_WIDTH = 262;
 const COLLAPSED_RAIL_WIDTH = 64;
 const MIN_CONSOLE_WIDTH = 360;
+// Smallest the center panel may be squeezed to while dragging the chat wider.
+// At this width the page templates reflow to their single-column mobile layout
+// (see the @container panel breakpoints), so the chat's effective max width is
+// the collapsed rail plus this readable mobile floor.
+const MIN_CONSOLE_DRAG_WIDTH = 320;
 const MIN_DESKTOP_TREE_WIDTH = 600;
 const MIN_DESKTOP_RAIL_CANVAS_WIDTH = 40;
 const STACKED_LAYOUT_WIDTH = 760;
@@ -168,7 +173,7 @@ export function useGsvShellState({
     stackedLayout ? MIN_STACKED_CHAT_HEIGHT : MIN_CHAT_WIDTH,
     stackedLayout
       ? rootHeight - MIN_STACKED_WORLD_HEIGHT
-      : rootWidth - (inPageZone ? COLLAPSED_RAIL_WIDTH + MIN_CONSOLE_WIDTH : COLLAPSED_RAIL_WIDTH),
+      : rootWidth - (inPageZone ? COLLAPSED_RAIL_WIDTH + MIN_CONSOLE_DRAG_WIDTH : COLLAPSED_RAIL_WIDTH),
   );
   const resolvedChatWidth = clamp(chatWidth, stackedLayout ? MIN_STACKED_CHAT_HEIGHT : MIN_CHAT_WIDTH, maxChatWidth);
   const mainWidth = rootWidth - (!stackedLayout && chatOpen ? resolvedChatWidth : 0);
@@ -360,7 +365,7 @@ export function useGsvShellState({
       return;
     }
 
-    const reserve = inPageZone ? COLLAPSED_RAIL_WIDTH + MIN_CONSOLE_WIDTH : COLLAPSED_RAIL_WIDTH;
+    const reserve = inPageZone ? COLLAPSED_RAIL_WIDTH + MIN_CONSOLE_DRAG_WIDTH : COLLAPSED_RAIL_WIDTH;
     const stackedDrag = rect.width <= STACKED_LAYOUT_WIDTH;
     const minChatExtent = stackedDrag ? MIN_STACKED_CHAT_HEIGHT : MIN_CHAT_WIDTH;
     const maxChatExtent = Math.max(

--- a/web/src/app/features/gsv-shell/hooks/useGsvShellState.ts
+++ b/web/src/app/features/gsv-shell/hooks/useGsvShellState.ts
@@ -39,9 +39,10 @@ const MIN_CONSOLE_WIDTH = 360;
 const MIN_CONSOLE_DRAG_WIDTH = 320;
 const MIN_DESKTOP_TREE_WIDTH = 600;
 const MIN_DESKTOP_RAIL_CANVAS_WIDTH = 40;
-const STACKED_LAYOUT_WIDTH = 760;
-const MIN_STACKED_CHAT_HEIGHT = 300;
-const MIN_STACKED_WORLD_HEIGHT = 260;
+// Below this panel width the shell switches to the mobile layout: the center
+// panel is the home screen, and the menu (rail) and chat become full-height
+// drawers revealed by swiping left/right (see GsvShell mobile pane handling).
+const MOBILE_LAYOUT_WIDTH = 760;
 const SHELL_TABS_STORAGE_KEY = "gsv.shell.tabs.v1";
 
 type UseGsvShellStateArgs = {
@@ -123,7 +124,6 @@ export function useGsvShellState({
   const [initialRoute] = useState<ShellRoute>(() => readInitialRoute());
   const initialTab = shellTabForRoute(initialRoute);
   const [rootWidth, setRootWidth] = useState(1280);
-  const [rootHeight, setRootHeight] = useState(760);
   const [activeSurface, setActiveSurface] = useState<ShellSurfaceId>(() => surfaceForRoute(initialRoute));
   const [openTabs, setOpenTabs] = useState<ShellPageTab[]>(() => {
     const persistedTabs = readPersistedTabs();
@@ -137,6 +137,9 @@ export function useGsvShellState({
   const [chatOpen, setChatOpen] = useState(false);
   const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
   const [chatDragging, setChatDragging] = useState(false);
+  // Mobile-only: the menu (rail) drawer. Chat reuses chatOpen; the two are kept
+  // mutually exclusive below so only one full-height drawer shows at a time.
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   // Set while dragging the rail divider, so the trailing click doesn't also toggle.
   const railDraggedRef = useRef(false);
 
@@ -149,7 +152,6 @@ export function useGsvShellState({
     const update = () => {
       const rect = node.getBoundingClientRect();
       setRootWidth(rect.width);
-      setRootHeight(rect.height);
     };
     update();
 
@@ -168,23 +170,33 @@ export function useGsvShellState({
   }, [openTabs]);
 
   const inPageZone = activeSurface !== "desktop";
-  const stackedLayout = rootWidth <= STACKED_LAYOUT_WIDTH;
+  const mobileLayout = rootWidth <= MOBILE_LAYOUT_WIDTH;
+  // Desktop chat resize math. On mobile the chat is a full-height drawer that
+  // overlays the center panel, so it no longer steals panel width and this is
+  // unused (the resize handle is hidden — see the mobile rules in ChatDock.css).
   const maxChatWidth = Math.max(
-    stackedLayout ? MIN_STACKED_CHAT_HEIGHT : MIN_CHAT_WIDTH,
-    stackedLayout
-      ? rootHeight - MIN_STACKED_WORLD_HEIGHT
-      : rootWidth - (inPageZone ? COLLAPSED_RAIL_WIDTH + MIN_CONSOLE_DRAG_WIDTH : COLLAPSED_RAIL_WIDTH),
+    MIN_CHAT_WIDTH,
+    rootWidth - (inPageZone ? COLLAPSED_RAIL_WIDTH + MIN_CONSOLE_DRAG_WIDTH : COLLAPSED_RAIL_WIDTH),
   );
-  const resolvedChatWidth = clamp(chatWidth, stackedLayout ? MIN_STACKED_CHAT_HEIGHT : MIN_CHAT_WIDTH, maxChatWidth);
-  const mainWidth = rootWidth - (!stackedLayout && chatOpen ? resolvedChatWidth : 0);
-  const desktopCollapsed = !stackedLayout && !inPageZone && chatOpen && mainWidth < MIN_DESKTOP_TREE_WIDTH;
-  const autoRailCollapsed = !stackedLayout && chatOpen && (
+  const resolvedChatWidth = clamp(chatWidth, MIN_CHAT_WIDTH, maxChatWidth);
+  const mainWidth = rootWidth - (!mobileLayout && chatOpen ? resolvedChatWidth : 0);
+  const desktopCollapsed = !mobileLayout && !inPageZone && chatOpen && mainWidth < MIN_DESKTOP_TREE_WIDTH;
+  const autoRailCollapsed = !mobileLayout && chatOpen && (
     inPageZone
       ? mainWidth - EXPANDED_RAIL_WIDTH < MIN_CONSOLE_WIDTH
       : desktopCollapsed && mainWidth - EXPANDED_RAIL_WIDTH < MIN_DESKTOP_RAIL_CANVAS_WIDTH
   );
-  const railCollapsed = manualRailCollapsed || autoRailCollapsed;
+  // On mobile the rail is the full-height menu drawer, always shown expanded.
+  const railCollapsed = !mobileLayout && (manualRailCollapsed || autoRailCollapsed);
   const showRail = inPageZone || desktopCollapsed;
+
+  // Mobile drawers are mutually exclusive and only exist in the mobile layout:
+  // leaving that layout, or opening the chat, closes the menu drawer.
+  useEffect(() => {
+    if (!mobileLayout || chatOpen) {
+      setMobileMenuOpen(false);
+    }
+  }, [mobileLayout, chatOpen]);
   const selectedObject = getDesktopObject(desktopObjects, selectedObjectId);
   const activePageTab = activeTabKey ? openTabs.find((tab) => tab.key === activeTabKey) ?? null : null;
 
@@ -366,20 +378,11 @@ export function useGsvShellState({
     }
 
     const reserve = inPageZone ? COLLAPSED_RAIL_WIDTH + MIN_CONSOLE_DRAG_WIDTH : COLLAPSED_RAIL_WIDTH;
-    const stackedDrag = rect.width <= STACKED_LAYOUT_WIDTH;
-    const minChatExtent = stackedDrag ? MIN_STACKED_CHAT_HEIGHT : MIN_CHAT_WIDTH;
-    const maxChatExtent = Math.max(
-      minChatExtent,
-      stackedDrag ? rect.height - MIN_STACKED_WORLD_HEIGHT : rect.width - reserve,
-    );
+    const maxChatExtent = Math.max(MIN_CHAT_WIDTH, rect.width - reserve);
     setChatDragging(true);
 
     const onMove = (moveEvent: MouseEvent) => {
-      const nextWidth = clamp(
-        stackedDrag ? rect.bottom - moveEvent.clientY : rect.right - moveEvent.clientX,
-        minChatExtent,
-        maxChatExtent,
-      );
+      const nextWidth = clamp(rect.right - moveEvent.clientX, MIN_CHAT_WIDTH, maxChatExtent);
       setChatWidth(nextWidth);
     };
     const onUp = () => {
@@ -445,6 +448,18 @@ export function useGsvShellState({
     setChatWidth(maxChatWidth);
   };
 
+  // Mobile pane controls. The menu and chat are full-height drawers over the
+  // center panel; opening one closes the other (chatOpen also closes the menu
+  // via the effect above, covering the non-mobile-menu open paths).
+  const openMobileMenu = (): void => {
+    setChatOpen(false);
+    setMobileMenuOpen(true);
+  };
+  const closeMobilePanels = (): void => {
+    setMobileMenuOpen(false);
+    setChatOpen(false);
+  };
+
   const pickerTitle = "GSV // CONTROL";
   const pickerSubtitle = "System surfaces";
 
@@ -462,10 +477,14 @@ export function useGsvShellState({
     chatDragging,
     chatOpen,
     closeActiveScreen,
+    closeMobilePanels,
     desktopCollapsed,
     gsvOpen,
     maxChatWidth,
+    mobileLayout,
+    mobileMenuOpen,
     openControlMenu,
+    openMobileMenu,
     openObject,
     openAppRoute,
     openSettingsRoute,

--- a/web/src/app/features/gsv-shell/styles/gsvShell.css
+++ b/web/src/app/features/gsv-shell/styles/gsvShell.css
@@ -1970,10 +1970,12 @@
    desktop and the JS layout flag and CSS can't drift across a media breakpoint.
    ────────────────────────────────────────────────────────────────────────── */
 
-/* Menu drawer: lift the rail out of the flex row and slide it over the center
-   panel from the left. (The rail only renders inside a page surface, so swipe-
-   to-menu is a no-op on the desktop home, where the left affordance is hidden.) */
-.gsv-shell-viewport.is-mobile .gsv-shell-rail {
+/* Menu drawer (in a page): lift the in-flow rail — the direct child of the world
+   row — out and slide it over the center panel from the left. The `> ` keeps
+   this off the home menu (which is a rail nested in the canvas, below). The rail
+   only renders in-flow inside a page surface, so swipe-to-menu is a no-op on the
+   desktop home, where the left affordance is hidden. */
+.gsv-shell-viewport.is-mobile .gsv-shell-world > .gsv-shell-rail {
   position: absolute;
   z-index: 40;
   top: 0;
@@ -1985,8 +1987,20 @@
   box-shadow: 22px 0 60px rgba(0, 0, 0, 0.5);
 }
 
-.gsv-shell-viewport.is-mobile.is-pane-menu .gsv-shell-rail {
+.gsv-shell-viewport.is-mobile.is-pane-menu .gsv-shell-world > .gsv-shell-rail {
   transform: translateX(0);
+}
+
+/* Mobile home: the stacked menu fills the canvas in place of the node view. */
+.gsv-mobile-menu-home {
+  position: absolute;
+  inset: 0;
+  display: flex;
+}
+
+.gsv-mobile-menu-home .gsv-shell-rail {
+  width: 100%;
+  border-right: 0;
 }
 
 /* The vertical rail drag-divider is a desktop-only resize affordance. */

--- a/web/src/app/features/gsv-shell/styles/gsvShell.css
+++ b/web/src/app/features/gsv-shell/styles/gsvShell.css
@@ -1712,6 +1712,17 @@
   padding: 20px;
 }
 
+/* Large-screen reading width. Strips (title bars, toolbars) stay full-width;
+   their inner content and the page content align to this centered column via
+   `padding-inline: max(<base>, var(--gsv-gutter))`. The gutter is 0 until the
+   panel exceeds the cap, then grows to center the column. `100%` resolves
+   against the using element's containing block (the full-width strip = the
+   panel), so it tracks the panel, not the viewport — no breakpoint needed. */
+:root {
+  --gsv-content-cap: 1440px;
+  --gsv-gutter: max(0px, calc((100% - var(--gsv-content-cap)) / 2));
+}
+
 .gsv-console-page.is-flush .gsv-console-page-body {
   padding: 0;
   display: flex;

--- a/web/src/app/features/gsv-shell/styles/gsvShell.css
+++ b/web/src/app/features/gsv-shell/styles/gsvShell.css
@@ -1907,18 +1907,6 @@
 }
 
 @media (max-width: 760px) {
-  .gsv-shell-viewport {
-    flex-direction: column;
-  }
-
-  .gsv-shell-viewport.is-chat-dragging {
-    cursor: ns-resize;
-  }
-
-  .gsv-shell-world {
-    min-height: 0;
-  }
-
   .gsv-space-hud {
     left: 16px;
     right: 16px;
@@ -1972,4 +1960,119 @@
   .gsv-status-actions > span:nth-last-child(2) {
     display: none;
   }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Mobile layout. The center panel is the home screen; the menu (rail) and chat
+   become full-height drawers revealed by swiping left/right (or tapping the
+   edge-arrow affordances). Everything here is gated on `.is-mobile`, which the
+   shell adds below MOBILE_LAYOUT_WIDTH — so the transforms can't leak onto
+   desktop and the JS layout flag and CSS can't drift across a media breakpoint.
+   ────────────────────────────────────────────────────────────────────────── */
+
+/* Menu drawer: lift the rail out of the flex row and slide it over the center
+   panel from the left. (The rail only renders inside a page surface, so swipe-
+   to-menu is a no-op on the desktop home, where the left affordance is hidden.) */
+.gsv-shell-viewport.is-mobile .gsv-shell-rail {
+  position: absolute;
+  z-index: 40;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: min(320px, 86vw);
+  transform: translateX(-100%);
+  transition: transform 0.24s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 22px 0 60px rgba(0, 0, 0, 0.5);
+}
+
+.gsv-shell-viewport.is-mobile.is-pane-menu .gsv-shell-rail {
+  transform: translateX(0);
+}
+
+/* The vertical rail drag-divider is a desktop-only resize affordance. */
+.gsv-shell-viewport.is-mobile .gsv-console-rail-handle {
+  display: none;
+}
+
+/* Scrim behind the menu drawer; the chat drawer is full-bleed so it needs none. */
+.gsv-mobile-scrim {
+  position: absolute;
+  z-index: 38;
+  inset: 0;
+  background: rgba(4, 3, 16, 0.55);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.24s ease;
+}
+
+.gsv-shell-viewport.is-pane-menu .gsv-mobile-scrim {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Edge affordances: a thin tab on each side of the center pane with a chevron
+   pointing the way the reveal-swipe travels (left edge → swipe right for the
+   menu; right edge → swipe left for the chat). Hidden once a drawer is open. */
+.gsv-mobile-edge {
+  position: absolute;
+  z-index: 30;
+  top: 50%;
+  width: 22px;
+  height: 64px;
+  transform: translateY(-50%);
+  border: 1px solid var(--border);
+  background: rgba(10, 8, 29, 0.72);
+  color: var(--label);
+  cursor: pointer;
+  opacity: 0.9;
+  transition: opacity 0.18s ease, color 0.18s ease, background 0.18s ease;
+}
+
+.gsv-mobile-edge.is-menu {
+  left: 0;
+  border-left: 0;
+  border-radius: 0 9px 9px 0;
+}
+
+.gsv-mobile-edge.is-chat {
+  right: 0;
+  border-right: 0;
+  border-radius: 9px 0 0 9px;
+}
+
+.gsv-mobile-edge:hover,
+.gsv-mobile-edge:focus-visible {
+  opacity: 1;
+  color: var(--text-hi);
+  background: rgba(20, 16, 48, 0.92);
+  outline: none;
+}
+
+/* CSS chevron — a small square with two adjacent borders, rotated to a point
+   (no icon asset needed). is-menu points right (›), is-chat points left (‹). */
+.gsv-mobile-edge::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 7px;
+  height: 7px;
+  border-style: solid;
+  border-color: currentColor;
+}
+
+.gsv-mobile-edge.is-menu::before {
+  border-width: 1.5px 1.5px 0 0;
+  transform: translate(-60%, -50%) rotate(45deg);
+}
+
+.gsv-mobile-edge.is-chat::before {
+  border-width: 0 0 1.5px 1.5px;
+  transform: translate(-40%, -50%) rotate(45deg);
+}
+
+.gsv-shell-viewport.is-pane-menu .gsv-mobile-edge,
+.gsv-shell-viewport.is-pane-chat .gsv-mobile-edge {
+  opacity: 0;
+  pointer-events: none;
 }

--- a/web/src/app/features/gsv-shell/styles/gsvShell.css
+++ b/web/src/app/features/gsv-shell/styles/gsvShell.css
@@ -2003,6 +2003,13 @@
   border-right: 0;
 }
 
+/* The home menu is the screen itself — there's nothing to hide it back to, so
+   drop the rail's "Hide menu" control here. (On the in-page drawer it stays and
+   closes the drawer; see onToggleCollapsed in GsvShell.) */
+.gsv-mobile-menu-home .gsv-rail-menu {
+  display: none;
+}
+
 /* The vertical rail drag-divider is a desktop-only resize affordance. */
 .gsv-shell-viewport.is-mobile .gsv-console-rail-handle {
   display: none;

--- a/web/src/app/features/repositories/RepositoriesPage.css
+++ b/web/src/app/features/repositories/RepositoriesPage.css
@@ -1,4 +1,8 @@
 .repositories-surface {
+  /* Reflow off the PANEL width, not the viewport — so the template responds
+     when the chat is dragged wider. */
+  container-type: inline-size;
+  container-name: panel;
   position: relative;
   min-height: 0;
   height: 100%;
@@ -20,6 +24,8 @@
   flex-wrap: wrap;
   gap: 12px;
   padding: 14px;
+  /* Reading-width: full-width band, keep controls aligned to the centered column. */
+  padding-inline: max(14px, var(--gsv-gutter));
   border-bottom: 1px solid var(--rule-section);
   background: color-mix(in srgb, var(--panel) 92%, var(--shadow-deep));
 }
@@ -130,6 +136,8 @@
   grid-template-columns: minmax(0, 1fr);
   align-items: end;
   background: var(--void);
+  /* Reading-width: full-width tab strip, align tabs to the centered column. */
+  padding-inline: var(--gsv-gutter);
 }
 
 .repositories-tab-panel {
@@ -141,12 +149,21 @@
   background: var(--panel);
 }
 
+/* Reading-width: the panel's SectionTitle is a full-width SectionHeader strip
+   (inline padding 14px 20px from the DS component) — center its inner content
+   while it stays full-width. */
+.repositories-tab-panel > .gsv-section-header {
+  padding-inline: max(20px, var(--gsv-gutter)) !important;
+}
+
 .repositories-breadcrumbs-container {
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 12px;
   padding: 8px 14px;
+  /* Reading-width: full-width band. */
+  padding-inline: max(14px, var(--gsv-gutter));
   border-bottom: 1px solid var(--rule-inner);
   background: color-mix(in srgb, var(--panel) 92%, var(--shadow-deep));
 }
@@ -170,6 +187,8 @@
   display: grid;
   gap: 12px;
   padding: 14px;
+  /* Reading-width: full-width toolbar band, keep controls in the centered column. */
+  padding-inline: max(14px, var(--gsv-gutter));
 }
 
 .repositories-toolbar-row {
@@ -225,10 +244,15 @@
   align-items: center;
   gap: 8px;
   padding: 10px 14px;
+  /* Reading-width: full-width list header. */
+  padding-inline: max(14px, var(--gsv-gutter));
 }
 
 .repositories-object-row {
   border-bottom: 1px solid var(--rule-inner) !important;
+  /* Reading-width: rows fill the full-width list; the row sets padding inline
+     (COMPACT_ROW_STYLE: 12px 14px), so override with !important, base 14px. */
+  padding-inline: max(14px, var(--gsv-gutter)) !important;
 }
 
 .repositories-object-row.is-selected {
@@ -243,7 +267,8 @@
 .repositories-row-action {
   position: absolute;
   top: 50%;
-  right: 40px;
+  /* Reading-width: track the centered column so the action stays inside it. */
+  right: calc(40px + var(--gsv-gutter));
   transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
@@ -269,6 +294,8 @@
   gap: 12px;
   align-items: center;
   padding: 11px 14px;
+  /* Reading-width: full-width result/commit rows. */
+  padding-inline: max(14px, var(--gsv-gutter));
   text-align: left;
   cursor: pointer;
   font: inherit;
@@ -361,6 +388,8 @@
   flex-wrap: wrap;
   gap: 8px;
   padding: 10px 14px;
+  /* Reading-width: full-width file meta band. */
+  padding-inline: max(14px, var(--gsv-gutter));
   border-bottom: 1px solid var(--rule-inner);
   background: color-mix(in srgb, var(--panel) 86%, var(--field-deep));
 }
@@ -414,6 +443,8 @@
   display: grid;
   gap: 14px;
   padding: 14px;
+  /* Reading-width: full-width diff region (its scroll parent spans the panel). */
+  padding-inline: max(14px, var(--gsv-gutter));
 }
 
 .repositories-diff-head,
@@ -511,6 +542,8 @@
 
 .repositories-empty-inline {
   padding: 18px 14px;
+  /* Reading-width: full-width inline notice inside the results region. */
+  padding-inline: max(14px, var(--gsv-gutter));
   color: var(--text-muted);
   font-family: var(--gsv-font-mono);
   font-size: 10px;
@@ -524,11 +557,13 @@
   flex-wrap: wrap;
   gap: 12px;
   padding: 14px;
+  /* Reading-width: full-width compare toolbar band. */
+  padding-inline: max(14px, var(--gsv-gutter));
   border-bottom: 1px solid var(--rule-section);
   background: color-mix(in srgb, var(--panel) 92%, var(--shadow-deep));
 }
 
-@media (max-width: 760px) {
+@container panel (max-width: 760px) {
   .repositories-header-bar,
   .repositories-toolbar-row,
   .repositories-editor-toolbar,


### PR DESCRIPTION
## Summary
The center panel shrinks when the chat is dragged wider, but its template breakpoints were keyed to the **viewport** — so on a wide monitor a squeezed panel kept its desktop layout and broke. This makes the console templates reflow off the **panel** width instead, adds phone-width single-column layouts, and caps reading width on large screens.

## Changes
- **Viewport `@media` → `@container` (panel-width) queries** across the console templates (Card / List / Detail / Settings / Overview / Config / Agent, connect-flows, repositories), establishing per-template `container-type` contexts; phone-width single-column layouts down to ~320px.
- **Lower the chat resize floor** to a 320px mobile panel (`MIN_CONSOLE_DRAG_WIDTH`) so the chat can expand to collapsed-rail + a readable mobile center.
- **Portal the AgentEditor delete modal to `<body>`** so the new container contexts don't trap its `position: fixed`.
- **Large-screen reading width** (`--gsv-content-cap: 1440px` + `--gsv-gutter`): full-width strips (title bars, toolbars) keep spanning the panel while inner/page content centers via `padding-inline: max(base, var(--gsv-gutter))`. No breakpoint needed — the gutter is 0 below the cap.

Files/Terminal stay full-bleed; connect-flow wizards keep their fixed 560px column.

## Scope note
**Library reflow is intentionally excluded here.** The Library page is redesigned wholesale on `breadcrumb-config-detail` (#177); leaving it untouched in this PR avoids a conflicting layout. The AgentEditor portal is kept.

## Verification
- ✅ `tsc --noEmit` passes.
- Visual reflow verified locally (the preview sandbox can't reach the auth-gated gateway).
