### PR TITLE
Rebuild CREW page on ListTemplate with in-body defaults editor

### DIFF
--- a/web/src/app/components/ui/AgentEditor.css
+++ b/web/src/app/components/ui/AgentEditor.css
@@ -33,87 +33,6 @@
   box-shadow: 0 14px 22px rgba(4, 3, 16, 0.42);
 }
 
-/* code editor scrollbar (from source <style> .gsv-ed rules) */
-.gsv-ed::-webkit-scrollbar {
-  width: 9px;
-}
-.gsv-ed::-webkit-scrollbar-thumb {
-  background: var(--border);
-}
-.gsv-ed::-webkit-scrollbar-track {
-  background: var(--panel-2);
-}
-
-/* ===== new-file folder ===== */
-.gsv-ae-file-tab {
-  appearance: none;
-  width: 78px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 9px;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-  text-align: center;
-}
-
-.gsv-ae-file-tab:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 4px;
-}
-
-.gsv-ae-newfile:hover {
-  opacity: 0.8;
-}
-.gsv-ae-newfile:disabled:hover {
-  opacity: 0.45;
-}
-.gsv-ae-newfile.is-disabled {
-  cursor: not-allowed !important;
-  opacity: 0.45;
-}
-
-/* ===== code editor textarea ===== */
-.gsv-ae-editor {
-  width: 100%;
-  height: 300px;
-  resize: vertical;
-  background: var(--panel-2);
-  border: 1px solid var(--border);
-  outline: none;
-  padding: 16px 17px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 12.5px;
-  line-height: 1.7;
-  color: #dcd9ff;
-}
-.gsv-ae-editor:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 1px rgba(179, 174, 255, 0.35);
-}
-.gsv-ae-editor:read-only {
-  cursor: default;
-  color: #aaa5d8;
-}
-
-.gsv-ae-empty-context {
-  min-height: 220px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px dashed var(--rule-inner);
-  background: color-mix(in srgb, var(--panel-2) 86%, transparent);
-  color: var(--text-dim);
-  font-family: var(--gsv-font-mono);
-  font-size: 10px;
-  letter-spacing: 0.16em;
-}
-
 .gsv-ae-overrides-heading {
   min-width: 0;
   margin: 0 0 16px;
@@ -134,18 +53,3 @@
   letter-spacing: 0.14em;
 }
 
-/* ===== delete modal ===== */
-.gsv-ae-modal-scrim {
-  position: fixed;
-  inset: 0;
-  z-index: 90;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(4, 3, 16, 0.66);
-}
-
-.gsv-ae-modal-wrap {
-  width: 440px;
-  max-width: 90vw;
-}

--- a/web/src/app/components/ui/AgentEditor.tsx
+++ b/web/src/app/components/ui/AgentEditor.tsx
@@ -1,4 +1,3 @@
-import { createPortal } from "preact/compat";
 import { useEffect, useRef, useState } from "preact/hooks";
 import "./AgentEditor.css";
 import { TextInput } from "./TextInput";
@@ -8,7 +7,7 @@ import { Button } from "./Button";
 import { Avatar, type AvatarStatus } from "./Avatar";
 import { Tabs } from "./Tabs";
 import { SectionHeader } from "./SectionHeader";
-import { ConfirmModal } from "./ConfirmModal";
+import { ContextSectionsEditor } from "./ContextSectionsEditor";
 import { approvalTargetFromValue } from "../../domain/agentApproval";
 import {
   AgentToolsPanel,
@@ -117,7 +116,7 @@ const MODELS: AgentEditorModelOption[] = [
 const FALLBACK_MODELS: AgentEditorModelOption[] = [
   { label: "INHERIT FALLBACK", value: "" },
 ];
-const REASONING_VALUES = ["", "off", "minimal", "low", "medium", "high", "xhigh"];
+export const REASONING_VALUES = ["", "off", "minimal", "low", "medium", "high", "xhigh"];
 const DEFAULT_APPROVAL_POLICY: AgentToolApprovalPolicy = {
   default: "auto",
   rules: [
@@ -127,9 +126,9 @@ const DEFAULT_APPROVAL_POLICY: AgentToolApprovalPolicy = {
     { match: "sys.mcp.call", action: "ask" },
   ],
 };
-const MODEL_SETTING_INFO = "Which AI this agent uses to respond. Inherit uses the default model.";
-const FALLBACK_SETTING_INFO = "Backup AI to try if the main one fails. Inherit uses the default backup, if one is set.";
-const REASONING_SETTING_INFO = "How much the AI thinks before replying. Higher can help with hard tasks, but may be slower.";
+export const MODEL_SETTING_INFO = "Which AI this agent uses to respond. Inherit uses the default model.";
+export const FALLBACK_SETTING_INFO = "Backup AI to try if the main one fails. Inherit uses the default backup, if one is set.";
+export const REASONING_SETTING_INFO = "How much the AI thinks before replying. Higher can help with hard tasks, but may be slower.";
 
 function optionValue(option: AgentEditorModelOption): string {
   return typeof option === "string" ? option : option.value ?? option.label;
@@ -145,7 +144,7 @@ function modelIndexForValue(value: string | undefined, options: readonly AgentEd
   return index >= 0 ? index : 0;
 }
 
-function reasoningIndexForValue(value: string | undefined): number {
+export function reasoningIndexForValue(value: string | undefined): number {
   const trimmed = value?.trim().toLowerCase() ?? "";
   if (!trimmed || trimmed === "inherit") {
     return 0;
@@ -160,7 +159,7 @@ function reasoningOptionLabel(value: string): string {
   return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
 }
 
-function reasoningOptions(inherited: string | undefined): SelectOption[] {
+export function reasoningOptions(inherited: string | undefined): SelectOption[] {
   const inheritedLabel = inherited?.trim();
   return REASONING_VALUES.map((value) => value
     ? { label: reasoningOptionLabel(value), value }
@@ -305,81 +304,6 @@ function defaults(mode: AgentEditorMode, props: AgentEditorProps): Defaults {
   };
 }
 
-function fileLabel(file: AgentEditorFile, index: number): string {
-  return file.label.trim() || file.name?.trim() || `SECTION ${index + 1}`;
-}
-
-function fileName(file: AgentEditorFile, index: number): string {
-  const explicit = file.name?.trim();
-  if (explicit) {
-    return explicit;
-  }
-  const label = file.label.trim();
-  if (label.toUpperCase() === "PERSONA") {
-    return "05-persona.md";
-  }
-  const base = label.toLowerCase().replace(/\.md$/i, "").replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
-  return `${base || `file-${index + 1}`}.md`;
-}
-
-function sectionSlug(label: string, index: number): string {
-  const slug = label
-    .trim()
-    .replace(/\.md$/i, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return slug || `section-${index + 1}`;
-}
-
-function contextOrderPrefix(file: AgentEditorFile, index: number): string {
-  const existing = (file.name ?? file.origName ?? "").match(/^(\d+)-/);
-  if (existing) {
-    return `${existing[1]}-`;
-  }
-  if (fileLabel(file, index).toUpperCase() === "PERSONA") {
-    return "05-";
-  }
-  return `${String((index + 1) * 10).padStart(2, "0")}-`;
-}
-
-function contextFileNameForSection(
-  label: string,
-  index: number,
-  file: AgentEditorFile,
-  files: readonly AgentEditorFile[],
-): string {
-  const prefix = contextOrderPrefix(file, index);
-  const baseName = `${prefix}${sectionSlug(label, index)}.md`;
-  const used = new Set(
-    files
-      .filter((candidate) => candidate !== file)
-      .map((candidate, candidateIndex) => fileName(candidate, candidateIndex).toLowerCase()),
-  );
-  if (!used.has(baseName.toLowerCase())) {
-    return baseName;
-  }
-  let suffix = 2;
-  while (used.has(`${prefix}${sectionSlug(label, index)}-${suffix}.md`.toLowerCase())) {
-    suffix += 1;
-  }
-  return `${prefix}${sectionSlug(label, index)}-${suffix}.md`;
-}
-
-function nextUntitledSection(files: readonly AgentEditorFile[]): { label: string; name: string } {
-  const names = new Set(files.map((file, index) => fileName(file, index).toLowerCase()));
-  let index = 1;
-  while (true) {
-    const label = index === 1 ? "Untitled" : `Untitled ${index}`;
-    const file: AgentEditorFile = { label, content: "" };
-    const name = contextFileNameForSection(label, files.length, file, files);
-    if (!names.has(name.toLowerCase())) {
-      return { label, name };
-    }
-    index += 1;
-  }
-}
-
 /** AgentEditor — composite ported from Agent Editor.dc.html. A full agent
  *  authoring surface with GENERAL / CONTEXT / TASKS folder tabs. GENERAL composes
  *  TextInput/TextArea/Select/Segmented/Button atoms; CONTEXT has a markdown
@@ -415,7 +339,6 @@ export function AgentEditor(props: AgentEditorProps) {
   const [flash, setFlash] = useState("");
   const [formError, setFormError] = useState("");
   const [pendingAction, setPendingAction] = useState<"create" | "save" | null>(null);
-  const [deleteOpen, setDeleteOpen] = useState(false);
   const [w, setW] = useState(0);
   const [formNonce, setFormNonce] = useState(0);
 
@@ -470,11 +393,6 @@ export function AgentEditor(props: AgentEditorProps) {
 
   // ---- files ----
   const hasContextSections = files.length > 0;
-  const curFile = files[fileIdx] || files[0] || { label: "", content: "" };
-
-  const setFileContent = (v: string) => {
-    setFiles((s) => s.map((f, i) => (i === fileIdx ? { ...f, content: v } : f)));
-  };
 
   // ---- unsaved-changes guard ----
   // Baseline is the initial values captured once in metaRef (see line ~172).
@@ -516,30 +434,8 @@ export function AgentEditor(props: AgentEditorProps) {
   const createReady = name.trim().length > 0 && !duplicateName;
 
   // ---- handlers ----
-  const onContent = (e: Event) => {
-    if (!filesReadOnly) {
-      setFileContent((e.target as HTMLTextAreaElement).value);
-    }
-  };
-  const onAddFile = () => {
-    if (filesReadOnly) return;
-    const next = nextUntitledSection(files);
-    setFiles((s) => [...s, { label: next.label, name: next.name, content: "# Untitled\n\n" }]);
-    setFileIdx(files.length);
-    setFlash("");
-    setFormError("");
-  };
-  const setCurrentSectionName = (value: string) => {
-    if (filesReadOnly) return;
-    setFiles((s) => s.map((f, i) => (
-      i === fileIdx
-        ? {
-            ...f,
-            label: value,
-            name: contextFileNameForSection(value, i, f, s),
-          }
-        : f
-    )));
+  const onFilesChange = (next: AgentEditorFile[]) => {
+    setFiles(next);
     setFlash("");
     setFormError("");
   };
@@ -608,23 +504,6 @@ export function AgentEditor(props: AgentEditorProps) {
     setFormNonce((n) => n + 1);
     setFormError("");
     setFlash("");
-  };
-
-  const delName = hasContextSections ? fileLabel(curFile, fileIdx) : "context section";
-  const onDelete = () => {
-    if (!filesReadOnly && hasContextSections) setDeleteOpen(true);
-  };
-  const onCancelDelete = () => setDeleteOpen(false);
-  const onConfirmDelete = () => {
-    if (filesReadOnly) return;
-    setFiles((s) => {
-      const next = s.filter((_, i) => i !== fileIdx);
-      setFileIdx((idx) => Math.max(0, Math.min(idx, next.length - 1)));
-      return next;
-    });
-    setDeleteOpen(false);
-    setFlash("");
-    setFormError("");
   };
 
   // ---- styles ----
@@ -855,86 +734,32 @@ export function AgentEditor(props: AgentEditorProps) {
                   </div>
                 </div>
 
-                {/* context section tabs */}
-                <div style="display:flex;align-items:flex-start;gap:30px;flex-wrap:wrap;padding-bottom:24px;border-bottom:1px solid var(--rule-inner);margin-bottom:22px;">
-                  {files.map((f, i) => (
-                    <button
-                      key={`${f.origName ?? f.name ?? f.label}-${i}`}
-                      type="button"
-                      class="gsv-ae-file-tab"
-                      onClick={() => {
-                        setFileIdx(i);
-                        setFlash("");
-                        setFormError("");
-                      }}
-                    >
-                      <svg width="34" height="30" viewBox="0 0 16 14" shape-rendering="crispEdges" fill={i === fileIdx ? "var(--accent-bright)" : "#4a4585"}>
-                        <rect x="1" y="2" width="6" height="2" />
-                        <rect x="1" y="4" width="14" height="9" />
-                      </svg>
-                      <span class="gsv-sublabel" style={`letter-spacing:.1em;color:${i === fileIdx ? "var(--text)" : "#9a95cf"};line-height:1.35;`}>
-                        {fileLabel(f, i)}
-                      </span>
-                    </button>
-                  ))}
-                  <button
-                    type="button"
-                    disabled={filesReadOnly}
-                    onClick={filesReadOnly ? undefined : onAddFile}
-                    class={`gsv-ae-file-tab gsv-ae-newfile${filesReadOnly ? " is-disabled" : ""}`}
-                  >
-                    <svg width="34" height="30" viewBox="0 0 16 14" shape-rendering="crispEdges" fill="none" stroke="var(--dashed)" stroke-width="1">
-                      <path d="M1.5 3.5 H6.5 V4.5" />
-                      <rect x="1.5" y="4.5" width="13" height="8" />
-                    </svg>
-                    <span class="gsv-sublabel" style="letter-spacing:.1em;color:var(--accent);border-bottom:1px solid var(--accent);padding-bottom:1px;">NEW SECTION</span>
-                  </button>
-                </div>
-
-                {hasContextSections ? (
-                  <>
-                    <div style="max-width:520px;margin-bottom:16px;">
-                      <TextInput
-                        value={fileLabel(curFile, fileIdx)}
-                        onChange={setCurrentSectionName}
-                        placeholder="Operating notes"
-                        size="medium"
-                        label="SECTION NAME"
-                        readonly={filesReadOnly}
-                      />
-                    </div>
-
-                    {/* editor */}
-                    <textarea
-                      class="gsv-ed gsv-ae-editor"
-                      value={curFile.content}
-                      onInput={onContent}
-                      spellcheck={false}
-                      readOnly={filesReadOnly}
-                    />
-                  </>
-                ) : (
-                  <div class="gsv-ae-empty-context">
-                    <strong>NO CONTEXT SECTIONS</strong>
-                  </div>
-                )}
-
-                {/* actions */}
-                <div style="display:flex;align-items:center;gap:12px;margin-top:16px;">
-                  <Button variant="dangerGhost" label="DELETE" onClick={onDelete} disabled={filesReadOnly || !hasContextSections} />
-                  <span style="flex:1;" />
-                  {filesReadOnly ? (
-                    <span class="gsv-ae-readonly-note gsv-sublabel">READ ONLY</span>
-                  ) : formError ? (
-                    <span class="gsv-sublabel" style="letter-spacing:.12em;color:var(--error);">{formError}</span>
-                  ) : pendingAction === "save" ? (
-                    <span class="gsv-sublabel" style="letter-spacing:.14em;color:var(--accent);">SAVING</span>
-                  ) : flash ? (
-                    <span class="gsv-sublabel" style="letter-spacing:.14em;color:var(--online);">{flash}</span>
-                  ) : null}
-                  <Button variant="secondary" label="RESET" onClick={onReset} disabled={filesReadOnly || !hasContextSections || pendingAction !== null} />
-                  <Button variant="primary" label="SAVE" onClick={onSave} disabled={filesReadOnly || pendingAction !== null} />
-                </div>
+                <ContextSectionsEditor
+                  files={files}
+                  onChange={onFilesChange}
+                  activeIndex={fileIdx}
+                  onActiveIndexChange={(index) => {
+                    setFileIdx(index);
+                    setFlash("");
+                    setFormError("");
+                  }}
+                  readOnly={filesReadOnly}
+                  actions={
+                    <>
+                      {filesReadOnly ? (
+                        <span class="gsv-ae-readonly-note gsv-sublabel">READ ONLY</span>
+                      ) : formError ? (
+                        <span class="gsv-sublabel" style="letter-spacing:.12em;color:var(--error);">{formError}</span>
+                      ) : pendingAction === "save" ? (
+                        <span class="gsv-sublabel" style="letter-spacing:.14em;color:var(--accent);">SAVING</span>
+                      ) : flash ? (
+                        <span class="gsv-sublabel" style="letter-spacing:.14em;color:var(--online);">{flash}</span>
+                      ) : null}
+                      <Button variant="secondary" label="RESET" onClick={onReset} disabled={filesReadOnly || !hasContextSections || pendingAction !== null} />
+                      <Button variant="primary" label="SAVE" onClick={onSave} disabled={filesReadOnly || pendingAction !== null} />
+                    </>
+                  }
+                />
               </div>
             ) : null}
 
@@ -954,23 +779,6 @@ export function AgentEditor(props: AgentEditorProps) {
                   ))}
                 </div>
               </div>
-            ) : null}
-
-            {/* DELETE CONFIRM MODAL — portaled to <body> so the editor's panel
-                container (container-type) doesn't trap its viewport-fixed scrim. */}
-            {deleteOpen ? createPortal(
-              <div class="gsv-ae-modal-scrim" onClick={onCancelDelete}>
-                <div class="gsv-ae-modal-wrap" onClick={(event) => event.stopPropagation()}>
-                  <ConfirmModal
-                    title="CONFIRM DELETE"
-                    message={`Are you sure you want to delete "${delName}"?`}
-                    note="This file is removed from the agent -- it can't be recovered."
-                    onCancel={onCancelDelete}
-                    onConfirm={onConfirmDelete}
-                  />
-                </div>
-              </div>,
-              document.body,
             ) : null}
           </div>
         </div>

--- a/web/src/app/components/ui/AgentToolsPanel.css
+++ b/web/src/app/components/ui/AgentToolsPanel.css
@@ -1,145 +1,147 @@
 .gsv-tools-panel {
-  display: grid;
-  gap: 14px;
+  display: flex;
+  flex-direction: column;
   min-width: 0;
   max-width: 640px;
 }
 
-.gsv-tools-bar {
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+/* Section heading — yellow step-title + full-width description. The description
+   holds the gap down to the first field (matches the create-agent form: title,
+   desc, then the field groups). */
+.gsv-tools-heading {
+  margin-bottom: 28px;
 }
 
+/* Same desktop-yellow step-title treatment as the surface's top title. */
 .gsv-tools-title {
+  margin: 0;
+  color: var(--update);
+  text-shadow: 0 0 9px rgba(255, 210, 77, 0.3);
+}
+
+.gsv-tools-desc {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+}
+
+/* Field group — a field label above its control, 30px between groups to match
+   the MODEL/FALLBACK/REASONING rhythm of the create-agent form above. */
+.gsv-tools-field {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   min-width: 0;
+}
+
+.gsv-tools-field + .gsv-tools-field {
+  margin-top: 30px;
+}
+
+/* Field label row — the same treatment as the Select/Segmented field label
+   (.gsv-fld-lab): 12px sublabel text, 8px down to the control. */
+.gsv-tools-field-lab {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
+  gap: 8px;
+  margin-bottom: 8px;
+  min-height: 13px;
 }
 
-.gsv-tools-title > span:first-child {
-  color: var(--label);
-  font-size: 9.5px;
-  letter-spacing: 0.2em;
-}
-
-.gsv-tools-title .gsv-infotip {
+.gsv-tools-field-lab .gsv-infotip {
   margin-inline-start: 0;
 }
 
-.gsv-tools-bar-actions {
-  min-width: 0;
-  display: flex;
-  justify-content: flex-end;
+/* OVERRIDES label row: the label group on the left, the ADD OVERRIDE link on the
+   right (space-between). On a narrow/mobile panel the link wraps to its own line
+   and, as a lone item, falls to flex-start — left-aligned. */
+.gsv-tools-overrides-lab {
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px 12px;
+  justify-content: space-between;
 }
 
-.gsv-tools-bar-actions .gsv-btn {
-  min-height: 30px;
-  padding: 8px 12px;
-  font-size: 9px;
-}
-
-.gsv-tools-overrides {
+.gsv-tools-overrides-name {
   min-width: 0;
-  display: grid;
-  border-top: 1px solid var(--rule-inner);
-  border-bottom: 1px solid var(--rule-inner);
-}
-
-.gsv-tools-overrides-head,
-.gsv-tools-rule {
-  min-width: 0;
-  display: grid;
-  grid-template-columns: minmax(180px, 1fr) minmax(150px, 190px) minmax(150px, 190px) auto;
-  align-items: center;
-  gap: 12px;
-}
-
-.gsv-tools-overrides-head {
-  padding: 8px 0;
-  border-bottom: 1px solid var(--rule-inner);
-  color: var(--label);
-  font-family: var(--gsv-font-mono);
-  font-size: 9px;
-  letter-spacing: 0.18em;
-}
-
-.gsv-tools-column-head {
-  display: inline-flex;
-  align-items: center;
-  min-width: 0;
-  gap: 6px;
-}
-
-.gsv-tools-column-head .gsv-infotip {
-  letter-spacing: 0;
-}
-
-.gsv-tools-rule-list {
-  display: grid;
-  min-width: 0;
-}
-
-.gsv-tools-rule {
-  padding: 10px 0;
-  border-bottom: 1px solid color-mix(in srgb, var(--rule-inner) 72%, transparent);
-}
-
-.gsv-tools-rule:last-child {
-  border-bottom: 0;
-}
-
-.gsv-tools-rule-tool,
-.gsv-tools-rule-target,
-.gsv-tools-rule-action,
-.gsv-tools-rule-delete {
-  min-width: 0;
-}
-
-.gsv-tools-rule-action {
-  min-width: 0;
-}
-
-.gsv-tools-rule-delete {
   display: flex;
-  justify-content: flex-end;
-  justify-self: end;
+  align-items: center;
+  gap: 8px;
 }
 
-.gsv-tools-rule-delete .gsv-ibtn,
-.gsv-tools-rule-delete .gsv-ibtn-disabled {
-  justify-self: end;
+/* Rule list — stored overrides as read-only summary rows (pencil to unlock),
+   the editing/new rule as a stacked labeled-select card. */
+.gsv-tools-rules {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-@container panel (max-width: 700px) {
-  .gsv-tools-bar,
-  .gsv-tools-overrides-head,
-  .gsv-tools-rule {
-    grid-template-columns: minmax(0, 1fr);
-  }
+.gsv-tools-rule-item {
+  min-width: 0;
+  border: 1px solid var(--rule-inner);
+  background: var(--panel-2);
+  padding: 10px 12px;
+}
 
-  .gsv-tools-bar {
-    align-items: stretch;
-    flex-direction: column;
-  }
+.gsv-tools-rule-item.is-editing {
+  border-color: var(--border-raised);
+}
 
-  .gsv-tools-bar-actions,
-  .gsv-tools-bar-actions .gsv-btn,
-  .gsv-tools-rule-delete {
-    width: 100%;
-  }
+.gsv-tools-rule-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 
-  .gsv-tools-overrides-head {
-    display: none;
-  }
+.gsv-tools-rule-text {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
 
-  .gsv-tools-rule-delete {
-    justify-self: end;
-  }
+.gsv-tools-rule-text .gsv-listitem {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gsv-tools-rule-text .gsv-sublabel {
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gsv-tools-rule-buttons {
+  display: flex;
+  gap: 8px;
+  flex: none;
+}
+
+.gsv-tools-rule-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.gsv-tools-rule-edit-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+}
+
+.gsv-tools-rule-edit-head > :last-child {
+  margin-left: auto;
+}
+
+.gsv-tools-empty {
+  margin: 0;
+  color: var(--text-muted);
 }

--- a/web/src/app/components/ui/AgentToolsPanel.tsx
+++ b/web/src/app/components/ui/AgentToolsPanel.tsx
@@ -94,13 +94,13 @@ export function AgentToolsPanel({
     onChange(next);
   };
 
-  const hasNewRow = newIndex !== null;
-
   const addRule = () => {
-    if (hasNewRow) {
-      return;
-    }
-    setEditingIndexes((current) => new Set([0, ...[...current].map((index) => index + 1)]));
+    // Open one fresh editable override pinned on top (top tie-priority). Any row
+    // currently open (a prior new row, or a pencil-edited one) collapses to a
+    // read-only summary — its values are already applied to the policy — so
+    // several overrides can be staged in a single draft without a save between
+    // each. Keeps exactly one row expanded at a time.
+    setEditingIndexes(new Set());
     setNewIndex(0);
     emit({
       ...policy,
@@ -166,7 +166,7 @@ export function AgentToolsPanel({
           <Button
             variant="link"
             label="ADD OVERRIDE"
-            disabled={disabled || hasNewRow}
+            disabled={disabled}
             onClick={addRule}
           />
         </div>

--- a/web/src/app/components/ui/AgentToolsPanel.tsx
+++ b/web/src/app/components/ui/AgentToolsPanel.tsx
@@ -1,30 +1,36 @@
+import { useEffect, useRef, useState } from "preact/hooks";
 import { Button } from "./Button";
 import { IconButton } from "./IconButton";
 import { InfoTip } from "./InfoTip";
 import { Segmented } from "./Segmented";
-import { Select, type SelectOption } from "./Select";
+import { Select } from "./Select";
 import { Tag } from "./Tag";
+import {
+  APPROVAL_ACTIONS,
+  actionIndex,
+  actionLabel,
+  approvalOptionValue,
+  defaultOverrideAction,
+  humanToolCapabilityLabel,
+  matchIndexForRule,
+  matchOptionsForRule,
+  targetIndexForRule,
+  targetLabelForRule,
+  targetOptionsForRule,
+  type AgentToolApprovalAction,
+  type AgentToolApprovalPolicy,
+  type AgentToolApprovalRule,
+  type AgentToolTarget,
+} from "./agentToolApprovalOptions";
 import "./AgentToolsPanel.css";
 
-export type AgentToolApprovalAction = "auto" | "ask" | "deny";
-
-export type AgentToolApprovalRule = {
-  match: string;
-  target?: string;
-  action: AgentToolApprovalAction;
-};
-
-export type AgentToolApprovalPolicy = {
-  default: AgentToolApprovalAction;
-  rules: AgentToolApprovalRule[];
-};
-
-export type AgentToolTarget = {
-  id: string;
-  label?: string;
-  online?: boolean;
-  implements?: readonly string[];
-};
+export type {
+  AgentToolApprovalAction,
+  AgentToolApprovalPolicy,
+  AgentToolApprovalRule,
+  AgentToolTarget,
+} from "./agentToolApprovalOptions";
+export { humanToolCapabilityLabel } from "./agentToolApprovalOptions";
 
 export interface AgentToolsPanelProps {
   policy: AgentToolApprovalPolicy;
@@ -32,377 +38,245 @@ export interface AgentToolsPanelProps {
   capabilities?: readonly string[];
   targets?: readonly AgentToolTarget[];
   disabled?: boolean;
+  /** Copy under the DEFAULT PERMISSIONS title. Defaults to single-agent wording;
+   *  crew defaults / system overrides pass the "all your agents" framing. */
+  defaultDescription?: string;
   onChange: (policy: AgentToolApprovalPolicy) => void;
 }
 
-type CapabilityFamily = {
-  label: string;
-  options: ApprovalMatchOption[];
-};
+const DEFAULT_PERMISSION_DESC = "Used when no approval override matches.";
 
-type ApprovalMatchOption = {
-  match: string;
-  label: string;
-  description?: string;
-};
-
-const APPROVAL_ACTIONS: AgentToolApprovalAction[] = ["auto", "ask", "deny"];
 const TOOL_APPROVAL_INFO = "Tools let agents take actions like reading files or running commands. Approvals decide what can happen automatically, what asks first, and what is blocked.";
-const CAPABILITY_FAMILIES: CapabilityFamily[] = [
-  {
-    label: "Filesystem",
-    options: [
-      { match: "fs.*", label: "All file tools", description: "Read, write, edit, search, copy, and delete files." },
-      { match: "fs.read", label: "Read files" },
-      { match: "fs.write", label: "Write files" },
-      { match: "fs.edit", label: "Edit files" },
-      { match: "fs.search", label: "Search files" },
-      { match: "fs.copy", label: "Copy files" },
-      { match: "fs.delete", label: "Delete files" },
-    ],
-  },
-  {
-    label: "Shell",
-    options: [
-      { match: "shell.*", label: "All shell tools", description: "Every shell operation." },
-      { match: "shell.exec", label: "Run shell commands" },
-    ],
-  },
-  {
-    label: "Network",
-    options: [
-      { match: "net.*", label: "All network tools", description: "Every network operation." },
-      { match: "net.fetch", label: "Fetch URLs" },
-    ],
-  },
-  {
-    label: "Repositories",
-    options: [
-      { match: "repo.*", label: "All repository tools", description: "Every ripgit repository operation." },
-      { match: "repo.list", label: "List repositories" },
-      { match: "repo.read", label: "Read repository content" },
-      { match: "repo.search", label: "Search repositories" },
-      { match: "repo.compare", label: "Compare refs" },
-      { match: "repo.diff", label: "Read diffs" },
-      { match: "repo.apply", label: "Apply repository changes" },
-      { match: "repo.import", label: "Pull upstream" },
-      { match: "repo.delete", label: "Delete repositories" },
-      { match: "repo.visibility.set", label: "Change repository visibility" },
-    ],
-  },
-  {
-    label: "Processes",
-    options: [
-      { match: "proc.*", label: "All process tools", description: "Every process and conversation operation." },
-      { match: "proc.spawn", label: "Start processes" },
-      { match: "proc.send", label: "Send process messages" },
-      { match: "proc.history", label: "Read process history" },
-      { match: "proc.abort", label: "Abort runs" },
-      { match: "proc.reset", label: "Reset processes" },
-      { match: "proc.kill", label: "Kill processes" },
-    ],
-  },
-  {
-    label: "MCP",
-    options: [
-      { match: "sys.mcp.*", label: "All MCP tools", description: "Every MCP server operation." },
-      { match: "sys.mcp.call", label: "Call MCP tools" },
-      { match: "sys.mcp.list", label: "List MCP servers" },
-      { match: "sys.mcp.add", label: "Add MCP servers" },
-      { match: "sys.mcp.refresh", label: "Refresh MCP servers" },
-      { match: "sys.mcp.remove", label: "Remove MCP servers" },
-    ],
-  },
-  {
-    label: "System Config",
-    options: [
-      { match: "sys.config.*", label: "All system config tools", description: "Read and write gateway config." },
-      { match: "sys.config.get", label: "Read system config" },
-      { match: "sys.config.set", label: "Write system config" },
-    ],
-  },
-];
-const APPROVAL_MATCH_OPTIONS: SelectOption[] = CAPABILITY_FAMILIES.flatMap((family) =>
-  family.options.map((option) => ({
-    group: family.label,
-    label: option.label,
-    value: option.match,
-    description: option.description ?? "",
-  })),
-);
-const APPROVAL_MATCH_VALUES = CAPABILITY_FAMILIES.flatMap((family) => family.options.map((option) => option.match));
-const APPROVAL_MATCH_LABELS = new Map(
-  CAPABILITY_FAMILIES.flatMap((family) =>
-    family.options.map((option) => [option.match, option.label] as const)
-  ),
-);
-const BUILTIN_TARGET_OPTIONS: SelectOption[] = [
-  {
-    label: "All machines",
-    value: "",
-  },
-  {
-    label: "GSV computer",
-    value: "gsv",
-  },
-];
-const LEGACY_EXTERNAL_TARGET_OPTION: SelectOption = {
-  group: "Stored machine",
-  label: "All machines",
-  value: "targets/*",
-};
+const PRIORITY_INFO = "When several overrides match, the most machine-specific rule wins, then the most tool-specific. If still tied, rules higher in this list win.";
+const MACHINE_INFO = "Where this override applies: every machine, the GSV computer, or one named machine.";
+const ACTION_INFO = "What happens when the tool and machine match: allow it, ask for confirmation, or block it.";
 
-export function humanToolCapabilityLabel(capability: string): string {
-  const normalized = capability.trim();
-  if (!normalized) {
-    return "Capability";
-  }
-  const known = APPROVAL_MATCH_LABELS.get(normalized);
-  if (known) {
-    return known;
-  }
-  return normalized
-    .replace(/\.\*/g, "")
-    .split(/[._:-]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
+function ruleSignature(policy: AgentToolApprovalPolicy): string {
+  return JSON.stringify({ default: policy.default, rules: policy.rules });
 }
 
-function actionLabel(action: AgentToolApprovalAction): string {
-  if (action === "auto") return "Allow";
-  if (action === "deny") return "Block";
-  return "Ask";
-}
-
-function defaultOverrideAction(defaultAction: AgentToolApprovalAction): AgentToolApprovalAction {
-  if (defaultAction === "auto") return "ask";
-  if (defaultAction === "deny") return "ask";
-  return "deny";
-}
-
-function updateRule(
-  policy: AgentToolApprovalPolicy,
-  index: number,
-  patch: Partial<AgentToolApprovalRule>,
-): AgentToolApprovalPolicy {
-  return {
-    ...policy,
-    rules: policy.rules.map((rule, candidate) => candidate === index ? { ...rule, ...patch } : rule),
-  };
-}
-
-function removeRule(policy: AgentToolApprovalPolicy, index: number): AgentToolApprovalPolicy {
-  return {
-    ...policy,
-    rules: policy.rules.filter((_, candidate) => candidate !== index),
-  };
-}
-
-function addRule(policy: AgentToolApprovalPolicy): AgentToolApprovalPolicy {
-  return {
-    ...policy,
-    rules: [...policy.rules, { match: "fs.*", action: defaultOverrideAction(policy.default) }],
-  };
-}
-
-function matchOptionsForRule(match: string): SelectOption[] {
-  if (!match || APPROVAL_MATCH_VALUES.includes(match)) {
-    return APPROVAL_MATCH_OPTIONS;
-  }
-  return [
-    ...APPROVAL_MATCH_OPTIONS,
-    {
-      group: "Custom",
-      label: "Custom match",
-      value: match,
-      description: "Stored custom approval match.",
-    },
-  ];
-}
-
-function matchIndexForRule(match: string): number {
-  const options = matchOptionsForRule(match);
-  const index = options.findIndex((option) => typeof option !== "string" && option.value === match);
-  return index >= 0 ? index : 0;
-}
-
-function optionValue(option: SelectOption): string {
-  return typeof option === "string" ? option : option.value ?? option.label;
-}
-
-function targetOptionsForRule(target: string | undefined, targets: readonly AgentToolTarget[]): SelectOption[] {
-  const targetOptions = targets
-    .filter((candidate) => candidate.id.trim().length > 0)
-    .map((candidate) => {
-      const label = candidate.label?.trim() || candidate.id;
-      return {
-        group: "Machines",
-        label,
-        value: candidate.id,
-      };
-    });
-  const knownValues = new Set([
-    ...BUILTIN_TARGET_OPTIONS.map((option) => typeof option === "string" ? option : option.value ?? option.label),
-    ...targetOptions.map((option) => option.value ?? option.label),
-  ]);
-  const baseOptions = target === "targets/*"
-    ? [...BUILTIN_TARGET_OPTIONS, LEGACY_EXTERNAL_TARGET_OPTION, ...targetOptions]
-    : [...BUILTIN_TARGET_OPTIONS, ...targetOptions];
-  if (!target || knownValues.has(target) || target === "targets/*") {
-    return baseOptions;
-  }
-  return [
-    ...baseOptions,
-    {
-      group: "Stored machine",
-      label: target,
-      value: target,
-    },
-  ];
-}
-
-function targetIndexForRule(target: string | undefined, targets: readonly AgentToolTarget[]): number {
-  const options = targetOptionsForRule(target, targets);
-  const value = target ?? "";
-  const index = options.findIndex((option) => typeof option !== "string" && (option.value ?? option.label) === value);
-  return index >= 0 ? index : 0;
-}
-
-function updateRuleTarget(
-  policy: AgentToolApprovalPolicy,
-  index: number,
-  target: string,
-): AgentToolApprovalPolicy {
-  const patch: Partial<AgentToolApprovalRule> = target ? { target } : { target: undefined };
-  const next = updateRule(policy, index, patch);
-  return {
-    ...next,
-    rules: next.rules.map((rule, candidate) => candidate === index && !target
-      ? { match: rule.match, action: rule.action }
-      : rule),
-  };
-}
-
-function actionIndex(action: AgentToolApprovalAction): number {
-  return Math.max(0, APPROVAL_ACTIONS.indexOf(action));
-}
-
+/** AgentToolsPanel — controlled tool-approval editor shared by the agent
+ *  editor / create-agent form, the global settings page, and the CREW defaults
+ *  editor. Stored overrides render read-only until pencil-unlocked; ADD
+ *  OVERRIDE pins one new editable rule on top (top tie-break priority — the
+ *  gateway resolves ties first-in-list) and is guarded so only one unsaved new
+ *  rule can exist at a time. Editing/new flags are internal UI state; they
+ *  reset whenever the incoming policy changes from outside (host reset,
+ *  remount baseline, post-save refresh). */
 export function AgentToolsPanel({
   policy,
   sourceLabel,
   targets = [],
   disabled = false,
+  defaultDescription = DEFAULT_PERMISSION_DESC,
   onChange,
 }: AgentToolsPanelProps) {
   const normalizedSource = sourceLabel?.trim();
+  const [editingIndexes, setEditingIndexes] = useState<ReadonlySet<number>>(new Set());
+  const [newIndex, setNewIndex] = useState<number | null>(null);
+  // Signature of the last policy WE emitted — an incoming policy that doesn't
+  // match it is an external change (reset/baseline), so the row UI state resets.
+  const emittedRef = useRef<string | null>(null);
+  const signature = ruleSignature(policy);
+
+  useEffect(() => {
+    if (emittedRef.current === signature) {
+      emittedRef.current = null;
+      return;
+    }
+    emittedRef.current = null;
+    setEditingIndexes(new Set());
+    setNewIndex(null);
+  }, [signature]);
+
+  const emit = (next: AgentToolApprovalPolicy) => {
+    emittedRef.current = ruleSignature(next);
+    onChange(next);
+  };
+
+  const hasNewRow = newIndex !== null;
+
+  const addRule = () => {
+    if (hasNewRow) {
+      return;
+    }
+    setEditingIndexes((current) => new Set([0, ...[...current].map((index) => index + 1)]));
+    setNewIndex(0);
+    emit({
+      ...policy,
+      rules: [{ match: "fs.*", action: defaultOverrideAction(policy.default) }, ...policy.rules],
+    });
+  };
+
+  const removeRule = (index: number) => {
+    setEditingIndexes((current) => new Set(
+      [...current].filter((candidate) => candidate !== index).map((candidate) => candidate > index ? candidate - 1 : candidate),
+    ));
+    setNewIndex((current) => current === null || current === index
+      ? null
+      : current > index ? current - 1 : current);
+    emit({
+      ...policy,
+      rules: policy.rules.filter((_, candidate) => candidate !== index),
+    });
+  };
+
+  const startEditing = (index: number) => {
+    setEditingIndexes((current) => new Set([...current, index]));
+  };
+
+  const updateRule = (index: number, next: AgentToolApprovalRule) => {
+    emit({
+      ...policy,
+      rules: policy.rules.map((rule, candidate) => candidate === index ? next : rule),
+    });
+  };
 
   return (
     <section class="gsv-tools-panel" aria-label="Agent tools">
-      <div class="gsv-tools-bar">
-        <div class="gsv-tools-title">
-          <span>TOOL APPROVAL</span>
+      <div class="gsv-tools-heading">
+        <h4 class="gsv-tools-title gsv-section">DEFAULT PERMISSIONS</h4>
+        <p class="gsv-tools-desc gsv-paragraph-small">{defaultDescription}</p>
+      </div>
+
+      <div class="gsv-tools-field">
+        <div class="gsv-tools-field-lab">
+          <span class="gsv-fld-lab-t gsv-sublabel">TOOL APPROVAL</span>
           <InfoTip text={TOOL_APPROVAL_INFO} position="right" label="Tool approval info" />
           {normalizedSource ? <Tag tone="info" label={normalizedSource.toUpperCase()} boxed /> : null}
         </div>
-        <div class="gsv-tools-bar-actions">
-          <Button
-            variant="secondary"
-            label="ADD OVERRIDE"
-            disabled={disabled}
-            onClick={() => onChange(addRule(policy))}
-          />
-        </div>
+        <Segmented
+          l0="ALLOW"
+          l1="ASK"
+          l2="BLOCK"
+          value={actionIndex(policy.default)}
+          onChange={disabled ? undefined : (index) => emit({ ...policy, default: APPROVAL_ACTIONS[index] ?? "ask" })}
+          width={300}
+          ariaLabel="Tool approval default"
+          disabled={disabled}
+        />
       </div>
 
-      <Segmented
-        l0="ALLOW"
-        l1="ASK"
-        l2="BLOCK"
-        value={actionIndex(policy.default)}
-        onChange={disabled ? undefined : (index) => onChange({ ...policy, default: APPROVAL_ACTIONS[index] ?? "ask" })}
-        width={300}
-        label="DEFAULT"
-        description="Used when no approval override matches."
-        disabled={disabled}
-      />
+      <div class="gsv-tools-field">
+        <div class="gsv-tools-field-lab gsv-tools-overrides-lab">
+          <span class="gsv-tools-overrides-name">
+            <span class="gsv-fld-lab-t gsv-sublabel">OVERRIDES</span>
+            <InfoTip text={PRIORITY_INFO} position="right" label="Override priority" />
+          </span>
+          <Button
+            variant="link"
+            label="ADD OVERRIDE"
+            disabled={disabled || hasNewRow}
+            onClick={addRule}
+          />
+        </div>
 
-      {policy.rules.length > 0 ? (
-        <div class="gsv-tools-overrides" role="table" aria-label="Tool approval overrides">
-          <div class="gsv-tools-overrides-head" role="row">
-            <span role="columnheader">TOOL</span>
-            <span class="gsv-tools-column-head" role="columnheader">
-              MACHINE
-              <InfoTip
-                text="Where this override applies: every machine, the GSV computer, or one named machine."
-                position="top"
-                label="Machine scope"
-              />
-            </span>
-            <span class="gsv-tools-column-head" role="columnheader">
-              ACTION
-              <InfoTip
-                text="What happens when the tool and machine match: allow it, ask for confirmation, or block it."
-                position="top"
-                label="Approval action"
-              />
-            </span>
-            <span role="columnheader" aria-label="Actions" />
-          </div>
-          <div class="gsv-tools-rule-list" role="rowgroup">
-            {policy.rules.map((rule, index) => {
-              const matchOptions = matchOptionsForRule(rule.match);
-              const targetOptions = targetOptionsForRule(rule.target, targets);
+        {policy.rules.length > 0 ? (
+        <ul class="gsv-tools-rules" aria-label="Tool approval overrides">
+          {policy.rules.map((rule, index) => {
+            const toolLabel = humanToolCapabilityLabel(rule.match);
+            const isNewRule = index === newIndex;
+            const isEditing = isNewRule || editingIndexes.has(index);
+            if (!isEditing) {
               return (
-                <div class="gsv-tools-rule" role="row" key={index}>
-                  <div class="gsv-tools-rule-tool" role="cell">
-                    <Select
-                      options={matchOptions}
-                      value={matchIndexForRule(rule.match)}
-                      width={280}
-                      size="small"
-                      disabled={disabled}
-                      onChange={(selected) => onChange(updateRule(policy, index, { match: optionValue(matchOptions[selected] ?? matchOptions[0] ?? "fs.*") }))}
-                    />
+                <li class="gsv-tools-rule-item" key={index}>
+                  <div class="gsv-tools-rule-summary">
+                    <div class="gsv-tools-rule-text">
+                      <span class="gsv-listitem">{toolLabel}</span>
+                      <span class="gsv-sublabel">
+                        {targetLabelForRule(rule.target, targets)} · {actionLabel(rule.action)}
+                      </span>
+                    </div>
+                    <div class="gsv-tools-rule-buttons">
+                      <IconButton
+                        glyph="edit"
+                        size="medium"
+                        ariaLabel={`Edit override: ${toolLabel}`}
+                        disabled={disabled}
+                        onClick={() => startEditing(index)}
+                      />
+                      <IconButton
+                        glyph="close"
+                        size="medium"
+                        ariaLabel={`Remove override: ${toolLabel}`}
+                        disabled={disabled}
+                        onClick={() => removeRule(index)}
+                      />
+                    </div>
                   </div>
-                  <div class="gsv-tools-rule-target" role="cell">
-                    <Select
-                      options={targetOptions}
-                      value={targetIndexForRule(rule.target, targets)}
-                      width={190}
-                      size="small"
-                      disabled={disabled}
-                      onChange={(selected) => onChange(updateRuleTarget(policy, index, optionValue(targetOptions[selected] ?? targetOptions[0] ?? "")))}
-                    />
-                  </div>
-                  <div class="gsv-tools-rule-action" role="cell">
-                    <Select
-                      options={APPROVAL_ACTIONS.map((action) => ({
-                        label: actionLabel(action),
-                        value: action,
-                      }))}
-                      value={actionIndex(rule.action)}
-                      width={170}
-                      size="small"
-                      disabled={disabled}
-                      onChange={(selected) => onChange(updateRule(policy, index, { action: APPROVAL_ACTIONS[selected] ?? "ask" }))}
-                    />
-                  </div>
-                  <div class="gsv-tools-rule-delete" role="cell">
+                </li>
+              );
+            }
+            const matchOptions = matchOptionsForRule(rule.match);
+            const targetOptions = targetOptionsForRule(rule.target, targets);
+            return (
+              <li class="gsv-tools-rule-item is-editing" key={index}>
+                <div class="gsv-tools-rule-edit">
+                  <div class="gsv-tools-rule-edit-head">
+                    <span class="gsv-sublabel">{isNewRule ? "NEW OVERRIDE" : "EDIT OVERRIDE"}</span>
+                    {isNewRule ? <InfoTip text={PRIORITY_INFO} position="right" label="Override priority" /> : null}
                     <IconButton
                       glyph="close"
                       size="small"
-                      title="Delete override"
+                      ariaLabel={`Remove override: ${toolLabel}`}
                       disabled={disabled}
-                      onClick={() => onChange(removeRule(policy, index))}
+                      onClick={() => removeRule(index)}
                     />
                   </div>
+                  <Select
+                    label="TOOL"
+                    options={matchOptions}
+                    value={matchIndexForRule(rule.match)}
+                    block
+                    size="small"
+                    disabled={disabled}
+                    onChange={(selected) => updateRule(index, {
+                      ...rule,
+                      match: approvalOptionValue(matchOptions[selected] ?? matchOptions[0] ?? "fs.*"),
+                    })}
+                  />
+                  <Select
+                    label="MACHINE"
+                    info={MACHINE_INFO}
+                    options={targetOptions}
+                    value={targetIndexForRule(rule.target, targets)}
+                    block
+                    size="small"
+                    disabled={disabled}
+                    onChange={(selected) => {
+                      const target = approvalOptionValue(targetOptions[selected] ?? targetOptions[0] ?? "");
+                      updateRule(index, target
+                        ? { ...rule, target }
+                        : { match: rule.match, action: rule.action });
+                    }}
+                  />
+                  <Select
+                    label="ACTION"
+                    info={ACTION_INFO}
+                    options={APPROVAL_ACTIONS.map((action: AgentToolApprovalAction) => ({
+                      label: actionLabel(action),
+                      value: action,
+                    }))}
+                    value={actionIndex(rule.action)}
+                    block
+                    size="small"
+                    disabled={disabled}
+                    onChange={(selected) => updateRule(index, {
+                      ...rule,
+                      action: APPROVAL_ACTIONS[selected] ?? "ask",
+                    })}
+                  />
                 </div>
-              );
-            })}
-          </div>
-        </div>
-      ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p class="gsv-tools-empty gsv-paragraph-small">
+          No overrides yet. Add one to set a specific rule for a tool or machine.
+        </p>
+        )}
+      </div>
     </section>
   );
 }

--- a/web/src/app/components/ui/AgentToolsPanel.tsx
+++ b/web/src/app/components/ui/AgentToolsPanel.tsx
@@ -41,6 +41,10 @@ export interface AgentToolsPanelProps {
   /** Copy under the DEFAULT PERMISSIONS title. Defaults to single-agent wording;
    *  crew defaults / system overrides pass the "all your agents" framing. */
   defaultDescription?: string;
+  /** Suppress the internal DEFAULT PERMISSIONS heading + description when the
+   *  host already supplies its own section title (e.g. the CREW permissions
+   *  surface). Defaults to false — the heading shows. */
+  hideHeading?: boolean;
   onChange: (policy: AgentToolApprovalPolicy) => void;
 }
 
@@ -69,6 +73,7 @@ export function AgentToolsPanel({
   targets = [],
   disabled = false,
   defaultDescription = DEFAULT_PERMISSION_DESC,
+  hideHeading = false,
   onChange,
 }: AgentToolsPanelProps) {
   const normalizedSource = sourceLabel?.trim();
@@ -134,10 +139,12 @@ export function AgentToolsPanel({
 
   return (
     <section class="gsv-tools-panel" aria-label="Agent tools">
-      <div class="gsv-tools-heading">
-        <h4 class="gsv-tools-title gsv-section">DEFAULT PERMISSIONS</h4>
-        <p class="gsv-tools-desc gsv-paragraph-small">{defaultDescription}</p>
-      </div>
+      {hideHeading ? null : (
+        <div class="gsv-tools-heading">
+          <h4 class="gsv-tools-title gsv-section">DEFAULT PERMISSIONS</h4>
+          <p class="gsv-tools-desc gsv-paragraph-small">{defaultDescription}</p>
+        </div>
+      )}
 
       <div class="gsv-tools-field">
         <div class="gsv-tools-field-lab">

--- a/web/src/app/components/ui/AgentToolsPanel.tsx
+++ b/web/src/app/components/ui/AgentToolsPanel.tsx
@@ -127,7 +127,11 @@ export function AgentToolsPanel({
   };
 
   const startEditing = (index: number) => {
-    setEditingIndexes((current) => new Set([...current, index]));
+    // One row expanded at a time (matching addRule): opening a saved override
+    // collapses any other pencil-edited row and the pinned new row to read-only
+    // summaries — their values are already applied to the policy.
+    setEditingIndexes(new Set([index]));
+    setNewIndex(null);
   };
 
   const updateRule = (index: number, next: AgentToolApprovalRule) => {

--- a/web/src/app/components/ui/ContextSectionsEditor.css
+++ b/web/src/app/components/ui/ContextSectionsEditor.css
@@ -1,0 +1,118 @@
+.gsv-cse {
+  min-width: 0;
+}
+
+/* section tabs row */
+.gsv-cse-tabs {
+  display: flex;
+  align-items: flex-start;
+  gap: 30px;
+  flex-wrap: wrap;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--rule-inner);
+  margin-bottom: 22px;
+}
+
+.gsv-cse-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+/* code editor scrollbar */
+.gsv-ed::-webkit-scrollbar {
+  width: 9px;
+}
+.gsv-ed::-webkit-scrollbar-thumb {
+  background: var(--border);
+}
+.gsv-ed::-webkit-scrollbar-track {
+  background: var(--panel-2);
+}
+
+/* ===== section (file) tab ===== */
+.gsv-cse-file-tab {
+  appearance: none;
+  width: 78px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: center;
+}
+
+.gsv-cse-file-tab:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.gsv-cse-newfile:hover {
+  opacity: 0.8;
+}
+.gsv-cse-newfile:disabled:hover {
+  opacity: 0.45;
+}
+.gsv-cse-newfile.is-disabled {
+  cursor: not-allowed !important;
+  opacity: 0.45;
+}
+
+/* ===== code editor textarea ===== */
+.gsv-cse-editor {
+  width: 100%;
+  height: 300px;
+  resize: vertical;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  outline: none;
+  padding: 16px 17px;
+  font-family: var(--gsv-font-mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  color: var(--text-title);
+}
+.gsv-cse-editor:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.gsv-cse-editor:read-only {
+  cursor: default;
+  color: var(--text-muted);
+}
+
+.gsv-cse-empty-context {
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--rule-inner);
+  background: color-mix(in srgb, var(--panel-2) 86%, transparent);
+  color: var(--text-dim);
+  font-family: var(--gsv-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+}
+
+/* ===== delete modal ===== */
+.gsv-cse-modal-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(4, 3, 16, 0.66);
+}
+
+.gsv-cse-modal-wrap {
+  width: 440px;
+  max-width: 90vw;
+}

--- a/web/src/app/components/ui/ContextSectionsEditor.css
+++ b/web/src/app/components/ui/ContextSectionsEditor.css
@@ -54,6 +54,21 @@
   outline-offset: 4px;
 }
 
+/* Keep long section names inside the fixed-width tab: wrap to at most two
+   centered lines, break over-long single words, and ellipsize the rest so
+   labels never overflow and collide with neighbouring tabs (full name in the
+   native title tooltip). */
+.gsv-cse-file-label {
+  width: 100%;
+  text-align: center;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .gsv-cse-newfile:hover {
   opacity: 0.8;
 }

--- a/web/src/app/components/ui/ContextSectionsEditor.tsx
+++ b/web/src/app/components/ui/ContextSectionsEditor.tsx
@@ -1,0 +1,240 @@
+import type { ComponentChildren } from "preact";
+import { createPortal } from "preact/compat";
+import { useState } from "preact/hooks";
+import { Button } from "./Button";
+import { ConfirmModal } from "./ConfirmModal";
+import { TextInput } from "./TextInput";
+import "./ContextSectionsEditor.css";
+
+/** One markdown context section (structurally identical to AgentEditorFile). */
+export interface ContextSection {
+  label: string;
+  name?: string;
+  origName?: string;
+  content: string;
+  orig?: string;
+}
+
+export interface ContextSectionsEditorProps {
+  files: readonly ContextSection[];
+  onChange: (files: ContextSection[]) => void;
+  /** Controlled active-section index (host owns it so per-section RESET works). */
+  activeIndex: number;
+  onActiveIndexChange: (index: number) => void;
+  readOnly?: boolean;
+  /** Right-aligned controls in the action row (e.g. host SAVE / RESET / status).
+   *  Rendered next to the section's own DELETE affordance. */
+  actions?: ComponentChildren;
+}
+
+export function fileLabel(file: ContextSection, index: number): string {
+  return file.label.trim() || file.name?.trim() || `SECTION ${index + 1}`;
+}
+
+function fileName(file: ContextSection, index: number): string {
+  const explicit = file.name?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const label = file.label.trim();
+  if (label.toUpperCase() === "PERSONA") {
+    return "05-persona.md";
+  }
+  const base = label.toLowerCase().replace(/\.md$/i, "").replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  return `${base || `file-${index + 1}`}.md`;
+}
+
+function sectionSlug(label: string, index: number): string {
+  const slug = label
+    .trim()
+    .replace(/\.md$/i, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || `section-${index + 1}`;
+}
+
+function contextOrderPrefix(file: ContextSection, index: number): string {
+  const existing = (file.name ?? file.origName ?? "").match(/^(\d+)-/);
+  if (existing) {
+    return `${existing[1]}-`;
+  }
+  if (fileLabel(file, index).toUpperCase() === "PERSONA") {
+    return "05-";
+  }
+  return `${String((index + 1) * 10).padStart(2, "0")}-`;
+}
+
+function contextFileNameForSection(
+  label: string,
+  index: number,
+  file: ContextSection,
+  files: readonly ContextSection[],
+): string {
+  const prefix = contextOrderPrefix(file, index);
+  const baseName = `${prefix}${sectionSlug(label, index)}.md`;
+  const used = new Set(
+    files
+      .filter((candidate) => candidate !== file)
+      .map((candidate, candidateIndex) => fileName(candidate, candidateIndex).toLowerCase()),
+  );
+  if (!used.has(baseName.toLowerCase())) {
+    return baseName;
+  }
+  let suffix = 2;
+  while (used.has(`${prefix}${sectionSlug(label, index)}-${suffix}.md`.toLowerCase())) {
+    suffix += 1;
+  }
+  return `${prefix}${sectionSlug(label, index)}-${suffix}.md`;
+}
+
+function nextUntitledSection(files: readonly ContextSection[]): { label: string; name: string } {
+  const names = new Set(files.map((file, index) => fileName(file, index).toLowerCase()));
+  let index = 1;
+  while (true) {
+    const label = index === 1 ? "Untitled" : `Untitled ${index}`;
+    const file: ContextSection = { label, content: "" };
+    const name = contextFileNameForSection(label, files.length, file, files);
+    if (!names.has(name.toLowerCase())) {
+      return { label, name };
+    }
+    index += 1;
+  }
+}
+
+/** ContextSectionsEditor — the markdown context-sections editing surface shared
+ *  by the AgentEditor CONTEXT tab and the CREW defaults editor: a row of file-tab
+ *  sections + NEW SECTION, the active section's name + content editor, a
+ *  per-section DELETE (with confirm), and an `actions` slot for the host's own
+ *  SAVE/RESET/status. Controlled via `files`/`onChange` and `activeIndex`. */
+export function ContextSectionsEditor({
+  files,
+  onChange,
+  activeIndex,
+  onActiveIndexChange,
+  readOnly = false,
+  actions,
+}: ContextSectionsEditorProps) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const hasSections = files.length > 0;
+  const fileIdx = Math.max(0, Math.min(activeIndex, files.length - 1));
+  const curFile = files[fileIdx] || files[0] || { label: "", content: "" };
+
+  const addSection = () => {
+    if (readOnly) return;
+    const next = nextUntitledSection(files);
+    onChange([...files, { label: next.label, name: next.name, content: "# Untitled\n\n" }]);
+    onActiveIndexChange(files.length);
+  };
+
+  const renameSection = (value: string) => {
+    if (readOnly) return;
+    onChange(files.map((f, i) => (
+      i === fileIdx
+        ? { ...f, label: value, name: contextFileNameForSection(value, i, f, files) }
+        : f
+    )));
+  };
+
+  const setContent = (value: string) => {
+    if (readOnly) return;
+    onChange(files.map((f, i) => (i === fileIdx ? { ...f, content: value } : f)));
+  };
+
+  const confirmDelete = () => {
+    if (readOnly) return;
+    const next = files.filter((_, i) => i !== fileIdx);
+    onChange(next);
+    onActiveIndexChange(Math.max(0, Math.min(fileIdx, next.length - 1)));
+    setDeleteOpen(false);
+  };
+
+  const delName = hasSections ? fileLabel(curFile, fileIdx) : "context section";
+
+  return (
+    <div class="gsv-cse">
+      {/* section tabs */}
+      <div class="gsv-cse-tabs">
+        {files.map((f, i) => (
+          <button
+            key={`${f.origName ?? f.name ?? f.label}-${i}`}
+            type="button"
+            class="gsv-cse-file-tab"
+            onClick={() => onActiveIndexChange(i)}
+          >
+            <svg width="34" height="30" viewBox="0 0 16 14" shape-rendering="crispEdges" fill={i === fileIdx ? "var(--accent-bright)" : "var(--border-raised)"}>
+              <rect x="1" y="2" width="6" height="2" />
+              <rect x="1" y="4" width="14" height="9" />
+            </svg>
+            <span class="gsv-sublabel" style={`letter-spacing:.1em;color:${i === fileIdx ? "var(--text)" : "var(--text-muted)"};line-height:1.35;`}>
+              {fileLabel(f, i)}
+            </span>
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={readOnly}
+          onClick={readOnly ? undefined : addSection}
+          class={`gsv-cse-file-tab gsv-cse-newfile${readOnly ? " is-disabled" : ""}`}
+        >
+          <svg width="34" height="30" viewBox="0 0 16 14" shape-rendering="crispEdges" fill="none" stroke="var(--dashed)" stroke-width="1">
+            <path d="M1.5 3.5 H6.5 V4.5" />
+            <rect x="1.5" y="4.5" width="13" height="8" />
+          </svg>
+          <span class="gsv-sublabel" style="letter-spacing:.1em;color:var(--accent);border-bottom:1px solid var(--accent);padding-bottom:1px;">NEW SECTION</span>
+        </button>
+      </div>
+
+      {hasSections ? (
+        <>
+          <div style="max-width:520px;margin-bottom:16px;">
+            <TextInput
+              value={fileLabel(curFile, fileIdx)}
+              onChange={renameSection}
+              placeholder="Operating notes"
+              size="medium"
+              label="SECTION NAME"
+              readonly={readOnly}
+            />
+          </div>
+
+          <textarea
+            class="gsv-ed gsv-cse-editor"
+            value={curFile.content}
+            onInput={(event) => setContent((event.target as HTMLTextAreaElement).value)}
+            spellcheck={false}
+            readOnly={readOnly}
+          />
+        </>
+      ) : (
+        <div class="gsv-cse-empty-context">
+          <strong>NO CONTEXT SECTIONS</strong>
+        </div>
+      )}
+
+      <div class="gsv-cse-actions">
+        <Button variant="dangerGhost" label="DELETE" onClick={() => setDeleteOpen(true)} disabled={readOnly || !hasSections} />
+        <span style="flex:1;" />
+        {actions}
+      </div>
+
+      {/* DELETE CONFIRM MODAL — portaled to <body> so an ancestor
+          container-type doesn't trap its viewport-fixed scrim. */}
+      {deleteOpen ? createPortal(
+        <div class="gsv-cse-modal-scrim" onClick={() => setDeleteOpen(false)}>
+          <div class="gsv-cse-modal-wrap" onClick={(event) => event.stopPropagation()}>
+            <ConfirmModal
+              title="CONFIRM DELETE"
+              message={`Are you sure you want to delete "${delName}"?`}
+              note="This file is removed from the agent -- it can't be recovered."
+              onCancel={() => setDeleteOpen(false)}
+              onConfirm={confirmDelete}
+            />
+          </div>
+        </div>,
+        document.body,
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/app/components/ui/ContextSectionsEditor.tsx
+++ b/web/src/app/components/ui/ContextSectionsEditor.tsx
@@ -22,6 +22,11 @@ export interface ContextSectionsEditorProps {
   activeIndex: number;
   onActiveIndexChange: (index: number) => void;
   readOnly?: boolean;
+  /** When provided, DELETE commits immediately through the host (removing the
+   *  section from disk right away) rather than only staging a draft removal.
+   *  The host owns updating `files`/`activeIndex` afterwards. Omit to keep the
+   *  staged draft-until-SAVE behavior. */
+  onDeleteSection?: (index: number) => void;
   /** Right-aligned controls in the action row (e.g. host SAVE / RESET / status).
    *  Rendered next to the section's own DELETE affordance. */
   actions?: ComponentChildren;
@@ -113,6 +118,7 @@ export function ContextSectionsEditor({
   activeIndex,
   onActiveIndexChange,
   readOnly = false,
+  onDeleteSection,
   actions,
 }: ContextSectionsEditorProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -144,13 +150,25 @@ export function ContextSectionsEditor({
 
   const confirmDelete = () => {
     if (readOnly) return;
+    setDeleteOpen(false);
+    // Immediate-delete host: it persists the removal and owns the resulting
+    // files/activeIndex update.
+    if (onDeleteSection) {
+      onDeleteSection(fileIdx);
+      return;
+    }
+    // Staged host: draft removal, committed on the host's own SAVE.
     const next = files.filter((_, i) => i !== fileIdx);
     onChange(next);
     onActiveIndexChange(Math.max(0, Math.min(fileIdx, next.length - 1)));
-    setDeleteOpen(false);
   };
 
   const delName = hasSections ? fileLabel(curFile, fileIdx) : "context section";
+  // Immediate-delete hosts commit on confirm; staged hosts remove from the draft
+  // and only apply on the host's SAVE — the note reflects which.
+  const deleteNote = onDeleteSection
+    ? "This file is removed from the agent -- it can't be recovered."
+    : "You must save for this and any other unsaved changes to take effect.";
 
   return (
     <div class="gsv-cse">
@@ -167,7 +185,11 @@ export function ContextSectionsEditor({
               <rect x="1" y="2" width="6" height="2" />
               <rect x="1" y="4" width="14" height="9" />
             </svg>
-            <span class="gsv-sublabel" style={`letter-spacing:.1em;color:${i === fileIdx ? "var(--text)" : "var(--text-muted)"};line-height:1.35;`}>
+            <span
+              class="gsv-sublabel gsv-cse-file-label"
+              title={fileLabel(f, i)}
+              style={`letter-spacing:.1em;color:${i === fileIdx ? "var(--text)" : "var(--text-muted)"};line-height:1.35;`}
+            >
               {fileLabel(f, i)}
             </span>
           </button>
@@ -227,7 +249,7 @@ export function ContextSectionsEditor({
             <ConfirmModal
               title="CONFIRM DELETE"
               message={`Are you sure you want to delete "${delName}"?`}
-              note="This file is removed from the agent -- it can't be recovered."
+              note={deleteNote}
               onCancel={() => setDeleteOpen(false)}
               onConfirm={confirmDelete}
             />

--- a/web/src/app/components/ui/IconButton.tsx
+++ b/web/src/app/components/ui/IconButton.tsx
@@ -1,7 +1,7 @@
 import type { ComponentChildren } from "preact";
 import "./IconButton.css";
 
-export type IconButtonGlyph = "back" | "arrowBack" | "menu" | "max" | "min" | "close" | "plus" | "help" | "attention" | "refresh" | "newTab" | "attach" | "transcribe" | "mic" | "send" | "stop" | "sidepanel";
+export type IconButtonGlyph = "back" | "arrowBack" | "menu" | "max" | "min" | "close" | "plus" | "help" | "attention" | "refresh" | "newTab" | "attach" | "transcribe" | "mic" | "send" | "stop" | "sidepanel" | "edit";
 export type IconButtonSize = "small" | "medium" | "large" | number;
 /** Visual treatment. "default" = filled box with border; "floating" = borderless
  *  and transparent, glyph-only, with a color-shift on hover (for use inside bars
@@ -174,6 +174,12 @@ const GLYPHS: Record<IconButtonGlyph, ComponentChildren> = {
       <path d="M2.5 8 H9.5" />
       <path d="M7 5.5 L9.5 8 L7 10.5" />
       <path d="M13 3 V13" />
+    </svg>
+  ),
+  edit: (
+    <svg width="50%" height="50%" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="miter">
+      <path d="M11.2 2.8 L13.2 4.8 L5.5 12.5 L2.8 13.2 L3.5 10.5 Z" />
+      <path d="M9.7 4.3 L11.7 6.3" />
     </svg>
   ),
 };

--- a/web/src/app/components/ui/Segmented.tsx
+++ b/web/src/app/components/ui/Segmented.tsx
@@ -16,6 +16,9 @@ export interface SegmentedProps {
   disabled?: boolean;
   width?: number;
   label?: string;
+  /** Accessible name for the radiogroup when the visible label is rendered
+   *  externally (no `label` prop). Ignored when `label` is set. */
+  ariaLabel?: string;
   info?: string;
   description?: string;
   requirement?: SegmentedRequirement;
@@ -145,6 +148,7 @@ export function Segmented(props: SegmentedProps) {
         style={{ width: "100%" }}
         role="radiogroup"
         aria-labelledby={labelId}
+        aria-label={labelId ? undefined : props.ariaLabel || undefined}
         aria-describedby={describedBy}
         aria-invalid={status === "error" ? true : undefined}
       >

--- a/web/src/app/components/ui/Segmented.tsx
+++ b/web/src/app/components/ui/Segmented.tsx
@@ -1,4 +1,4 @@
-import { useId, useRef, useState } from "preact/hooks";
+import { useEffect, useId, useRef, useState } from "preact/hooks";
 import { InfoTip } from "./InfoTip";
 import "./Segmented.css";
 
@@ -54,6 +54,13 @@ export function Segmented(props: SegmentedProps) {
   } = props;
 
   const [selState, setSelState] = useState<number | undefined>(undefined);
+  // Stay controlled: when the parent supplies a new `value` (e.g. a RESET that
+  // restores the saved selection), drop the local click state so the control
+  // reflects the incoming value instead of the last-clicked segment. Uncontrolled
+  // callers pass a static `value`, so this never fires for them after mount.
+  useEffect(() => {
+    setSelState(undefined);
+  }, [props.value]);
   const sel = selState === undefined ? props.value ?? 1 : selState;
   const groupId = useId();
   const segRefs = useRef<(HTMLButtonElement | null)[]>([]);

--- a/web/src/app/components/ui/agentToolApprovalOptions.ts
+++ b/web/src/app/components/ui/agentToolApprovalOptions.ts
@@ -1,0 +1,251 @@
+import type { SelectOption } from "./Select";
+
+/** Shared model + option builders for tool-approval editing. Extracted from
+ *  AgentToolsPanel so other approval editors (e.g. the CREW overrides drawer)
+ *  can reuse the same capability families, machine scopes and labels. */
+
+export type AgentToolApprovalAction = "auto" | "ask" | "deny";
+
+export type AgentToolApprovalRule = {
+  match: string;
+  target?: string;
+  action: AgentToolApprovalAction;
+};
+
+export type AgentToolApprovalPolicy = {
+  default: AgentToolApprovalAction;
+  rules: AgentToolApprovalRule[];
+};
+
+export type AgentToolTarget = {
+  id: string;
+  label?: string;
+  online?: boolean;
+  implements?: readonly string[];
+};
+
+type CapabilityFamily = {
+  label: string;
+  options: ApprovalMatchOption[];
+};
+
+type ApprovalMatchOption = {
+  match: string;
+  label: string;
+  description?: string;
+};
+
+export const APPROVAL_ACTIONS: AgentToolApprovalAction[] = ["auto", "ask", "deny"];
+
+export const CAPABILITY_FAMILIES: CapabilityFamily[] = [
+  {
+    label: "Filesystem",
+    options: [
+      { match: "fs.*", label: "All file tools", description: "Read, write, edit, search, copy, and delete files." },
+      { match: "fs.read", label: "Read files" },
+      { match: "fs.write", label: "Write files" },
+      { match: "fs.edit", label: "Edit files" },
+      { match: "fs.search", label: "Search files" },
+      { match: "fs.copy", label: "Copy files" },
+      { match: "fs.delete", label: "Delete files" },
+    ],
+  },
+  {
+    label: "Shell",
+    options: [
+      { match: "shell.*", label: "All shell tools", description: "Every shell operation." },
+      { match: "shell.exec", label: "Run shell commands" },
+    ],
+  },
+  {
+    label: "Network",
+    options: [
+      { match: "net.*", label: "All network tools", description: "Every network operation." },
+      { match: "net.fetch", label: "Fetch URLs" },
+    ],
+  },
+  {
+    label: "Repositories",
+    options: [
+      { match: "repo.*", label: "All repository tools", description: "Every ripgit repository operation." },
+      { match: "repo.list", label: "List repositories" },
+      { match: "repo.read", label: "Read repository content" },
+      { match: "repo.search", label: "Search repositories" },
+      { match: "repo.compare", label: "Compare refs" },
+      { match: "repo.diff", label: "Read diffs" },
+      { match: "repo.apply", label: "Apply repository changes" },
+      { match: "repo.import", label: "Pull upstream" },
+      { match: "repo.delete", label: "Delete repositories" },
+      { match: "repo.visibility.set", label: "Change repository visibility" },
+    ],
+  },
+  {
+    label: "Processes",
+    options: [
+      { match: "proc.*", label: "All process tools", description: "Every process and conversation operation." },
+      { match: "proc.spawn", label: "Start processes" },
+      { match: "proc.send", label: "Send process messages" },
+      { match: "proc.history", label: "Read process history" },
+      { match: "proc.abort", label: "Abort runs" },
+      { match: "proc.reset", label: "Reset processes" },
+      { match: "proc.kill", label: "Kill processes" },
+    ],
+  },
+  {
+    label: "MCP",
+    options: [
+      { match: "sys.mcp.*", label: "All MCP tools", description: "Every MCP server operation." },
+      { match: "sys.mcp.call", label: "Call MCP tools" },
+      { match: "sys.mcp.list", label: "List MCP servers" },
+      { match: "sys.mcp.add", label: "Add MCP servers" },
+      { match: "sys.mcp.refresh", label: "Refresh MCP servers" },
+      { match: "sys.mcp.remove", label: "Remove MCP servers" },
+    ],
+  },
+  {
+    label: "System Config",
+    options: [
+      { match: "sys.config.*", label: "All system config tools", description: "Read and write gateway config." },
+      { match: "sys.config.get", label: "Read system config" },
+      { match: "sys.config.set", label: "Write system config" },
+    ],
+  },
+];
+
+export const APPROVAL_MATCH_OPTIONS: SelectOption[] = CAPABILITY_FAMILIES.flatMap((family) =>
+  family.options.map((option) => ({
+    group: family.label,
+    label: option.label,
+    value: option.match,
+    description: option.description ?? "",
+  })),
+);
+const APPROVAL_MATCH_VALUES = CAPABILITY_FAMILIES.flatMap((family) => family.options.map((option) => option.match));
+const APPROVAL_MATCH_LABELS = new Map(
+  CAPABILITY_FAMILIES.flatMap((family) =>
+    family.options.map((option) => [option.match, option.label] as const)
+  ),
+);
+export const BUILTIN_TARGET_OPTIONS: SelectOption[] = [
+  {
+    label: "All machines",
+    value: "",
+  },
+  {
+    label: "GSV computer",
+    value: "gsv",
+  },
+];
+const LEGACY_EXTERNAL_TARGET_OPTION: SelectOption = {
+  group: "Stored machine",
+  label: "All machines",
+  value: "targets/*",
+};
+
+export function humanToolCapabilityLabel(capability: string): string {
+  const normalized = capability.trim();
+  if (!normalized) {
+    return "Capability";
+  }
+  const known = APPROVAL_MATCH_LABELS.get(normalized);
+  if (known) {
+    return known;
+  }
+  return normalized
+    .replace(/\.\*/g, "")
+    .split(/[._:-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function actionLabel(action: AgentToolApprovalAction): string {
+  if (action === "auto") return "Allow";
+  if (action === "deny") return "Block";
+  return "Ask";
+}
+
+export function defaultOverrideAction(defaultAction: AgentToolApprovalAction): AgentToolApprovalAction {
+  if (defaultAction === "auto") return "ask";
+  if (defaultAction === "deny") return "ask";
+  return "deny";
+}
+
+export function matchOptionsForRule(match: string): SelectOption[] {
+  if (!match || APPROVAL_MATCH_VALUES.includes(match)) {
+    return APPROVAL_MATCH_OPTIONS;
+  }
+  return [
+    ...APPROVAL_MATCH_OPTIONS,
+    {
+      group: "Custom",
+      label: "Custom match",
+      value: match,
+      description: "Stored custom approval match.",
+    },
+  ];
+}
+
+export function matchIndexForRule(match: string): number {
+  const options = matchOptionsForRule(match);
+  const index = options.findIndex((option) => typeof option !== "string" && option.value === match);
+  return index >= 0 ? index : 0;
+}
+
+export function approvalOptionValue(option: SelectOption): string {
+  return typeof option === "string" ? option : option.value ?? option.label;
+}
+
+export function targetOptionsForRule(target: string | undefined, targets: readonly AgentToolTarget[]): SelectOption[] {
+  const targetOptions = targets
+    .filter((candidate) => candidate.id.trim().length > 0)
+    .map((candidate) => {
+      const label = candidate.label?.trim() || candidate.id;
+      return {
+        group: "Machines",
+        label,
+        value: candidate.id,
+      };
+    });
+  const knownValues = new Set([
+    ...BUILTIN_TARGET_OPTIONS.map((option) => typeof option === "string" ? option : option.value ?? option.label),
+    ...targetOptions.map((option) => option.value ?? option.label),
+  ]);
+  const baseOptions = target === "targets/*"
+    ? [...BUILTIN_TARGET_OPTIONS, LEGACY_EXTERNAL_TARGET_OPTION, ...targetOptions]
+    : [...BUILTIN_TARGET_OPTIONS, ...targetOptions];
+  if (!target || knownValues.has(target) || target === "targets/*") {
+    return baseOptions;
+  }
+  return [
+    ...baseOptions,
+    {
+      group: "Stored machine",
+      label: target,
+      value: target,
+    },
+  ];
+}
+
+export function targetIndexForRule(target: string | undefined, targets: readonly AgentToolTarget[]): number {
+  const options = targetOptionsForRule(target, targets);
+  const value = target ?? "";
+  const index = options.findIndex((option) => typeof option !== "string" && (option.value ?? option.label) === value);
+  return index >= 0 ? index : 0;
+}
+
+/** Human label for a rule's machine scope (mirrors the target Select options). */
+export function targetLabelForRule(target: string | undefined, targets: readonly AgentToolTarget[]): string {
+  if (!target || target === "targets/*") {
+    return "All machines";
+  }
+  if (target === "gsv") {
+    return "GSV computer";
+  }
+  const known = targets.find((candidate) => candidate.id === target);
+  return known?.label?.trim() || target;
+}
+
+export function actionIndex(action: AgentToolApprovalAction): number {
+  return Math.max(0, APPROVAL_ACTIONS.indexOf(action));
+}

--- a/web/src/app/features/chat/components/ChatAgentPanel.tsx
+++ b/web/src/app/features/chat/components/ChatAgentPanel.tsx
@@ -194,6 +194,16 @@ export function ChatAgentPanel({
               onOpenCrew();
             }}
           />
+          <ListRow
+            icon="cog"
+            label="MANAGE DEFAULTS"
+            status="none"
+            chevron
+            onClick={() => {
+              onClose();
+              onOpenCrew();
+            }}
+          />
         </div>
       </div>
     </div>

--- a/web/src/app/features/files/FilesPage.tsx
+++ b/web/src/app/features/files/FilesPage.tsx
@@ -1,5 +1,6 @@
+import type { ShellFilesRoute } from "../gsv-shell/domain/shellModel";
 import { FilesSurfaceSummary } from "./components/FilesSurfaceSummary";
 
-export function FilesPage() {
-  return <FilesSurfaceSummary />;
+export function FilesPage({ filesRoute }: { filesRoute?: ShellFilesRoute }) {
+  return <FilesSurfaceSummary initialLocation={filesRoute ?? null} />;
 }

--- a/web/src/app/features/files/components/FilesSurfaceSummary.tsx
+++ b/web/src/app/features/files/components/FilesSurfaceSummary.tsx
@@ -909,6 +909,11 @@ export function FilesSurfaceSummary({
         : tab);
     });
     setActiveTabId(linkedTab.id);
+    // Match navigateBrowserTab: a deep link changes the active directory, so drop
+    // any open CREATE draft / delete feedback — otherwise a stale draft would
+    // resolve against (and write into) the newly-linked directory.
+    setCreateState(emptyCreateState());
+    setDeleteFeedback(null);
   }, [initialTarget, initialPath, targets]);
 
   useEffect(() => {

--- a/web/src/app/features/files/components/FilesSurfaceSummary.tsx
+++ b/web/src/app/features/files/components/FilesSurfaceSummary.tsx
@@ -885,7 +885,7 @@ export function FilesSurfaceSummary({
     if (!initialTarget || !initialPath) {
       return;
     }
-    const locationKey = `${initialTarget} ${initialPath}`;
+    const locationKey = `${initialTarget}\u0000${initialPath}`;
     if (appliedLocationRef.current === locationKey) {
       return;
     }

--- a/web/src/app/features/files/components/FilesSurfaceSummary.tsx
+++ b/web/src/app/features/files/components/FilesSurfaceSummary.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "preact";
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { AddAction } from "../../../components/ui/AddAction";
 import { Breadcrumbs } from "../../../components/ui/Breadcrumbs";
 import { Button } from "../../../components/ui/Button";
@@ -824,11 +824,21 @@ function FileTabView({
   );
 }
 
-export function FilesSurfaceSummary() {
+export function FilesSurfaceSummary({
+  initialLocation = null,
+}: {
+  /** Deep-link entry from /files/<target>/<path> — opens the surface on that
+   *  machine + directory. null keeps the default target + client-side tabs. */
+  initialLocation?: { target: string; path: string } | null;
+} = {}) {
   const { connected } = useGateway();
   const targetsQuery = useFilesTargets();
   const filesMutations = useFilesMutations();
   const targets = targetsQuery.targets;
+  // Split the deep link into primitives so the seeding/entry effects key on the
+  // target + path identity rather than the wrapping object's reference.
+  const initialTarget = initialLocation?.target ?? null;
+  const initialPath = initialLocation?.path ?? null;
   const [tabs, setTabs] = useState<FilesWorkspaceTab[]>([]);
   const [activeTabId, setActiveTabId] = useState("");
   const [drafts, setDrafts] = useState<Record<string, FileDraftState>>({});
@@ -850,10 +860,56 @@ export function FilesSurfaceSummary() {
       if (validTabs.length > 0) {
         return validTabs.length === currentTabs.length ? currentTabs : validTabs;
       }
+      // A /files/<target>/<path> deep link seeds the first tab directly at that
+      // target + directory, so the surface opens on the linked folder instead of
+      // the default target root. An unknown target falls through to the normal
+      // default (it must not crash).
+      if (initialTarget && targetIds.has(initialTarget)) {
+        return [createBrowserTab(initialTarget, initialPath ?? DEFAULT_PATH)];
+      }
       const initialTargetId = chooseInitialTarget(targets) ?? targets[0]?.id;
       return initialTargetId ? [createBrowserTab(initialTargetId, DEFAULT_PATH)] : [];
     });
+    // Seeds only when the target list (re)loads; live deep-link changes on an
+    // already-mounted surface are handled by the entry effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [targets]);
+
+  // A deep link arriving (or changing) while the surface is already mounted —
+  // e.g. navigating /files/gsv/a → /files/gsv/b — opens/points a browser tab at
+  // the new target + directory and focuses it. The ref records the last-applied
+  // location so this doesn't refire on unrelated re-renders, and so it stops
+  // fighting the client-side tab state once the user starts browsing.
+  const appliedLocationRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!initialTarget || !initialPath) {
+      return;
+    }
+    const locationKey = `${initialTarget} ${initialPath}`;
+    if (appliedLocationRef.current === locationKey) {
+      return;
+    }
+    if (!targets.some((target) => target.id === initialTarget)) {
+      return;
+    }
+    appliedLocationRef.current = locationKey;
+    const linkedTab = createBrowserTab(initialTarget, initialPath);
+    setTabs((currentTabs) => {
+      const existing = currentTabs.find((tab) => tab.id === linkedTab.id);
+      if (!existing) {
+        return [...currentTabs, linkedTab];
+      }
+      if (existing.kind === "browser" && existing.path === linkedTab.path) {
+        return currentTabs;
+      }
+      // Browser tabs are keyed by target (one per target), so point the existing
+      // one at the linked directory rather than duplicating it.
+      return currentTabs.map((tab) => tab.id === linkedTab.id && tab.kind === "browser"
+        ? { ...tab, path: linkedTab.path, commandInput: "", commandInputKey: tab.commandInputKey + 1, searchQuery: "" }
+        : tab);
+    });
+    setActiveTabId(linkedTab.id);
+  }, [initialTarget, initialPath, targets]);
 
   useEffect(() => {
     if (tabs.length === 0) {

--- a/web/src/app/features/files/components/FilesSurfaceSummary.tsx
+++ b/web/src/app/features/files/components/FilesSurfaceSummary.tsx
@@ -883,6 +883,7 @@ export function FilesSurfaceSummary({
   const appliedLocationRef = useRef<string | null>(null);
   useEffect(() => {
     if (!initialTarget || !initialPath) {
+      appliedLocationRef.current = null;
       return;
     }
     const locationKey = `${initialTarget}\u0000${initialPath}`;

--- a/web/src/app/features/gsv-console/components/CrewDefaultsPanel.tsx
+++ b/web/src/app/features/gsv-console/components/CrewDefaultsPanel.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "preact/hooks";
+import { actionLabel } from "../../../components/ui/agentToolApprovalOptions";
+import {
+  behaviorForAccount,
+  inheritedFallbackModelLabelForAccount,
+  inheritedModelLabelForAccount,
+  inheritedReasoningForAccount,
+  parseApprovalPolicy,
+} from "../domain/consoleAgentBehavior";
+import type { ConsoleAccount, ConsoleConfigEntry } from "../domain/consoleModels";
+import { useConsoleAgentContext } from "../hooks/useConsoleData";
+import { DefaultsSummaryPanel } from "./DefaultsSummaryPanel";
+
+export interface CrewDefaultsPanelProps {
+  /** The viewer (human) account whose defaults apply to all their agents. */
+  viewer: ConsoleAccount;
+  config: readonly ConsoleConfigEntry[];
+  /** Narrow-panel mode: the summary renders as a collapsed disclosure. */
+  compact: boolean;
+  /** Open the in-body edit surface (list column) on its defaults / overrides /
+   *  context (global instructions) section. */
+  onEditDefaults?: () => void;
+  onConfigureOverrides?: () => void;
+  onManageContext?: () => void;
+}
+
+function reasoningDisplayLabel(value: string): string {
+  if (!value) return "—";
+  if (value === "xhigh") return "Extra high";
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+}
+
+/** CrewDefaultsPanel — the "DEFAULTS" block of the CREW action column: a
+ *  read-only summary of the viewer's effective defaults. Every row opens the
+ *  in-body edit surface on its matching section (defaults / overrides / global
+ *  instructions). */
+export function CrewDefaultsPanel({
+  viewer,
+  config,
+  compact,
+  onEditDefaults,
+  onConfigureOverrides,
+  onManageContext,
+}: CrewDefaultsPanelProps) {
+  const context = useConsoleAgentContext(viewer.username);
+
+  const behavior = behaviorForAccount(config, viewer.uid, viewer.uid);
+  const savedPolicy = useMemo(() => parseApprovalPolicy(behavior.approval), [behavior.approval]);
+
+  const modelValue = behavior.modelLabel || inheritedModelLabelForAccount(config, viewer.uid, viewer.uid) || "—";
+  const fallbackValue = behavior.fallbackModelLabel
+    || inheritedFallbackModelLabelForAccount(config, viewer.uid, viewer.uid)
+    || "None";
+  const reasoningValue = reasoningDisplayLabel(
+    behavior.reasoning || inheritedReasoningForAccount(config, viewer.uid, viewer.uid),
+  );
+  const contextFilesCount = context.resource.isLoading || context.resource.isUnavailable || context.resource.isError
+    ? null
+    : context.files.length;
+
+  return (
+    <DefaultsSummaryPanel
+      model={modelValue}
+      fallback={fallbackValue}
+      reasoning={reasoningValue}
+      permissionsAction={actionLabel(savedPolicy.default).toUpperCase()}
+      overridesCount={savedPolicy.rules.length}
+      contextFilesCount={contextFilesCount}
+      onEditDefaults={onEditDefaults}
+      onConfigureOverrides={onConfigureOverrides}
+      onManageContext={onManageContext}
+      compact={compact}
+    />
+  );
+}

--- a/web/src/app/features/gsv-console/components/DefaultsSummaryPanel.css
+++ b/web/src/app/features/gsv-console/components/DefaultsSummaryPanel.css
@@ -1,0 +1,26 @@
+/* DEFAULTS summary — the standard settings-card anatomy (ref: MODELS card on
+   the overview): compact SectionHeader + list rows with edge-to-edge rules.
+   The host column renders it FLUSH — no padding between the card's horizontal
+   rules and the template's vertical lines. */
+.gsv-defaults-summary {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  /* Closes the card's top edge against the action controls above. */
+  border-top: 1px solid var(--rule-section);
+}
+
+.gsv-defaults-summary-list {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.gsv-defaults-summary-row {
+  min-width: 0;
+  border-bottom: 1px solid var(--rule-inner);
+}
+
+/* ListRow already provides the clickable hover background and the focus-visible
+   outline (ListRow.css); no override here — an earlier one used !important and
+   stripped the keyboard focus ring. */

--- a/web/src/app/features/gsv-console/components/DefaultsSummaryPanel.tsx
+++ b/web/src/app/features/gsv-console/components/DefaultsSummaryPanel.tsx
@@ -1,0 +1,115 @@
+import type { JSX } from "preact";
+import { useState } from "preact/hooks";
+import { ListRow } from "../../../components/ui/ListRow";
+import { SectionHeader } from "../../../components/ui/SectionHeader";
+import "./DefaultsSummaryPanel.css";
+
+/* Same row metrics as the settings/overview cards (MODELS etc.). */
+const SUMMARY_ROW_STYLE: JSX.CSSProperties = {
+  minHeight: "44px",
+  padding: "13px 16px",
+};
+
+export interface DefaultsSummaryPanelProps {
+  /** Display values — already resolved to their effective labels. */
+  model: string;
+  fallback: string;
+  reasoning: string;
+  /** Default approval action label, e.g. "ALLOW". */
+  permissionsAction: string;
+  overridesCount: number;
+  /** null while the context listing is loading/unavailable (renders "—"). */
+  contextFilesCount: number | null;
+  /** Open the in-body editor on its defaults / overrides / context section. */
+  onEditDefaults?: () => void;
+  onConfigureOverrides?: () => void;
+  onManageContext?: () => void;
+  /** Narrow-panel mode: header toggles a collapsed-by-default disclosure. */
+  compact?: boolean;
+}
+
+function SummaryRow({ value, field, onClick }: {
+  value: string;
+  field: string;
+  onClick?: () => void;
+}) {
+  return (
+    <div class="gsv-defaults-summary-row">
+      <ListRow
+        label={value}
+        sub={field}
+        status="none"
+        chevron={Boolean(onClick)}
+        onClick={onClick}
+        style={SUMMARY_ROW_STYLE}
+      />
+    </div>
+  );
+}
+
+/** DefaultsSummaryPanel — the viewer's default configurations as a standard
+ *  settings card (the MODELS-card anatomy: compact SectionHeader + list rows
+ *  with edge-to-edge rules, value as the row label, field name as the sub).
+ *  Every row clicks through to the in-body editor's matching section.
+ *  Reusable on the agent detail page later. */
+export function DefaultsSummaryPanel({
+  model,
+  fallback,
+  reasoning,
+  permissionsAction,
+  overridesCount,
+  contextFilesCount,
+  onEditDefaults,
+  onConfigureOverrides,
+  onManageContext,
+  compact = false,
+}: DefaultsSummaryPanelProps) {
+  const [collapsed, setCollapsed] = useState(true);
+  const showBody = !compact || !collapsed;
+  // In compact (mobile) mode, opening a section auto-collapses the summary so the
+  // in-body editor below gets the vertical space — the panel would otherwise
+  // stack on top of the editor and leave too little room to see it.
+  const openSection = (handler?: () => void) =>
+    handler
+      ? () => {
+          if (compact) setCollapsed(true);
+          handler();
+        }
+      : undefined;
+  const overridesLabel = `${overridesCount} override${overridesCount === 1 ? "" : "s"}`;
+  const filesLabel = contextFilesCount === null
+    ? "—"
+    : `${contextFilesCount} file${contextFilesCount === 1 ? "" : "s"}`;
+
+  return (
+    <section class="gsv-defaults-summary" aria-label="Defaults">
+      <SectionHeader
+        title="DEFAULTS"
+        headingLevel={3}
+        density="compact"
+        divider
+        meta={compact ? (collapsed ? "SHOW" : "HIDE") : undefined}
+        onClick={compact ? () => setCollapsed((current) => !current) : undefined}
+      />
+      {showBody ? (
+        <>
+          <div class="gsv-defaults-summary-list">
+            <SummaryRow value={model} field="MODEL" onClick={openSection(onEditDefaults)} />
+            <SummaryRow value={fallback} field="FALLBACK" onClick={openSection(onEditDefaults)} />
+            <SummaryRow value={reasoning} field="REASONING" onClick={openSection(onEditDefaults)} />
+            <SummaryRow
+              value={`${permissionsAction} (${overridesLabel})`}
+              field="PERMISSIONS"
+              onClick={openSection(onConfigureOverrides)}
+            />
+            <SummaryRow
+              value={filesLabel}
+              field="GLOBAL INSTRUCTIONS"
+              onClick={contextFilesCount === null ? undefined : openSection(onManageContext)}
+            />
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/web/src/app/features/gsv-console/components/EditDefaultsPanel.css
+++ b/web/src/app/features/gsv-console/components/EditDefaultsPanel.css
@@ -1,0 +1,69 @@
+/* In-body edit surface — rendered in the ListTemplate list column in place of
+   the roster rows, with an ✕ back to the list. Field layout mirrors the
+   create-agent form column (AgentEditor GENERAL): max-width 640, 30px rhythm. */
+.gsv-edit-defaults {
+  display: block;
+  max-width: 640px;
+  padding: 16px;
+  outline: none;
+}
+
+.gsv-edit-defaults-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+/* "← AGENTS" back-to-roster control, mirroring the ✕ on the right. Same plain
+   sublabel treatment as the console detail back control. */
+.gsv-edit-defaults-back {
+  /* 44px tap target for touch; negative block margin collapses the extra height
+     back out of the layout so the head row keeps its visual rhythm. */
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  margin: -12px 0;
+  padding: 12px 8px 12px 0;
+  border: 0;
+  background: transparent;
+  color: var(--meta, #8c86c8);
+  /* size + family from .gsv-sublabel (12px); 0.16em tracking kept intentionally */
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.12s;
+}
+
+.gsv-edit-defaults-back:hover,
+.gsv-edit-defaults-back:focus-visible {
+  color: var(--text-hi, #cbc7ff);
+  outline: none;
+}
+
+/* Same plain desktop-yellow step-title treatment as the connect-flow steps. */
+.gsv-edit-defaults-title {
+  margin: 0;
+  text-align: left;
+  color: var(--update);
+  text-shadow: 0 0 9px rgba(255, 210, 77, 0.3);
+}
+
+.gsv-edit-defaults-desc {
+  margin: 0 0 28px;
+  color: var(--text-muted);
+}
+
+/* Scroll target for the CONFIGURE OVERRIDES CTA (within the defaults surface). */
+.gsv-edit-defaults-tools {
+  scroll-margin-top: 8px;
+}
+
+/* Inline discard confirm shown in place of the actions row while closing dirty. */
+.gsv-edit-defaults-discard {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--warn);
+}

--- a/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
+++ b/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
@@ -1,0 +1,411 @@
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { Button } from "../../../components/ui/Button";
+import { IconButton } from "../../../components/ui/IconButton";
+import { Select } from "../../../components/ui/Select";
+import {
+  FALLBACK_SETTING_INFO,
+  MODEL_SETTING_INFO,
+  REASONING_SETTING_INFO,
+  REASONING_VALUES,
+  reasoningIndexForValue,
+  reasoningOptions,
+} from "../../../components/ui/AgentEditor";
+import { AgentToolsPanel } from "../../../components/ui/AgentToolsPanel";
+import type { AgentToolTarget } from "../../../components/ui/agentToolApprovalOptions";
+import {
+  ContextSectionsEditor,
+  type ContextSection,
+} from "../../../components/ui/ContextSectionsEditor";
+import { useUnsavedGuard } from "../../gsv-shell/unsaved/unsavedGuard";
+import { modelOptionsForConfig, type ConsoleModelOption } from "../domain/consoleAi";
+import {
+  approvalForAgentSave,
+  behaviorForAccount,
+  fallbackModelOptionsForAccount,
+  inheritedFallbackModelLabelForAccount,
+  inheritedModelLabelForAccount,
+  inheritedReasoningForAccount,
+  modelOptionsForAccount,
+  parseApprovalPolicy,
+  serializeApprovalPolicy,
+  type ApprovalPolicy,
+} from "../domain/consoleAgentBehavior";
+import type { ConsoleAccount, ConsoleConfigEntry } from "../domain/consoleModels";
+import { useConsoleAgentContext, useSaveConsoleAgentBehavior, useSaveConsoleAgentContext } from "../hooks/useConsoleData";
+import "./EditDefaultsPanel.css";
+
+export type EditDefaultsSection = "defaults" | "overrides" | "context";
+
+/** Draft seed from the loaded context files (mirrors editorFilesForAccount). */
+function contextSectionsFromFiles(files: readonly { label: string; name: string; content: string; orig: string }[]): ContextSection[] {
+  return files.map((file) => ({ ...file, origName: file.name }));
+}
+
+/** Signature for dirty-detection — only the fields a save persists. */
+function contextSignature(files: readonly ContextSection[]): string {
+  return JSON.stringify(files.map((file) => ({ label: file.label, name: file.name ?? "", content: file.content })));
+}
+
+export interface EditDefaultsPanelProps {
+  /** Which part to reveal on open — "overrides" scrolls the overrides section
+   *  into view (both CTAs share this one surface). */
+  section?: EditDefaultsSection;
+  onClose: () => void;
+  /** The account whose defaults are edited (the viewer for CREW). */
+  viewer: ConsoleAccount;
+  config: readonly ConsoleConfigEntry[];
+  targets: readonly AgentToolTarget[];
+}
+
+function modelIndexForValue(options: readonly ConsoleModelOption[], value: string): number {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 0;
+  }
+  const index = options.findIndex((option) => option.value.trim() === trimmed);
+  return index >= 0 ? index : 0;
+}
+
+function optionsKey(options: readonly ConsoleModelOption[]): string {
+  return options.map((option) => `${option.value}:${option.label}`).join(" ");
+}
+
+/** EditDefaultsPanel — the in-body editing surface behind the CREW "DEFAULTS"
+ *  card, rendered in the list column with an ✕ back to the roster. The form is
+ *  the create-agent behavior template verbatim (same field widths, spacings,
+ *  info tips, shared AgentToolsPanel, AgentEditor-style actions row) minus the
+ *  identity fields. One draft, one SAVE — through the agent editor's
+ *  inheritance-preserving path. */
+export function EditDefaultsPanel({
+  section = "defaults",
+  onClose,
+  viewer,
+  config,
+  targets,
+}: EditDefaultsPanelProps) {
+  const saveBehavior = useSaveConsoleAgentBehavior();
+  const saveContext = useSaveConsoleAgentContext();
+  const context = useConsoleAgentContext(viewer.username);
+  const contextEditable = !context.resource.isLoading
+    && !context.resource.isUnavailable
+    && !context.resource.isError;
+
+  const behavior = behaviorForAccount(config, viewer.uid, viewer.uid);
+  const savedPolicy = useMemo(() => parseApprovalPolicy(behavior.approval), [behavior.approval]);
+  const savedSignature = serializeApprovalPolicy(savedPolicy);
+  const modelSelectOptions = modelOptionsForAccount(
+    modelOptionsForConfig(config),
+    behavior.model,
+    inheritedModelLabelForAccount(config, viewer.uid, viewer.uid),
+  );
+  const fallbackSelectOptions = fallbackModelOptionsForAccount(
+    config,
+    viewer.uid,
+    viewer.uid,
+    behavior.fallbackModel,
+    inheritedFallbackModelLabelForAccount(config, viewer.uid, viewer.uid),
+  );
+  const reasoningSelectOptions = reasoningOptions(inheritedReasoningForAccount(config, viewer.uid, viewer.uid));
+
+  const initialModelIndex = modelIndexForValue(modelSelectOptions, behavior.model);
+  const initialFallbackIndex = modelIndexForValue(fallbackSelectOptions, behavior.fallbackModel);
+  const initialReasoningIndex = reasoningIndexForValue(behavior.reasoning);
+  const baselineFiles = contextSectionsFromFiles(context.files);
+  const baselineFilesSignature = contextSignature(baselineFiles);
+  const baselineKey = [
+    initialModelIndex,
+    initialFallbackIndex,
+    initialReasoningIndex,
+    savedSignature,
+    context.dataUpdatedAt,
+    optionsKey(modelSelectOptions),
+    optionsKey(fallbackSelectOptions),
+  ].join("|");
+
+  const [modelIndex, setModelIndex] = useState(initialModelIndex);
+  const [fallbackIndex, setFallbackIndex] = useState(initialFallbackIndex);
+  const [reasoningIndex, setReasoningIndex] = useState(initialReasoningIndex);
+  const [approvalPolicy, setApprovalPolicy] = useState<ApprovalPolicy>(savedPolicy);
+  const [filesDraft, setFilesDraft] = useState<ContextSection[]>(baselineFiles);
+  const [contextIndex, setContextIndex] = useState(0);
+  const [pending, setPending] = useState(false);
+  const [flash, setFlash] = useState("");
+  const [formError, setFormError] = useState("");
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const rootRef = useRef<HTMLElement>(null);
+  const overridesRef = useRef<HTMLDivElement>(null);
+  const flashTimerRef = useRef<number | null>(null);
+
+  // Re-baseline whenever the saved values change (external edit, or our own
+  // save round-tripping through the config / context queries).
+  useEffect(() => {
+    setModelIndex(initialModelIndex);
+    setFallbackIndex(initialFallbackIndex);
+    setReasoningIndex(initialReasoningIndex);
+    setApprovalPolicy(savedPolicy);
+    setFilesDraft(contextSectionsFromFiles(context.files));
+    setContextIndex(0);
+    setConfirmDiscard(false);
+    setPending(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baselineKey]);
+
+  // On open: move focus to the surface (in-place swap).
+  useEffect(() => {
+    rootRef.current?.focus();
+    return () => {
+      if (flashTimerRef.current !== null) {
+        window.clearTimeout(flashTimerRef.current);
+      }
+    };
+  }, []);
+
+  // "context" is its own surface; "defaults"/"overrides" share the behavior
+  // form (overrides scrolls to the tools panel). Switching sections doesn't
+  // remount, so unsaved drafts survive.
+  const isContext = section === "context";
+  useEffect(() => {
+    if (section === "overrides") {
+      overridesRef.current?.scrollIntoView({ block: "start" });
+    } else {
+      rootRef.current?.scrollIntoView({ block: "start" });
+    }
+  }, [section]);
+
+  const draftPolicySignature = serializeApprovalPolicy(approvalPolicy);
+  const behaviorDirty =
+    modelIndex !== initialModelIndex ||
+    fallbackIndex !== initialFallbackIndex ||
+    reasoningIndex !== initialReasoningIndex ||
+    draftPolicySignature !== savedSignature;
+  const contextDirty = contextEditable && contextSignature(filesDraft) !== baselineFilesSignature;
+  const dirty = behaviorDirty || contextDirty;
+  useUnsavedGuard(() => dirty);
+
+  const editable = viewer.runnable;
+  const disabled = !editable || pending;
+
+  const touch = () => {
+    setFlash("");
+    setFormError("");
+    setConfirmDiscard(false);
+  };
+
+  const resetDrafts = () => {
+    setModelIndex(initialModelIndex);
+    setFallbackIndex(initialFallbackIndex);
+    setReasoningIndex(initialReasoningIndex);
+    setApprovalPolicy(savedPolicy);
+    setFilesDraft(contextSectionsFromFiles(context.files));
+    setContextIndex(0);
+    touch();
+  };
+
+  const save = async () => {
+    if (!dirty || pending) {
+      return;
+    }
+    setPending(true);
+    setFlash("");
+    setFormError("");
+    try {
+      if (behaviorDirty) {
+        await saveBehavior.mutateAsync({
+          uid: viewer.uid,
+          model: modelIndex === 0 ? "" : modelSelectOptions[modelIndex]?.value ?? "",
+          fallbackModel: fallbackIndex === 0 ? "" : fallbackSelectOptions[fallbackIndex]?.value ?? "",
+          reasoning: reasoningIndex === 0 ? "" : REASONING_VALUES[reasoningIndex] ?? "",
+          approval: approvalForAgentSave(draftPolicySignature, behavior),
+        });
+      }
+      if (contextDirty) {
+        await saveContext.mutateAsync({
+          username: viewer.username,
+          files: filesDraft,
+          baseNames: context.files.map((file) => file.name),
+        });
+      }
+      setFlash("✓ SAVED");
+      if (flashTimerRef.current !== null) {
+        window.clearTimeout(flashTimerRef.current);
+      }
+      flashTimerRef.current = window.setTimeout(() => setFlash(""), 1800);
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const requestClose = () => {
+    if (pending) {
+      return;
+    }
+    if (dirty) {
+      setConfirmDiscard(true);
+      return;
+    }
+    onClose();
+  };
+
+  const discardAndClose = () => {
+    resetDrafts();
+    onClose();
+  };
+
+  // Shared action-row pieces. In the context surface these ride in the
+  // ContextSectionsEditor `actions` slot (aligned with its DELETE); in the
+  // behavior surface they sit in the panel's own footer row.
+  const statusNode = !editable ? (
+    <span class="gsv-sublabel" style="letter-spacing:.12em;">READ ONLY</span>
+  ) : formError ? (
+    <span class="gsv-sublabel" style="letter-spacing:.12em;color:var(--error);">{formError}</span>
+  ) : flash ? (
+    <span class="gsv-sublabel" style="letter-spacing:.14em;color:var(--online);">{flash}</span>
+  ) : null;
+
+  const actionButtons = (
+    <>
+      <Button variant="secondary" label="RESET" onClick={resetDrafts} disabled={!dirty || pending} />
+      <Button
+        variant="primary"
+        label={pending ? "SAVING" : "SAVE"}
+        onClick={() => void save()}
+        disabled={!editable || !dirty || pending}
+      />
+    </>
+  );
+
+  return (
+    <section class="gsv-edit-defaults" aria-label="Edit defaults" ref={rootRef} tabIndex={-1}>
+      <div class="gsv-edit-defaults-head">
+        <button
+          type="button"
+          class="gsv-edit-defaults-back gsv-sublabel"
+          onClick={requestClose}
+        >
+          <span aria-hidden="true">←</span> AGENTS
+        </button>
+        <IconButton glyph="close" size="small" ariaLabel="Close editor" onClick={requestClose} />
+      </div>
+
+      <h3 class="gsv-edit-defaults-title gsv-section">
+        {isContext ? "GLOBAL INSTRUCTIONS" : "EDIT DEFAULTS"}
+      </h3>
+
+      <p class="gsv-edit-defaults-desc gsv-paragraph-small">
+        {isContext
+          ? "Instructions all your agents follow. These do not take precedence over agent definitions."
+          : "These are your preferences, applied to all your agents."}
+      </p>
+
+      {isContext ? (
+        <ContextSectionsEditor
+          files={filesDraft}
+          onChange={(next) => {
+            touch();
+            setFilesDraft(next);
+          }}
+          activeIndex={contextIndex}
+          onActiveIndexChange={(index) => {
+            touch();
+            setContextIndex(index);
+          }}
+          readOnly={!editable || !contextEditable || pending}
+          actions={confirmDiscard ? undefined : (
+            <>
+              {statusNode}
+              {actionButtons}
+            </>
+          )}
+        />
+      ) : (
+        <>
+          {/* Behavior fields — the create-agent form template verbatim
+              (AgentEditor GENERAL column: 420/300 widths, 30px rhythm, info tips). */}
+          <div style="max-width:420px;margin-bottom:30px;">
+            <Select
+              label="MODEL"
+              info={MODEL_SETTING_INFO}
+              requirement="optional"
+              options={modelSelectOptions}
+              value={modelIndex}
+              onChange={disabled ? undefined : (index) => {
+                touch();
+                setModelIndex(index);
+              }}
+              width={420}
+              disabled={disabled}
+            />
+          </div>
+
+          <div style="max-width:420px;margin-bottom:30px;">
+            <Select
+              label="FALLBACK"
+              info={FALLBACK_SETTING_INFO}
+              requirement="optional"
+              options={fallbackSelectOptions}
+              value={fallbackIndex}
+              onChange={disabled ? undefined : (index) => {
+                touch();
+                setFallbackIndex(index);
+              }}
+              width={420}
+              disabled={disabled}
+            />
+          </div>
+
+          <div style="max-width:300px;margin-bottom:30px;">
+            <Select
+              label="REASONING"
+              info={REASONING_SETTING_INFO}
+              requirement="optional"
+              options={reasoningSelectOptions}
+              value={reasoningIndex}
+              onChange={disabled ? undefined : (index) => {
+                touch();
+                setReasoningIndex(index);
+              }}
+              width={300}
+              disabled={disabled}
+            />
+          </div>
+
+          <div ref={overridesRef} class="gsv-edit-defaults-tools">
+            <AgentToolsPanel
+              policy={approvalPolicy}
+              targets={[...targets]}
+              disabled={disabled}
+              defaultDescription="When there are no overrides configured, all your agents will follow the default permission when using any tool. Overrides are machine or tool specific rules that take priority over the default action."
+              onChange={(next) => {
+                touch();
+                setApprovalPolicy(next);
+              }}
+            />
+          </div>
+        </>
+      )}
+
+      {confirmDiscard ? (
+        <div
+          class="gsv-edit-defaults-discard"
+          role="alertdialog"
+          aria-label="Discard changes?"
+          style="margin-top:42px;"
+        >
+          <span class="gsv-sublabel">Discard unsaved default changes?</span>
+          <div style="display:flex;gap:12px;">
+            <Button variant="danger" label="DISCARD" onClick={discardAndClose} />
+            <Button variant="secondary" label="KEEP EDITING" onClick={() => setConfirmDiscard(false)} />
+          </div>
+        </div>
+      ) : isContext ? null : (
+        <div style="display:flex;align-items:center;gap:12px;margin-top:42px;">
+          {statusNode}
+          <span style="flex:1;" />
+          <div style="display:flex;gap:12px;">{actionButtons}</div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
+++ b/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
@@ -34,7 +34,22 @@ import type { ConsoleAccount, ConsoleConfigEntry } from "../domain/consoleModels
 import { useConsoleAgentContext, useSaveConsoleAgentBehavior, useSaveConsoleAgentContext } from "../hooks/useConsoleData";
 import "./EditDefaultsPanel.css";
 
-export type EditDefaultsSection = "defaults" | "overrides" | "context";
+export type EditDefaultsSection = "defaults" | "permissions" | "context";
+
+/** Per-section surface copy. Each CREW default now opens its own titled
+ *  surface (model defaults / permissions / global instructions). */
+const SECTION_TITLE: Record<EditDefaultsSection, string> = {
+  defaults: "MODEL DEFAULTS",
+  permissions: "DEFAULT PERMISSIONS",
+  context: "GLOBAL INSTRUCTIONS",
+};
+
+const SECTION_DESC: Record<EditDefaultsSection, string> = {
+  defaults: "These are your preferences, applied to all your agents.",
+  permissions:
+    "When there are no overrides configured, all your agents will follow the default permission when using any tool. Overrides are machine or tool specific rules that take priority over the default action.",
+  context: "Instructions all your agents follow. These do not take precedence over agent definitions.",
+};
 
 /** Draft seed from the loaded context files (mirrors editorFilesForAccount). */
 function contextSectionsFromFiles(files: readonly { label: string; name: string; content: string; orig: string }[]): ContextSection[] {
@@ -47,8 +62,8 @@ function contextSignature(files: readonly ContextSection[]): string {
 }
 
 export interface EditDefaultsPanelProps {
-  /** Which part to reveal on open — "overrides" scrolls the overrides section
-   *  into view (both CTAs share this one surface). */
+  /** Which surface to reveal on open — model defaults, permissions, or the
+   *  context/files editor. Each is its own titled surface. */
   section?: EditDefaultsSection;
   onClose: () => void;
   /** The account whose defaults are edited (the viewer for CREW). */
@@ -133,7 +148,6 @@ export function EditDefaultsPanel({
   const [formError, setFormError] = useState("");
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const rootRef = useRef<HTMLElement>(null);
-  const overridesRef = useRef<HTMLDivElement>(null);
   const flashTimerRef = useRef<number | null>(null);
 
   // Re-baseline whenever the saved values change (external edit, or our own
@@ -160,16 +174,13 @@ export function EditDefaultsPanel({
     };
   }, []);
 
-  // "context" is its own surface; "defaults"/"overrides" share the behavior
-  // form (overrides scrolls to the tools panel). Switching sections doesn't
-  // remount, so unsaved drafts survive.
+  // Each section ("defaults" / "permissions" / "context") is its own surface.
+  // Switching sections doesn't remount, so unsaved drafts survive — scroll the
+  // surface back to the top on switch.
   const isContext = section === "context";
+  const isPermissions = section === "permissions";
   useEffect(() => {
-    if (section === "overrides") {
-      overridesRef.current?.scrollIntoView({ block: "start" });
-    } else {
-      rootRef.current?.scrollIntoView({ block: "start" });
-    }
+    rootRef.current?.scrollIntoView({ block: "start" });
   }, [section]);
 
   const draftPolicySignature = serializeApprovalPolicy(approvalPolicy);
@@ -277,7 +288,7 @@ export function EditDefaultsPanel({
   );
 
   return (
-    <section class="gsv-edit-defaults" aria-label="Edit defaults" ref={rootRef} tabIndex={-1}>
+    <section class="gsv-edit-defaults" aria-label={SECTION_TITLE[section]} ref={rootRef} tabIndex={-1}>
       <div class="gsv-edit-defaults-head">
         <button
           type="button"
@@ -290,13 +301,11 @@ export function EditDefaultsPanel({
       </div>
 
       <h3 class="gsv-edit-defaults-title gsv-section">
-        {isContext ? "GLOBAL INSTRUCTIONS" : "EDIT DEFAULTS"}
+        {SECTION_TITLE[section]}
       </h3>
 
       <p class="gsv-edit-defaults-desc gsv-paragraph-small">
-        {isContext
-          ? "Instructions all your agents follow. These do not take precedence over agent definitions."
-          : "These are your preferences, applied to all your agents."}
+        {SECTION_DESC[section]}
       </p>
 
       {isContext ? (
@@ -319,6 +328,19 @@ export function EditDefaultsPanel({
             </>
           )}
         />
+      ) : isPermissions ? (
+        <div class="gsv-edit-defaults-tools">
+          <AgentToolsPanel
+            policy={approvalPolicy}
+            targets={[...targets]}
+            disabled={disabled}
+            hideHeading
+            onChange={(next) => {
+              touch();
+              setApprovalPolicy(next);
+            }}
+          />
+        </div>
       ) : (
         <>
           {/* Behavior fields — the create-agent form template verbatim
@@ -368,19 +390,6 @@ export function EditDefaultsPanel({
               }}
               width={300}
               disabled={disabled}
-            />
-          </div>
-
-          <div ref={overridesRef} class="gsv-edit-defaults-tools">
-            <AgentToolsPanel
-              policy={approvalPolicy}
-              targets={[...targets]}
-              disabled={disabled}
-              defaultDescription="When there are no overrides configured, all your agents will follow the default permission when using any tool. Overrides are machine or tool specific rules that take priority over the default action."
-              onChange={(next) => {
-                touch();
-                setApprovalPolicy(next);
-              }}
             />
           </div>
         </>

--- a/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
+++ b/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
@@ -127,12 +127,14 @@ export function EditDefaultsPanel({
   const initialReasoningIndex = reasoningIndexForValue(behavior.reasoning);
   const baselineFiles = contextSectionsFromFiles(context.files);
   const baselineFilesSignature = contextSignature(baselineFiles);
-  const baselineKey = [
+  // Behavior-only baseline — deliberately excludes the context query so a
+  // behavior save (which invalidates the config query) can't re-baseline the
+  // context draft out from under a still-unsaved / failed context edit.
+  const behaviorBaselineKey = [
     initialModelIndex,
     initialFallbackIndex,
     initialReasoningIndex,
     savedSignature,
-    context.dataUpdatedAt,
     optionsKey(modelSelectOptions),
     optionsKey(fallbackSelectOptions),
   ].join("|");
@@ -150,19 +152,26 @@ export function EditDefaultsPanel({
   const rootRef = useRef<HTMLElement>(null);
   const flashTimerRef = useRef<number | null>(null);
 
-  // Re-baseline whenever the saved values change (external edit, or our own
-  // save round-tripping through the config / context queries).
+  // Re-baseline behavior fields when the saved behavior changes (external edit,
+  // or our own save round-tripping through the config query).
   useEffect(() => {
     setModelIndex(initialModelIndex);
     setFallbackIndex(initialFallbackIndex);
     setReasoningIndex(initialReasoningIndex);
     setApprovalPolicy(savedPolicy);
-    setFilesDraft(contextSectionsFromFiles(context.files));
-    setContextIndex(0);
     setConfirmDiscard(false);
     setPending(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [baselineKey]);
+  }, [behaviorBaselineKey]);
+
+  // Re-baseline the context draft only when the saved context itself changes —
+  // keyed off the context query alone so a behavior save (or failed partial
+  // save) leaves an unsaved context draft intact.
+  useEffect(() => {
+    setFilesDraft(contextSectionsFromFiles(context.files));
+    setContextIndex(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context.dataUpdatedAt]);
 
   // On open: move focus to the surface (in-place swap).
   useEffect(() => {

--- a/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
+++ b/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
@@ -153,14 +153,16 @@ export function EditDefaultsPanel({
   const flashTimerRef = useRef<number | null>(null);
 
   // Re-baseline behavior fields when the saved behavior changes (external edit,
-  // or our own save round-tripping through the config query).
+  // or our own save round-tripping through the config query). `pending` is owned
+  // solely by save()'s try/finally — this effect must not clear it, or a
+  // behavior save that lands mid-combined-save (before the awaited context
+  // write) would re-enable the controls while that write is still in flight.
   useEffect(() => {
     setModelIndex(initialModelIndex);
     setFallbackIndex(initialFallbackIndex);
     setReasoningIndex(initialReasoningIndex);
     setApprovalPolicy(savedPolicy);
     setConfirmDiscard(false);
-    setPending(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [behaviorBaselineKey]);
 
@@ -257,6 +259,52 @@ export function EditDefaultsPanel({
     }
   };
 
+  // DELETE on the context surface commits immediately (per product decision):
+  // persist the file removal to disk on confirm rather than staging it for the
+  // next SAVE. Passes the saved baseline (minus the target) so ONLY the delete
+  // runs — other unsaved section edits are left untouched, not written. A
+  // brand-new section that was never saved just drops from the draft.
+  const deleteSection = async (index: number) => {
+    if (!editable || pending) {
+      return;
+    }
+    const target = filesDraft[index];
+    if (!target) {
+      return;
+    }
+    const remaining = filesDraft.filter((_, candidate) => candidate !== index);
+    const nextIndex = Math.max(0, Math.min(index, remaining.length - 1));
+    const diskName = target.origName ?? target.name;
+    const onDisk = Boolean(diskName) && context.files.some((file) => file.name === diskName);
+
+    const prevDraft = filesDraft;
+    const prevIndex = contextIndex;
+    touch();
+    setFilesDraft(remaining);
+    setContextIndex(nextIndex);
+
+    if (!onDisk) {
+      return;
+    }
+
+    setPending(true);
+    setFormError("");
+    try {
+      await saveContext.mutateAsync({
+        username: viewer.username,
+        files: context.files.filter((file) => file.name !== diskName),
+        baseNames: context.files.map((file) => file.name),
+      });
+    } catch (error) {
+      // Persist failed — restore the section so the UI matches disk.
+      setFilesDraft(prevDraft);
+      setContextIndex(prevIndex);
+      setFormError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPending(false);
+    }
+  };
+
   const requestClose = () => {
     if (pending) {
       return;
@@ -330,6 +378,7 @@ export function EditDefaultsPanel({
             setContextIndex(index);
           }}
           readOnly={!editable || !contextEditable || pending}
+          onDeleteSection={(index) => void deleteSection(index)}
           actions={confirmDiscard ? undefined : (
             <>
               {statusNode}

--- a/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
+++ b/web/src/app/features/gsv-console/components/EditDefaultsPanel.tsx
@@ -151,6 +151,11 @@ export function EditDefaultsPanel({
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const rootRef = useRef<HTMLElement>(null);
   const flashTimerRef = useRef<number | null>(null);
+  // Set when an immediate delete has already reconciled the draft optimistically
+  // (dropping the deleted file, keeping every other unsaved edit). Skips the one
+  // context re-baseline that delete's own refetch triggers so those edits aren't
+  // clobbered. Reset on a failed delete so a genuine refetch still re-baselines.
+  const skipContextRebaselineRef = useRef(false);
 
   // Re-baseline behavior fields when the saved behavior changes (external edit,
   // or our own save round-tripping through the config query). `pending` is owned
@@ -168,8 +173,13 @@ export function EditDefaultsPanel({
 
   // Re-baseline the context draft only when the saved context itself changes —
   // keyed off the context query alone so a behavior save (or failed partial
-  // save) leaves an unsaved context draft intact.
+  // save) leaves an unsaved context draft intact. Skipped once after an
+  // immediate delete, which has already reconciled the draft (see deleteSection).
   useEffect(() => {
+    if (skipContextRebaselineRef.current) {
+      skipContextRebaselineRef.current = false;
+      return;
+    }
     setFilesDraft(contextSectionsFromFiles(context.files));
     setContextIndex(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -289,6 +299,11 @@ export function EditDefaultsPanel({
 
     setPending(true);
     setFormError("");
+    // The draft above is already the post-delete state (deleted file dropped,
+    // every other unsaved edit kept); suppress the re-baseline that this delete's
+    // own refetch will fire so it doesn't overwrite those edits with the server
+    // baseline. Cleared on failure so a real refetch still re-baselines.
+    skipContextRebaselineRef.current = true;
     try {
       await saveContext.mutateAsync({
         username: viewer.username,
@@ -297,6 +312,7 @@ export function EditDefaultsPanel({
       });
     } catch (error) {
       // Persist failed — restore the section so the UI matches disk.
+      skipContextRebaselineRef.current = false;
       setFilesDraft(prevDraft);
       setContextIndex(prevIndex);
       setFormError(error instanceof Error ? error.message : String(error));

--- a/web/src/app/features/gsv-console/components/GsvConsole.tsx
+++ b/web/src/app/features/gsv-console/components/GsvConsole.tsx
@@ -468,7 +468,12 @@ export function GsvConsole({
               onDetailChange={setSettingsConfigDetail}
             />
           ) : settingsRoute.view === "crew" ? (
-            <ConsoleCrewPage onManageAgent={openSettingsAgent} onCreateAgent={openSettingsNewAgent} />
+            <ConsoleCrewPage
+              onManageAgent={openSettingsAgent}
+              // Route through the unsaved guard: NEW AGENT unmounts the in-body
+              // defaults editor, so a dirty draft must prompt before it's dropped.
+              onCreateAgent={() => guardedSettingsNavigate({ view: "agent", accountUid: null, createNew: true })}
+            />
           ) : (
             <ConsoleAgentPage
               accountUid={settingsRoute.accountUid}

--- a/web/src/app/features/gsv-console/components/GsvConsole.tsx
+++ b/web/src/app/features/gsv-console/components/GsvConsole.tsx
@@ -7,6 +7,7 @@ import { TerminalPage } from "../../terminal/TerminalPage";
 import {
   shellSurfaceLabel,
   type DesktopObjectId,
+  type ShellFilesRoute,
   type ShellLibraryRoute,
   type ShellSettingsRoute,
   type ShellSurfaceId,
@@ -31,6 +32,7 @@ type GsvConsoleProps = {
   onClose?: () => void;
   libraryRoute?: ShellLibraryRoute;
   onLibraryRouteChange?: (route: ShellLibraryRoute) => void;
+  filesRoute?: ShellFilesRoute;
   onOpenSurface?: (surface: Exclude<ShellSurfaceId, "desktop">) => void;
   onOpenSectionCreate?: (kind: DesktopObjectId) => void;
   onOpenChat?: () => void;
@@ -174,6 +176,7 @@ function settingsRouteTail(route: SettingsRoute): string {
 export function GsvConsole({
   activeSurface,
   libraryRoute = { view: "index" },
+  filesRoute,
   onBackToDesktop,
   onClose,
   onLibraryRouteChange,
@@ -497,7 +500,7 @@ export function GsvConsole({
             onRouteChange={onLibraryRouteChange}
           />
         ) : activeSurface === "files" ? (
-          <FilesPage />
+          <FilesPage filesRoute={filesRoute} />
         ) : activeSurface === "repositories" ? (
           <RepositoriesPage />
         ) : activeSurface === "terminal" ? (

--- a/web/src/app/features/gsv-console/domain/consoleAgentBehavior.ts
+++ b/web/src/app/features/gsv-console/domain/consoleAgentBehavior.ts
@@ -3,6 +3,7 @@ import { approvalTargetFromValue } from "../../../domain/agentApproval";
 import {
   defaultModelLabelForConfig,
   modelProfileOptionValue,
+  modelProfileSummary,
   modelProfilesForConfig,
   modelOptionForValue,
   type ConsoleModelProfile,
@@ -342,6 +343,80 @@ export function parseApprovalPolicy(raw: string): ApprovalPolicy {
 
 export function serializeApprovalPolicy(policy: ApprovalPolicy): string {
   return JSON.stringify({ default: policy.default, rules: policy.rules });
+}
+
+export function normalizedApprovalPolicy(raw: string): string {
+  return serializeApprovalPolicy(parseApprovalPolicy(raw));
+}
+
+/** Empty string when the draft equals the inherited policy — writing "" keeps
+ *  the account on inheritance instead of materializing an identical override. */
+export function approvalOverrideForInheritedPolicy(draftApproval: string, inheritedApproval: string): string {
+  const normalizedDraft = normalizedApprovalPolicy(draftApproval);
+  const normalizedInherited = normalizedApprovalPolicy(inheritedApproval);
+  return normalizedDraft === normalizedInherited ? "" : normalizedDraft;
+}
+
+export function approvalForAgentSave(
+  draftApproval: string,
+  behavior: ConsoleAgentBehavior,
+): string {
+  return behavior.approvalInherited
+    ? approvalOverrideForInheritedPolicy(draftApproval, behavior.approval)
+    : normalizedApprovalPolicy(draftApproval);
+}
+
+/** Fallback-model Select options for an account: "Inherit" first, then the
+ *  account's + owner's model profiles, then a stored-but-unknown selection. */
+export function fallbackModelOptionsForAccount(
+  config: readonly ConsoleConfigEntry[],
+  uid: number | null,
+  ownerUid: number | null,
+  selectedValue: string,
+  inheritedLabel: string,
+): ConsoleModelOption[] {
+  const inherited = inheritedLabel.trim();
+  const options: ConsoleModelOption[] = [{
+    value: "",
+    label: inherited ? `Inherit: ${inherited}` : "Inherit fallback",
+    description: inherited ? "Uses the inherited fallback model." : "No fallback override.",
+  }];
+  const seen = new Set([""]);
+
+  const addProfileOptions = (profileUid: number | null) => {
+    if (profileUid === null || !Number.isFinite(profileUid)) {
+      return;
+    }
+    for (const profile of modelProfilesForConfig(config, profileUid)) {
+      const value = modelProfileOptionValue(profile.id);
+      const key = value.trim().toLowerCase();
+      if (!value || seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      options.push({
+        value,
+        label: profile.name,
+        description: modelProfileSummary(profile),
+      });
+    }
+  };
+
+  addProfileOptions(uid);
+  if (ownerUid !== uid) {
+    addProfileOptions(ownerUid);
+  }
+
+  const selected = selectedValue.trim();
+  if (selected && !seen.has(selected.toLowerCase())) {
+    options.push({
+      value: selected,
+      label: selected.replace(/^model-profile:/i, ""),
+      description: "Stored fallback model is not currently available.",
+    });
+  }
+
+  return options;
 }
 
 function configValue(config: readonly ConsoleConfigEntry[], key: string): string {

--- a/web/src/app/features/gsv-console/list-template/ListTemplate.css
+++ b/web/src/app/features/gsv-console/list-template/ListTemplate.css
@@ -22,9 +22,47 @@
   min-height: 0;
   display: grid;
   grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  grid-template-areas: "action list";
   /* Big screens: center the action+list column to the reading cap; the panel
      border and the header divider above still span full width. */
   padding-inline: var(--gsv-gutter);
+}
+
+/* With an actionExtra block the left column splits into two rows (controls,
+   then the extra section); the list spans both. */
+.gsv-list-template-body[data-extra="true"] {
+  grid-template-areas:
+    "action list"
+    "extra list";
+  grid-template-rows: auto 1fr;
+}
+
+/* scrollBody: bound the template to the available height and scroll the list
+   column (and the action-extra) independently, so the action controls stay
+   anchored while the body scrolls (e.g. clicking a DEFAULTS row scrolls the
+   editor to a section without moving the action column). Opt-in — other list
+   pages keep their whole-page scroll. */
+.gsv-list-template.is-scroll-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+  margin-bottom: 0;
+  overflow: hidden;
+}
+
+.gsv-list-template.is-scroll-body .gsv-list-template-body {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.gsv-list-template.is-scroll-body .gsv-list-template-list {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.gsv-list-template.is-scroll-body .gsv-list-template-action-extra {
+  min-height: 0;
+  overflow-y: auto;
 }
 
 /* The title bar is a full-width strip — only its inner content indents to the
@@ -35,6 +73,7 @@
 }
 
 .gsv-list-template-action,
+.gsv-list-template-action-extra,
 .gsv-list-template-list {
   min-width: 0;
   min-height: 0;
@@ -42,11 +81,30 @@
   flex-direction: column;
 }
 
+.gsv-list-template-action {
+  grid-area: action;
+}
+
+.gsv-list-template-list {
+  grid-area: list;
+  /* The column divider lives on the list (border-left) rather than the action
+     column (border-right) so it spans full height even when the left column
+     splits into action + extra rows. Same pixel position either way. */
+  border-left: 1px solid var(--rule-section);
+}
+
 /* Action column: stacked controls, connect-new pinned to the bottom. */
 .gsv-list-template-action {
-  border-right: 1px solid var(--rule-section);
   gap: 16px;
   padding: 16px;
+}
+
+/* Extra block under the action controls (e.g. CREW's defaults card). No
+   padding: card content runs flush to the column's vertical divider/edges so
+   its rules and the template lines touch (settings-template treatment). */
+.gsv-list-template-action-extra {
+  grid-area: extra;
+  padding: 0;
 }
 
 .gsv-list-template-search,
@@ -99,14 +157,28 @@
      without this the grid stretches the bar to half the height. */
   .gsv-list-template-body {
     grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: "action" "list";
     grid-template-rows: auto 1fr;
+  }
+
+  /* Extra block becomes a full-width strip between the action bar and list. */
+  .gsv-list-template-body[data-extra="true"] {
+    grid-template-areas: "action" "extra" "list";
+    grid-template-rows: auto auto 1fr;
+  }
+
+  .gsv-list-template-list {
+    border-left: 0;
+  }
+
+  .gsv-list-template-action-extra {
+    border-bottom: 1px solid var(--rule-section);
   }
 
   .gsv-list-template-action {
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;
-    border-right: 0;
     border-bottom: 1px solid var(--rule-section);
   }
 

--- a/web/src/app/features/gsv-console/list-template/ListTemplate.tsx
+++ b/web/src/app/features/gsv-console/list-template/ListTemplate.tsx
@@ -11,7 +11,9 @@ import "./ListTemplate.css";
 
 export type ListTemplateRow = {
   id: string;
-  icon: string;
+  icon?: string;
+  /** Custom leading node (e.g. an Avatar); takes precedence over `icon`. */
+  leading?: ComponentChildren;
   label: string;
   sub: string;
   tone: StatusTone;
@@ -42,6 +44,16 @@ type ListTemplateProps = {
   search?: ListTemplateSearch;
   /** Optional filter controls (Selects, chips). */
   filters?: ComponentChildren;
+  /** Optional extra content rendered below the action controls (wide: under the
+   *  action column; narrow: a full-width block between the action bar and list). */
+  actionExtra?: ComponentChildren;
+  /** When set, replaces the list column content (rows / empty state) — e.g. an
+   *  in-body editor surface with its own close affordance. */
+  listContent?: ComponentChildren;
+  /** Bounds the template to the viewport and scrolls the list column (and the
+   *  action-extra) independently, so the action controls stay anchored. Opt-in
+   *  so other list pages keep their whole-page scroll. */
+  scrollBody?: boolean;
 };
 
 function ListTemplateRowView({ row }: { row: ListTemplateRow }) {
@@ -49,6 +61,7 @@ function ListTemplateRowView({ row }: { row: ListTemplateRow }) {
     <div class="gsv-list-template-row">
       <ListRow
         icon={row.icon}
+        leading={row.leading}
         label={row.label}
         sub={row.sub}
         status={listRowStatusForTone(row.tone) as ListRowStatus}
@@ -74,13 +87,19 @@ export function ListTemplate({
   onConnect,
   search,
   filters,
+  actionExtra,
+  listContent,
+  scrollBody = false,
 }: ListTemplateProps) {
   // Action-bar arrangement keys off how many controls are present (connect is
   // always there): 1 → centered, 2 → inline, 3 → search row then filter+connect.
   const actionCount = 1 + (search ? 1 : 0) + (filters ? 1 : 0);
 
   return (
-    <div class="gsv-list-template" aria-label={`${listTitle} list`}>
+    <div
+      class={`gsv-list-template${scrollBody ? " is-scroll-body" : ""}`}
+      aria-label={`${listTitle} list`}
+    >
       <SectionHeader
         className="gsv-list-template-header"
         title={listTitle}
@@ -88,7 +107,7 @@ export function ListTemplate({
         divider
         headingLevel={2}
       />
-      <div class="gsv-list-template-body">
+      <div class="gsv-list-template-body" data-extra={actionExtra ? "true" : undefined}>
         <section class="gsv-list-template-action" data-actions={actionCount}>
           {search ? (
             <div class="gsv-list-template-search">
@@ -107,8 +126,14 @@ export function ListTemplate({
           </div>
         </section>
 
+        {actionExtra ? (
+          <section class="gsv-list-template-action-extra">{actionExtra}</section>
+        ) : null}
+
         <section class="gsv-list-template-list">
-          {rows.length === 0 ? (
+          {listContent != null ? (
+            listContent
+          ) : rows.length === 0 ? (
             <TemplateEmptyState object={emptyObject} />
           ) : (
             rows.map((row) => <ListTemplateRowView key={row.id} row={row} />)

--- a/web/src/app/features/gsv-console/pages/ConsoleAgentPage.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleAgentPage.tsx
@@ -24,20 +24,19 @@ import type {
 } from "../domain/consoleModels";
 import {
   modelOptionsForConfig,
-  modelProfileOptionValue,
-  modelProfileSummary,
-  modelProfilesForConfig,
   type ConsoleModelOption,
 } from "../domain/consoleAi";
 import {
+  approvalForAgentSave,
+  approvalOverrideForInheritedPolicy,
   behaviorForAccount,
   defaultApprovalPolicyForConfig,
+  fallbackModelOptionsForAccount,
   inheritedFallbackModelLabelForAccount,
   inheritedModelLabelForAccount,
   inheritedReasoningForAccount,
   modelOptionsForAccount,
-  parseApprovalPolicy,
-  serializeApprovalPolicy,
+  normalizedApprovalPolicy,
 } from "../domain/consoleAgentBehavior";
 import {
   avatarForAccount,
@@ -384,25 +383,6 @@ function agentDraftToCreateInput(draft: AgentEditorDraft, defaultApprovalPolicy:
   };
 }
 
-function normalizedApprovalPolicy(raw: string): string {
-  return serializeApprovalPolicy(parseApprovalPolicy(raw));
-}
-
-function approvalOverrideForInheritedPolicy(draftApproval: string, inheritedApproval: string): string {
-  const normalizedDraft = normalizedApprovalPolicy(draftApproval);
-  const normalizedInherited = normalizedApprovalPolicy(inheritedApproval);
-  return normalizedDraft === normalizedInherited ? "" : normalizedDraft;
-}
-
-function approvalForAgentSave(
-  draftApproval: string,
-  behavior: ReturnType<typeof behaviorForAccount>,
-): string {
-  return behavior.approvalInherited
-    ? approvalOverrideForInheritedPolicy(draftApproval, behavior.approval)
-    : normalizedApprovalPolicy(draftApproval);
-}
-
 function approvalSourceLabel(editsUserDefaults: boolean, inherited: boolean): string {
   if (editsUserDefaults) return "Your default";
   return inherited ? "Inherited default" : "Agent override";
@@ -415,57 +395,6 @@ function modelOptionsKey(options: readonly AgentEditorModelOption[]): string {
     }
     return `${option.value ?? ""}:${option.label}:${option.description ?? ""}`;
   }).join("\u0000");
-}
-
-function fallbackModelOptionsForAccount(
-  config: readonly ConsoleConfigEntry[],
-  uid: number | null,
-  ownerUid: number | null,
-  selectedValue: string,
-  inheritedLabel: string,
-): AgentEditorModelOption[] {
-  const inherited = inheritedLabel.trim();
-  const options: AgentEditorModelOption[] = [{
-    value: "",
-    label: inherited ? `Inherit: ${inherited}` : "Inherit fallback",
-    description: inherited ? "Uses the inherited fallback model." : "No fallback override.",
-  }];
-  const seen = new Set([""]);
-
-  const addProfileOptions = (profileUid: number | null) => {
-    if (profileUid === null || !Number.isFinite(profileUid)) {
-      return;
-    }
-    for (const profile of modelProfilesForConfig(config, profileUid)) {
-      const value = modelProfileOptionValue(profile.id);
-      const key = value.trim().toLowerCase();
-      if (!value || seen.has(key)) {
-        continue;
-      }
-      seen.add(key);
-      options.push({
-        value,
-        label: profile.name,
-        description: modelProfileSummary(profile),
-      });
-    }
-  };
-
-  addProfileOptions(uid);
-  if (ownerUid !== uid) {
-    addProfileOptions(ownerUid);
-  }
-
-  const selected = selectedValue.trim();
-  if (selected && !seen.has(selected.toLowerCase())) {
-    options.push({
-      value: selected,
-      label: selected.replace(/^model-profile:/i, ""),
-      description: "Stored fallback model is not currently available.",
-    });
-  }
-
-  return options;
 }
 
 function agentToolTargetsForConsoleTargets(targets: readonly ConsoleTarget[]): AgentToolTarget[] {

--- a/web/src/app/features/gsv-console/pages/ConsoleConfigPage.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleConfigPage.tsx
@@ -908,6 +908,7 @@ function ToolApprovalSettingsGroup({
         sourceLabel="System fallback"
         targets={targets}
         disabled={!editable || pending}
+        defaultDescription="When there are no overrides configured, all your agents will follow the default permission when using any tool. Overrides are machine or tool specific rules that take priority over the default action."
         onChange={(nextPolicy) => {
           setPolicy(nextPolicy);
           setStatusText("");

--- a/web/src/app/features/gsv-console/pages/ConsoleCrewPage.css
+++ b/web/src/app/features/gsv-console/pages/ConsoleCrewPage.css
@@ -1,98 +1,12 @@
+/* CREW — same ListTemplate chrome as INTEGRATIONS/APPLICATIONS; this wrapper
+   only stretches the template and hosts the width probe for the defaults
+   panel's narrow-mode disclosure. */
 .gsv-console-crew {
-  position: relative;
-  flex: 1;
-  min-height: 100%;
-  overflow: hidden;
-  background: var(--void);
-}
-
-.gsv-console-crew::before,
-.gsv-console-crew::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
-
-.gsv-console-crew::before {
-  z-index: 0;
-  background-image:
-    linear-gradient(rgba(150, 140, 255, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(150, 140, 255, 0.04) 1px, transparent 1px);
-  background-size: 46px 46px;
-}
-
-.gsv-console-crew::after {
-  z-index: 1;
-  background:
-    radial-gradient(circle at 16% 13%, rgba(182, 177, 255, 0.12), transparent 1px),
-    radial-gradient(circle at 62% 8%, rgba(205, 213, 230, 0.12), transparent 1px),
-    radial-gradient(circle at 85% 30%, rgba(182, 177, 255, 0.1), transparent 1px),
-    radial-gradient(circle at 40% 52%, rgba(205, 213, 230, 0.11), transparent 1px),
-    radial-gradient(circle at 22% 78%, rgba(182, 177, 255, 0.09), transparent 1px);
-}
-
-.gsv-console-crew-panel {
-  position: relative;
-  z-index: 2;
-  min-width: 0;
-  min-height: 100%;
-  border: 1px solid var(--border-raised);
-  background: rgba(9, 7, 26, 0.72);
-  box-shadow: inset 0 0 0 1px #060414, 0 0 30px rgba(80, 70, 180, 0.1);
-  /* respond to the panel's own width (console column), not the viewport */
-  container-type: inline-size;
-  container-name: crew;
-}
-
-.gsv-console-crew-grid {
-  min-width: 0;
-  display: grid;
-  /* min(312px,100%) lets the track shrink below 312 in a narrow console
-     column (e.g. ChatDock open) instead of forcing horizontal scroll. */
-  grid-template-columns: repeat(auto-fill, minmax(min(312px, 100%), 1fr));
-  align-items: stretch;
-  gap: 22px;
-  padding: 26px;
-}
-
-.gsv-console-crew-card-shell {
-  min-width: 0;
-  min-height: 430px;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  box-shadow: 0 0 22px rgba(60, 52, 150, 0.12);
-}
-
-.gsv-console-crew-card-shell {
   display: flex;
   flex-direction: column;
-}
-
-.gsv-console-crew-card-shell[data-clickable="true"] {
-  cursor: pointer;
-  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
-}
-
-.gsv-console-crew-card-shell[data-clickable="true"]:hover,
-.gsv-console-crew-card-shell[data-clickable="true"]:focus-visible {
-  border-color: var(--primary-hi);
-  box-shadow: 0 0 28px rgba(150, 140, 255, 0.2);
-  outline: none;
-}
-
-.gsv-console-crew-card-shell[data-clickable="true"]:active {
-  transform: translateY(1px);
-}
-
-.gsv-console-crew-card-shell > div:first-child {
-  flex: 1 1 auto;
-}
-
-@container crew (max-width: 680px) {
-  .gsv-console-crew-grid {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 16px;
-    padding: 16px;
-  }
+  flex: 1;
+  /* Bounded (not min-height:100%) so the template's is-scroll-body child fills
+     and scrolls internally instead of growing the console stage. */
+  min-height: 0;
+  min-width: 0;
 }

--- a/web/src/app/features/gsv-console/pages/ConsoleCrewPage.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleCrewPage.tsx
@@ -1,29 +1,23 @@
-import type { JSX } from "preact";
-import { useMemo, useState } from "preact/hooks";
-import { AgentCard, type AgentTask } from "../../../components/ui/AgentCard";
-import type { AvatarStatus } from "../../../components/ui/Avatar";
-import { CardListTemplate } from "../card-template/CardListTemplate";
+import { useLayoutEffect, useRef, useState } from "preact/hooks";
+import { Avatar, type AvatarStatus } from "../../../components/ui/Avatar";
+import type { AgentToolTarget } from "../../../components/ui/agentToolApprovalOptions";
+import { CrewDefaultsPanel } from "../components/CrewDefaultsPanel";
+import { EditDefaultsPanel, type EditDefaultsSection } from "../components/EditDefaultsPanel";
 import {
   ConsolePage,
   ConsoleResourceBoundary,
 } from "../components/ConsolePageTemplate";
+import { ListTemplate, type ListTemplateRow } from "../list-template/ListTemplate";
 import type {
   ConsoleAccount,
   ConsoleConfigEntry,
   ConsoleProcess,
   ConsoleResourceState,
+  ConsoleTarget,
 } from "../domain/consoleModels";
-import { modelLabelsForConfig } from "../domain/consoleAi";
-import {
-  behaviorForAccount,
-  inheritedModelLabelForAccount,
-  modelLabelsForAccount,
-  type AgentApprovalAction,
-} from "../domain/consoleAgentBehavior";
 import {
   avatarForAccount,
   isConsoleAgentAccount,
-  isHumanCrewAccount,
   labelForConsoleAccountRelation,
   orderedCrewAccounts,
 } from "../domain/agentPresentation";
@@ -31,24 +25,13 @@ import {
   useConsoleAccounts,
   useConsoleConfig,
   useConsoleProcesses,
+  useConsoleTargets,
 } from "../hooks/useConsoleData";
 import "./ConsoleCrewPage.css";
 
-type CrewCardModel = {
-  account: ConsoleAccount;
-  processes: ConsoleProcess[];
-  imageSrc: string;
-  displayName: string;
-  role: string;
-  description: string;
-  status: AvatarStatus;
-  tasks: AgentTask[];
-  active: boolean;
-  model: string;
-  modelIsDefault: boolean;
-  modelOptions: string[];
-  permission: AgentApprovalAction;
-};
+/* The defaults panel collapses to a disclosure once the template's action
+   column folds into the horizontal bar (ListTemplate's container breakpoint). */
+const COMPACT_BREAKPOINT = 1024;
 
 type ConsoleCrewPageProps = {
   onManageAgent?: (uid: number) => void;
@@ -59,9 +42,10 @@ export function ConsoleCrewPage({ onManageAgent, onCreateAgent }: ConsoleCrewPag
   const accounts = useConsoleAccounts();
   const config = useConsoleConfig();
   const processes = useConsoleProcesses();
+  const targets = useConsoleTargets();
 
   return (
-    <ConsolePage flush>
+    <ConsolePage flush className="is-bounded">
       <ConsoleResourceBoundary
         resource={accounts.resource}
         emptyLabel="NO CREW ACCOUNTS"
@@ -71,6 +55,7 @@ export function ConsoleCrewPage({ onManageAgent, onCreateAgent }: ConsoleCrewPag
             accounts={data}
             config={config.config}
             processResource={processes.resource}
+            toolTargets={toolTargetsForConsoleTargets(targets.targets)}
             onManageAgent={onManageAgent}
             onCreateAgent={onCreateAgent}
           />
@@ -84,132 +69,102 @@ function CrewRoster({
   accounts,
   config,
   processResource,
+  toolTargets,
   onManageAgent,
   onCreateAgent,
 }: {
   accounts: readonly ConsoleAccount[];
   config: readonly ConsoleConfigEntry[];
   processResource: ConsoleResourceState<ConsoleProcess[]>;
+  toolTargets: readonly AgentToolTarget[];
   onManageAgent?: (uid: number) => void;
   onCreateAgent?: () => void;
 }) {
   const [query, setQuery] = useState("");
-  const processes = processResource.data ?? [];
-  const modelLabels = modelLabelsForConfig(config);
-  // Humans first; agents keep their existing rank order after.
-  const ordered = orderedCrewAccounts(accounts);
-  const ownerUid = viewerAccountForCrew(ordered)?.uid ?? null;
-  const cards = ordered.map((account) => {
-    const human = isHumanCrewAccount(account);
-    // Orb for humans; agents show their persisted portrait (legacy position
-    // fallback for agents created before portraits were fixed).
-    const imageSrc = avatarForAccount(account, config, accounts);
-    return buildCrewCard(account, processes, imageSrc, human, config, modelLabels, ownerUid);
-  });
-  const humanCount = accounts.filter(isHumanCrewAccount).length;
-  const machineCount = accounts.filter(isConsoleAgentAccount).length;
-  const crewMeta = `${humanCount} HUMAN${humanCount === 1 ? "" : "S"} / ${machineCount} MACHINE${machineCount === 1 ? "" : "S"}`;
+  // In-body edit surface: when set, the list column shows the defaults editor
+  // (opened on this section) instead of the roster; ✕ closes back to the list.
+  const [editorSection, setEditorSection] = useState<EditDefaultsSection | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
 
-  const visibleCards = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return q
-      ? cards.filter((card) =>
-          card.displayName.toLowerCase().includes(q) ||
-          card.account.displayName.toLowerCase().includes(q)
-        )
-      : cards;
-  }, [cards, query]);
+  useLayoutEffect(() => {
+    const node = rootRef.current;
+    if (!node) return;
+    const update = () => setWidth(node.clientWidth);
+    update();
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", update);
+      return () => window.removeEventListener("resize", update);
+    }
+    const observer = new ResizeObserver(update);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  const processes = processResource.data ?? [];
+  const agents = orderedCrewAccounts(accounts).filter(isConsoleAgentAccount);
+  const crewMeta = `${agents.length} AGENT${agents.length === 1 ? "" : "S"}`;
+  const viewer = viewerAccountForCrew(accounts);
+  const compact = width > 0 && width <= COMPACT_BREAKPOINT;
+
+  const q = query.trim().toLowerCase();
+  const rows: ListTemplateRow[] = agents
+    .filter((account) => {
+      if (!q) return true;
+      const role = labelForConsoleAccountRelation(account.relation);
+      return account.displayName.toLowerCase().includes(q) || role.toLowerCase().includes(q);
+    })
+    .map((account) => {
+      const owned = processes.filter((process) => ownsProcess(account, process));
+      const unknown = owned.some((process) => process.state === "unknown");
+      const active = owned.some((process) => isRunningProcess(process) || isQueuedProcess(process));
+      const status: AvatarStatus = unknown ? "error" : active ? "live" : "idle";
+      return {
+        id: String(account.uid),
+        leading: (
+          <Avatar src={avatarForAccount(account, config, accounts)} status={status} size={30} cover />
+        ),
+        label: account.displayName,
+        sub: labelForConsoleAccountRelation(account.relation),
+        tone: status,
+        statusLabel: unknown ? "ERROR" : active ? "RUNNING" : "IDLE",
+        onOpen: onManageAgent ? () => onManageAgent(account.uid) : undefined,
+      };
+    });
 
   return (
-    <CardListTemplate
-      listTitle="CREW"
-      listMeta={crewMeta}
-      emptyObject="CREW"
-      isEmpty={visibleCards.length === 0}
-      connectLabel={onCreateAgent ? "NEW AGENT" : undefined}
-      onConnect={onCreateAgent}
-      search={{ value: query, placeholder: "Search crew…", onChange: setQuery }}
-    >
-      {visibleCards.map((card) => (
-        <div
-          class="gsv-console-crew-card-shell"
-          data-clickable={onManageAgent ? "true" : undefined}
-          key={card.account.uid}
-          onClick={onManageAgent ? () => onManageAgent(card.account.uid) : undefined}
-          onKeyDown={onManageAgent ? (event) => handleCardKeyDown(event, card.account.uid, onManageAgent) : undefined}
-          tabIndex={onManageAgent ? 0 : undefined}
-        >
-          <AgentCard
-            agentName={card.displayName}
-            agentRole={card.role}
-            description={card.description}
-            imgSrc={card.imageSrc}
-            status={card.status}
-            initialModel={card.model}
-            initialPermission={card.permission}
-            modelIsDefault={card.modelIsDefault}
-            models={card.modelOptions}
-            tasks={card.tasks}
-            tasksTotal={card.processes.length}
-            active={card.active}
-            avatarCover={!isHumanCrewAccount(card.account)}
-            showActions={false}
-            readOnly
+    <div class="gsv-console-crew" ref={rootRef}>
+      <ListTemplate
+        listTitle="CREW"
+        listMeta={crewMeta}
+        rows={rows}
+        emptyObject="AGENTS"
+        connectLabel="NEW AGENT"
+        onConnect={onCreateAgent}
+        search={{ value: query, placeholder: "Search agents…", onChange: setQuery }}
+        scrollBody
+        actionExtra={viewer ? (
+          <CrewDefaultsPanel
+            viewer={viewer}
+            config={config}
+            compact={compact}
+            onEditDefaults={() => setEditorSection("defaults")}
+            onConfigureOverrides={() => setEditorSection("overrides")}
+            onManageContext={() => setEditorSection("context")}
           />
-        </div>
-      ))}
-    </CardListTemplate>
+        ) : undefined}
+        listContent={viewer && editorSection ? (
+          <EditDefaultsPanel
+            section={editorSection}
+            onClose={() => setEditorSection(null)}
+            viewer={viewer}
+            config={config}
+            targets={toolTargets}
+          />
+        ) : undefined}
+      />
+    </div>
   );
-}
-
-function handleCardKeyDown(
-  event: JSX.TargetedKeyboardEvent<HTMLDivElement>,
-  uid: number,
-  onManageAgent: (uid: number) => void,
-): void {
-  if (event.key !== "Enter" && event.key !== " ") {
-    return;
-  }
-  event.preventDefault();
-  onManageAgent(uid);
-}
-
-function buildCrewCard(
-  account: ConsoleAccount,
-  processes: readonly ConsoleProcess[],
-  imageSrc: string,
-  isHuman: boolean,
-  config: readonly ConsoleConfigEntry[],
-  modelLabels: readonly string[],
-  ownerUid: number | null,
-): CrewCardModel {
-  const ownedProcesses = processes.filter((process) => ownsProcess(account, process));
-  const behavior = behaviorForAccount(config, account.uid, ownerUid);
-  const inheritedModelLabel = inheritedModelLabelForAccount(config, account.uid, ownerUid);
-  const queued = ownedProcesses.some(isQueuedProcess);
-  const running = ownedProcesses.some(isRunningProcess);
-  const unknown = ownedProcesses.some((process) => process.state === "unknown");
-  const role = labelForConsoleAccountRelation(account.relation);
-  // The human is always shown online; agents reflect their process state.
-  const status: AvatarStatus = isHuman
-    ? "online"
-    : unknown ? "error" : running || queued ? "live" : "idle";
-
-  return {
-    account,
-    processes: ownedProcesses,
-    imageSrc,
-    displayName: isHuman ? "Defaults" : account.displayName,
-    role,
-    description: isHuman ? "These are your preferences, applied to all your agents." : accountDescription(account),
-    status,
-    tasks: tasksForProcesses(ownedProcesses),
-    active: account.runnable,
-    model: behavior.modelLabel,
-    modelIsDefault: behavior.model.trim().length === 0,
-    modelOptions: modelLabelsForAccount(modelLabels, behavior.modelLabel || behavior.model, inheritedModelLabel),
-    permission: behavior.permission,
-  };
 }
 
 function viewerAccountForCrew(accounts: readonly ConsoleAccount[]): ConsoleAccount | null {
@@ -217,6 +172,15 @@ function viewerAccountForCrew(accounts: readonly ConsoleAccount[]): ConsoleAccou
     ?? accounts.find((account) => account.uid === 0)
     ?? accounts.find((account) => account.relation === "human")
     ?? null;
+}
+
+function toolTargetsForConsoleTargets(targets: readonly ConsoleTarget[]): AgentToolTarget[] {
+  return targets.map((target) => ({
+    id: target.deviceId,
+    label: target.label || target.deviceId,
+    online: target.online,
+    implements: target.implements,
+  }));
 }
 
 function ownsProcess(account: ConsoleAccount, process: ConsoleProcess): boolean {
@@ -229,21 +193,4 @@ function isRunningProcess(process: ConsoleProcess): boolean {
 
 function isQueuedProcess(process: ConsoleProcess): boolean {
   return process.state === "queued" || process.queuedCount > 0;
-}
-
-function tasksForProcesses(processes: readonly ConsoleProcess[]): AgentTask[] {
-  if (processes.length === 0) {
-    return [{ name: "No process activity", status: "idle" }];
-  }
-  return processes.map((process) => ({
-    name: process.label || process.pid,
-    status: process.state === "unknown" ? "error" : isRunningProcess(process) || isQueuedProcess(process) ? "running" : "idle",
-  }));
-}
-
-function accountDescription(account: ConsoleAccount): string {
-  if (account.gecos.trim().length > 0) {
-    return account.gecos;
-  }
-  return `${account.username} / uid ${account.uid}`;
 }

--- a/web/src/app/features/gsv-console/pages/ConsoleCrewPage.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleCrewPage.tsx
@@ -5,6 +5,7 @@ import { CrewDefaultsPanel } from "../components/CrewDefaultsPanel";
 import { EditDefaultsPanel, type EditDefaultsSection } from "../components/EditDefaultsPanel";
 import {
   ConsolePage,
+  ConsolePageState,
   ConsoleResourceBoundary,
 } from "../components/ConsolePageTemplate";
 import { ListTemplate, type ListTemplateRow } from "../list-template/ListTemplate";
@@ -50,16 +51,32 @@ export function ConsoleCrewPage({ onManageAgent, onCreateAgent }: ConsoleCrewPag
         resource={accounts.resource}
         emptyLabel="NO CREW ACCOUNTS"
         errorLabel="CREW"
-        render={(data) => (
-          <CrewRoster
-            accounts={data}
-            config={config.config}
-            processResource={processes.resource}
-            toolTargets={toolTargetsForConsoleTargets(targets.targets)}
-            onManageAgent={onManageAgent}
-            onCreateAgent={onCreateAgent}
-          />
-        )}
+        render={(data) => {
+          // The defaults editor derives its model/fallback/reasoning/approval
+          // baselines from config; an in-flight or errored config would read as
+          // empty and a save could clear persisted overrides (saveBehavior writes
+          // every field with includeEmpty). Gate on config having loaded — but
+          // still render on a legitimately empty (loaded) config.
+          if (config.resource.isUnavailable) {
+            return <ConsolePageState kind="offline" detail="CONNECTION REQUIRED" />;
+          }
+          if (config.resource.isError) {
+            return <ConsolePageState kind="error" detail={config.resource.errorText || "CREW"} />;
+          }
+          if (config.resource.isLoading) {
+            return <ConsolePageState kind="loading" />;
+          }
+          return (
+            <CrewRoster
+              accounts={data}
+              config={config.config}
+              processResource={processes.resource}
+              toolTargets={toolTargetsForConsoleTargets(targets.targets)}
+              onManageAgent={onManageAgent}
+              onCreateAgent={onCreateAgent}
+            />
+          );
+        }}
       />
     </ConsolePage>
   );

--- a/web/src/app/features/gsv-console/pages/ConsoleCrewPage.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleCrewPage.tsx
@@ -149,7 +149,7 @@ function CrewRoster({
             config={config}
             compact={compact}
             onEditDefaults={() => setEditorSection("defaults")}
-            onConfigureOverrides={() => setEditorSection("overrides")}
+            onConfigureOverrides={() => setEditorSection("permissions")}
             onManageContext={() => setEditorSection("context")}
           />
         ) : undefined}

--- a/web/src/app/features/gsv-console/pages/ConsoleOverviewPanels.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleOverviewPanels.tsx
@@ -21,7 +21,6 @@ import type { ConsoleListKind } from "../domain/consoleListTypes";
 import {
   avatarForAccount,
   isConsoleAgentAccount,
-  isHumanCrewAccount,
   orderedCrewAccounts,
 } from "../domain/agentPresentation";
 import type {
@@ -178,23 +177,15 @@ function crewCards(
   processes: readonly ConsoleProcess[],
   config: readonly ConsoleConfigEntry[],
 ): CrewCard[] {
-  const ordered = orderedCrewAccounts(accounts).slice(0, 3);
-  return ordered.map((account) => {
-    const human = isHumanCrewAccount(account);
-    // Human is shown first, online, with the padded orb; agents show their
-    // persisted portrait (legacy position fallback for pre-existing agents).
-    const status = human
-      ? { meta: "you", statusLabel: "ONLINE", tone: "online" as StatusTone }
-      : accountStatus(account, processes);
-    return {
-      id: String(account.uid),
-      accountUid: account.uid,
-      imageSrc: avatarForAccount(account, config, accounts),
-      cover: !human,
-      name: human ? "Defaults" : account.displayName,
-      ...status,
-    };
-  });
+  const ordered = orderedCrewAccounts(accounts).filter(isConsoleAgentAccount).slice(0, 3);
+  return ordered.map((account) => ({
+    id: String(account.uid),
+    accountUid: account.uid,
+    imageSrc: avatarForAccount(account, config, accounts),
+    cover: true,
+    name: account.displayName,
+    ...accountStatus(account, processes),
+  }));
 }
 
 function sortTargets(targets: readonly ConsoleTarget[]): ConsoleTarget[] {
@@ -500,9 +491,8 @@ function CrewPanel({
   processes: readonly ConsoleProcess[];
 }) {
   const cards = crewCards(accounts, processes, config);
-  const humanCount = accounts.filter(isHumanCrewAccount).length;
   const agentCount = accounts.filter(isConsoleAgentAccount).length;
-  const crewMeta = `${humanCount} HUMAN${humanCount === 1 ? "" : "S"} / ${agentCount} AGENT${agentCount === 1 ? "" : "S"}`;
+  const crewMeta = `${agentCount} AGENT${agentCount === 1 ? "" : "S"}`;
 
   return (
     <section class="gsv-settings-block gsv-settings-crew-block">

--- a/web/src/app/features/gsv-shell/GsvShell.tsx
+++ b/web/src/app/features/gsv-shell/GsvShell.tsx
@@ -28,6 +28,7 @@ import { UnsavedGuardProvider, useUnsavedGuardController } from "./unsaved/unsav
 import {
   shellSurfaceLabel,
   type DesktopObjectId,
+  type ShellFilesRoute,
   type ShellLibraryRoute,
   type ShellSettingsRoute,
   type ShellSurfaceId,
@@ -399,6 +400,11 @@ export function GsvShell({
   const activeLibraryRoute: ShellLibraryRoute = shell.activeSurface === "library"
     ? shell.activePageTab?.libraryRoute ?? { view: "index" }
     : { view: "index" };
+  // Unlike Library (which always has a route), bare FILES carries none, so the
+  // default here is undefined — the deep-link entry point onto the surface.
+  const activeFilesRoute: ShellFilesRoute | undefined = shell.activeSurface === "files"
+    ? shell.activePageTab?.filesRoute
+    : undefined;
 
   const railProps = {
     activeSurface: shell.activeSurface,
@@ -526,6 +532,7 @@ export function GsvShell({
                       onLibraryRouteChange={shell.syncActiveLibraryRoute}
                       onSettingsRouteChange={shell.syncActiveSettingsRoute}
                       libraryRoute={activeLibraryRoute}
+                      filesRoute={activeFilesRoute}
                       settingsRoute={activeSettingsRoute}
                     />
                   </div>

--- a/web/src/app/features/gsv-shell/domain/shellModel.ts
+++ b/web/src/app/features/gsv-shell/domain/shellModel.ts
@@ -37,6 +37,7 @@ export type ShellPageTab = {
   icon: string;
   type: string;
   libraryRoute?: ShellLibraryRoute;
+  filesRoute?: ShellFilesRoute;
   settingsRoute?: ShellSettingsRoute;
 };
 
@@ -47,10 +48,15 @@ export type ShellLibraryRoute =
   | { view: "capture"; db: string }
   | { view: "build"; db?: string };
 
+/** A FILES deep link: which target (machine) and which absolute directory to
+ *  open on. Absent (bare /files) restores the default target + client-side tabs. */
+export type ShellFilesRoute = { target: string; path: string };
+
 export type ShellRoute =
   | { surface: "desktop" }
   | { surface: "library"; libraryRoute?: ShellLibraryRoute }
-  | { surface: Exclude<ShellPageSurfaceId, "library">; settingsRoute?: ShellSettingsRoute };
+  | { surface: "files"; filesRoute?: ShellFilesRoute }
+  | { surface: Exclude<ShellPageSurfaceId, "library" | "files">; settingsRoute?: ShellSettingsRoute };
 
 export type DesktopChildRoute = {
   kind: DesktopObjectId;
@@ -260,6 +266,13 @@ export function shellTabForLibraryRoute(route: ShellLibraryRoute): ShellPageTab 
   };
 }
 
+export function shellTabForFilesRoute(route: ShellFilesRoute): ShellPageTab {
+  return {
+    ...shellTabForSurface("files"),
+    filesRoute: route,
+  };
+}
+
 export function shellTabForRoute(route: ShellRoute): ShellPageTab | null {
   if (route.surface === "desktop") {
     return null;
@@ -269,6 +282,9 @@ export function shellTabForRoute(route: ShellRoute): ShellPageTab | null {
   }
   if (route.surface === "library" && route.libraryRoute) {
     return shellTabForLibraryRoute(route.libraryRoute);
+  }
+  if (route.surface === "files" && route.filesRoute) {
+    return shellTabForFilesRoute(route.filesRoute);
   }
   return shellTabForSurface(route.surface);
 }
@@ -285,6 +301,13 @@ export function shellRouteForTab(tab: ShellPageTab): ShellRoute {
       surface: "library",
       libraryRoute: tab.libraryRoute ?? { view: "index" },
     };
+  }
+  if (tab.surface === "files") {
+    // Bare FILES carries no route (default target + client-side tabs); only a
+    // deep-linked tab restores the target + directory.
+    return tab.filesRoute
+      ? { surface: "files", filesRoute: tab.filesRoute }
+      : { surface: "files" };
   }
   return { surface: tab.surface };
 }

--- a/web/src/app/features/gsv-shell/routing/shellRoutes.test.ts
+++ b/web/src/app/features/gsv-shell/routing/shellRoutes.test.ts
@@ -85,4 +85,31 @@ describe("shellRoutes", () => {
       libraryRoute: { view: "build" },
     });
   });
+
+  it("keeps bare /files on the default surface", () => {
+    const route: ShellRoute = { surface: "files" };
+
+    expect(shellRouteToPath(route)).toBe("/files");
+    expect(shellRouteFromLocation(location("/files"))).toEqual(route);
+  });
+
+  it("round-trips files deep-link routes", () => {
+    const route: ShellRoute = {
+      surface: "files",
+      filesRoute: { target: "gsv", path: "/home/jessica/context.d" },
+    };
+
+    expect(shellRouteToPath(route)).toBe("/files/gsv/home/jessica/context.d");
+    expect(shellRouteFromLocation(location("/files/gsv/home/jessica/context.d"))).toEqual(route);
+  });
+
+  it("round-trips files routes with encoded segments", () => {
+    const route: ShellRoute = {
+      surface: "files",
+      filesRoute: { target: "hank linux", path: "/var/My Notes/todo.txt" },
+    };
+
+    expect(shellRouteToPath(route)).toBe("/files/hank%20linux/var/My%20Notes/todo.txt");
+    expect(shellRouteFromLocation(location("/files/hank%20linux/var/My%20Notes/todo.txt"))).toEqual(route);
+  });
 });

--- a/web/src/app/features/gsv-shell/routing/shellRoutes.ts
+++ b/web/src/app/features/gsv-shell/routing/shellRoutes.ts
@@ -1,4 +1,5 @@
 import type {
+  ShellFilesRoute,
   ShellLibraryRoute,
   ShellRoute,
   ShellSettingsListKind,
@@ -146,6 +147,22 @@ function libraryRouteFromParts(parts: readonly string[], search: string): ShellL
   return { view: "reader", db, path: [actionOrPath, ...rest].join("/") };
 }
 
+/** Parse /files/<target>/<path…> into a deep-link route. The target is parts[1]
+ *  and the (absolute) directory is the remaining segments. A bare /files, a
+ *  missing target, or an undecodable segment yields null → the caller opens the
+ *  default FILES surface. */
+function filesRouteFromParts(parts: readonly string[]): ShellFilesRoute | null {
+  const decoded = decodedParts(parts.slice(1));
+  if (!decoded) {
+    return null;
+  }
+  const [target, ...rest] = decoded;
+  if (!target) {
+    return null;
+  }
+  return { target, path: `/${rest.join("/")}` };
+}
+
 export function shellRouteFromLocation(location: Pick<Location, "hash" | "pathname" | "search">): ShellRoute {
   if (isWorkerOwnedPath(location.pathname)) {
     return { surface: "desktop" };
@@ -162,6 +179,11 @@ export function shellRouteFromLocation(location: Pick<Location, "hash" | "pathna
 
   if (parts[0] === "library") {
     return { surface: "library", libraryRoute: libraryRouteFromParts(parts, location.search) };
+  }
+
+  if (parts[0] === "files") {
+    const filesRoute = filesRouteFromParts(parts);
+    return filesRoute ? { surface: "files", filesRoute } : { surface: "files" };
   }
 
   const surface = TOP_LEVEL_SURFACES[parts[0]];
@@ -216,6 +238,16 @@ function formatLibraryRoute(route: ShellLibraryRoute | undefined): string {
   return `/library/${encodeSegment(route.db)}/${path}`;
 }
 
+function formatFilesRoute(route: ShellFilesRoute | undefined): string {
+  if (!route) {
+    return "/files";
+  }
+  const path = route.path.split("/").filter(Boolean).map(encodeSegment).join("/");
+  return path
+    ? `/files/${encodeSegment(route.target)}/${path}`
+    : `/files/${encodeSegment(route.target)}`;
+}
+
 export function shellRouteToPath(route: ShellRoute): string {
   if (route.surface === "desktop") {
     return "/";
@@ -225,6 +257,9 @@ export function shellRouteToPath(route: ShellRoute): string {
   }
   if (route.surface === "library") {
     return formatLibraryRoute(route.libraryRoute);
+  }
+  if (route.surface === "files") {
+    return formatFilesRoute(route.filesRoute);
   }
   if (route.surface === "runtime") {
     return "/tasks";

--- a/web/src/app/features/gsv-shell/styles/gsvShell.css
+++ b/web/src/app/features/gsv-shell/styles/gsvShell.css
@@ -1729,6 +1729,15 @@
   flex-direction: column;
 }
 
+/* Bounded page (CREW): shrink to the console stage instead of growing past it,
+   so a list template's is-scroll-body child fills the stage and scrolls its own
+   body internally — rather than the whole stage scrolling. Overrides the base
+   `flex: 1 0 auto; min-height: 100%` (grow-to-content, whole-page scroll). */
+.gsv-console-page.is-bounded {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .gsv-console-state {
   min-height: 180px;
   border: 1px solid var(--border);

--- a/web/src/design-system/catalog.tsx
+++ b/web/src/design-system/catalog.tsx
@@ -72,6 +72,7 @@ import agentCard from "./stories/AgentCard.story";
 import crewTile from "./stories/CrewTile.story";
 import agentEditor from "./stories/AgentEditor.story";
 import agentToolsPanel from "./stories/AgentToolsPanel.story";
+import contextSectionsEditor from "./stories/ContextSectionsEditor.story";
 import link from "./stories/Link.story";
 
 const STORIES: Story[] = [
@@ -137,6 +138,7 @@ const STORIES: Story[] = [
   crewTile,
   agentEditor,
   agentToolsPanel,
+  contextSectionsEditor,
   // Templates — generic page archetypes: wireframe + live preview of the real
   // component at /design/preview/<id> (see previews.tsx)
   listTemplate,

--- a/web/src/design-system/stories/AgentToolsPanel.story.tsx
+++ b/web/src/design-system/stories/AgentToolsPanel.story.tsx
@@ -41,7 +41,7 @@ function PolicyPanel({
 const story: Story = {
   title: "Agent Tools Panel",
   group: "Composite",
-  blurb: "tool approval policy · ALLOW/ASK/BLOCK default · per-tool overrides with machine scope · composes Segmented/Select/InfoTip",
+  blurb: "tool approval policy · ALLOW/ASK/BLOCK default · read-only overrides w/ pencil-edit + ✕ · new rule pins on top (one at a time) · composes Segmented/Select/InfoTip",
   render: () => (
     <div class="ds-col">
       <div class="ds-cell">

--- a/web/src/design-system/stories/AgentToolsPanel.story.tsx
+++ b/web/src/design-system/stories/AgentToolsPanel.story.tsx
@@ -41,7 +41,7 @@ function PolicyPanel({
 const story: Story = {
   title: "Agent Tools Panel",
   group: "Composite",
-  blurb: "tool approval policy · ALLOW/ASK/BLOCK default · read-only overrides w/ pencil-edit + ✕ · new rule pins on top (one at a time) · composes Segmented/Select/InfoTip",
+  blurb: "tool approval policy · ALLOW/ASK/BLOCK default · read-only overrides w/ pencil-edit + ✕ · new rule pins on top, one row open at a time · composes Segmented/Select/InfoTip",
   render: () => (
     <div class="ds-col">
       <div class="ds-cell">

--- a/web/src/design-system/stories/ContextSectionsEditor.story.tsx
+++ b/web/src/design-system/stories/ContextSectionsEditor.story.tsx
@@ -1,0 +1,53 @@
+import { useState } from "preact/hooks";
+import { Button } from "../../app/components/ui/Button";
+import {
+  ContextSectionsEditor,
+  type ContextSection,
+} from "../../app/components/ui/ContextSectionsEditor";
+import type { Story } from "../story";
+
+const SEED: ContextSection[] = [
+  { label: "About you", name: "10-about-you.md", content: "# About you\n\nName: Jessica\nRole: Captain" },
+  { label: "Active projects", name: "20-active-projects.md", content: "# Active projects\n\n- GSV console\n- Nav IA" },
+];
+
+function EditorDemo({ initial, readOnly }: { initial: ContextSection[]; readOnly?: boolean }) {
+  const [files, setFiles] = useState<ContextSection[]>(initial);
+  const [active, setActive] = useState(0);
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <ContextSectionsEditor
+        files={files}
+        onChange={setFiles}
+        activeIndex={active}
+        onActiveIndexChange={setActive}
+        readOnly={readOnly}
+        actions={<Button variant="primary" label="SAVE" disabled />}
+      />
+    </div>
+  );
+}
+
+const story: Story = {
+  title: "Context Sections Editor",
+  group: "Composite",
+  blurb: "markdown context sections · file tabs + NEW SECTION · rename · content editor · per-section DELETE · host actions slot",
+  render: () => (
+    <div class="ds-col">
+      <div class="ds-cell">
+        <div class="ds-label">Sections (add / rename / delete)</div>
+        <EditorDemo initial={SEED} />
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Empty (no sections yet)</div>
+        <EditorDemo initial={[]} />
+      </div>
+      <div class="ds-cell">
+        <div class="ds-label">Read-only</div>
+        <EditorDemo initial={SEED} readOnly />
+      </div>
+    </div>
+  ),
+};
+
+export default story;

--- a/web/src/design-system/stories/IconButton.story.tsx
+++ b/web/src/design-system/stories/IconButton.story.tsx
@@ -1,12 +1,12 @@
 import { IconButton, type IconButtonGlyph } from "../../app/components/ui/IconButton";
 import type { Story } from "../story";
 
-const GLYPHS: IconButtonGlyph[] = ["back", "arrowBack", "menu", "max", "min", "close", "plus", "help", "attention", "refresh", "newTab", "attach", "transcribe", "mic", "send", "stop", "sidepanel"];
+const GLYPHS: IconButtonGlyph[] = ["back", "arrowBack", "menu", "max", "min", "close", "plus", "help", "attention", "refresh", "newTab", "attach", "transcribe", "mic", "send", "stop", "sidepanel", "edit"];
 
 const story: Story = {
   title: "IconButton",
   group: "Chrome",
-  blurb: "back · arrowBack · menu · max · min · close · plus · help · attention · refresh · newTab · attach · transcribe · mic · send · stop · sidepanel",
+  blurb: "back · arrowBack · menu · max · min · close · plus · help · attention · refresh · newTab · attach · transcribe · mic · send · stop · sidepanel · edit",
   render: () => (
     <div class="ds-col">
       <div class="ds-cell">


### PR DESCRIPTION
## Summary

Rebuilds the CREW page (`/crew`, `/settings/crew`) onto the shared `ListTemplate` with an in-body defaults editor, plus the surrounding extraction/DS work.

## What changed
- **CREW page** → shared `ListTemplate`: agents-only rows, a **DEFAULTS** summary card in the action column, and an in-body `EditDefaultsPanel` that replaces the roster (with a `← AGENTS` back link + ✕). Every summary row clicks through to its editor section (model/fallback/reasoning → defaults, PERMISSIONS → overrides, GLOBAL INSTRUCTIONS → context); one unified SAVE persists behavior + approval + context together.
- **Shared `ContextSectionsEditor`** extracted from AgentEditor's CONTEXT tab (file tabs, section name + content editor, per-section delete w/ confirm). AgentEditor now consumes it via an `actions` slot.
- **`AgentToolsPanel`** restructured: `DEFAULT PERMISSIONS` section title + description, `TOOL APPROVAL` and `OVERRIDES` as field labels (matching the create-agent form rhythm), `ADD OVERRIDE` link, context-aware default copy, shared `agentToolApprovalOptions`.
- **`ListTemplate`** gained opt-in `scrollBody` (bounded scroll chain so the list body scrolls while the action column stays anchored), plus `listContent` / `actionExtra` / `leading` slots.
- **Mobile**: compact DEFAULTS disclosure with auto-collapse on open, 44px tap targets, responsive reflow at 1024/480, no horizontal overflow.
- **a11y / DS**: restored ListRow focus ring (removed a stray `!important` override), `Segmented` `ariaLabel`, `IconButton` `edit` glyph, tokenized `ContextSectionsEditor` colors.

## Testing
- tsc clean · production build succeeds · **280/280 tests pass**
- Pre-PR design-system-parity and mobile-support audits completed; findings addressed (Drawer removed, focus ring, tap targets, tokenization, class-namespace cleanup).
- Live-verified in the DS catalog at desktop + mobile widths.

## Known non-issue
`ChatTranscript.test.ts` fails at import (DOMPurify `addHook` under vitest) — **pre-existing on `main`, unrelated** to this branch.