### PR TITLE
Console + machines papercuts: tooltips, required fields, unique names, detail footer

### DIFF
--- a/web/src/app/components/ui/AgentEditor.tsx
+++ b/web/src/app/components/ui/AgentEditor.tsx
@@ -54,6 +54,9 @@ export interface AgentEditorProps {
   behaviorReadOnly?: boolean;
   filesReadOnly?: boolean;
   initialTab?: AgentEditorTab;
+  /** Names/usernames already in use — a new agent whose name collides is blocked
+   *  (case-insensitive). Exclude the agent being edited when in "manage" mode. */
+  reservedNames?: readonly string[];
   onTabChange?: (tab: AgentEditorTab) => void;
   onCreate?: (draft: AgentEditorDraft) => Promise<void> | void;
   onSave?: (draft: AgentEditorDraft) => Promise<void> | void;
@@ -504,6 +507,14 @@ export function AgentEditor(props: AgentEditorProps) {
   const nameDisplay = name || "NEW AGENT";
   const roleDisplay = role || "UNASSIGNED ROLE";
 
+  // A new agent whose name collides with an existing name/username is blocked
+  // (case-insensitive). Compared inline to keep this shared component free of
+  // feature imports; the caller supplies the reserved list.
+  const nameNeedle = name.trim().toLowerCase();
+  const duplicateName = nameNeedle.length > 0 &&
+    (props.reservedNames ?? []).some((reserved) => reserved.trim().toLowerCase() === nameNeedle);
+  const createReady = name.trim().length > 0 && !duplicateName;
+
   // ---- handlers ----
   const onContent = (e: Event) => {
     if (!filesReadOnly) {
@@ -688,6 +699,8 @@ export function AgentEditor(props: AgentEditorProps) {
                       size="large"
                       label="NAME"
                       requirement="required"
+                      status={duplicateName ? "error" : "none"}
+                      message={duplicateName ? "That name is already in use" : ""}
                       readonly={identityReadOnly}
                     />
                   </div>
@@ -795,7 +808,7 @@ export function AgentEditor(props: AgentEditorProps) {
                         variant="primary"
                         label={pendingAction === "create" ? "CREATING" : "CREATE AGENT"}
                         onClick={onCreate}
-                        disabled={(identityReadOnly && behaviorReadOnly) || pendingAction !== null}
+                        disabled={(identityReadOnly && behaviorReadOnly) || pendingAction !== null || !createReady}
                       />
                     ) : (
                       <div style="display:flex;gap:12px;">

--- a/web/src/app/components/ui/InfoTip.tsx
+++ b/web/src/app/components/ui/InfoTip.tsx
@@ -1,7 +1,5 @@
-import { useId } from "preact/hooks";
 import { IconButton } from "./IconButton";
-import { POS_CLASS, type TooltipPosition } from "./Tooltip";
-import "./Tooltip.css";
+import { Hint, type TooltipPosition } from "./Tooltip";
 import "./InfoTip.css";
 
 export interface InfoTipProps {
@@ -15,18 +13,16 @@ export interface InfoTipProps {
 
 /** InfoTip — a borderless help icon (circle + "?") that reveals a short hint on
  *  hover/focus. Drop it after a field label to surface extra info. It composes
- *  the IconButton "help" glyph as the trigger inside the tooltip bubble
- *  structure, so there's a single button (unlike Tooltip's children mode, which
- *  would nest a button inside a button). */
+ *  the IconButton "help" glyph as the trigger, wrapped in the portaled `Hint`
+ *  so the bubble escapes any `overflow`-clipping ancestor (a field label row,
+ *  a list row, a scroll container). The `gsv-infotip` wrapper is kept so
+ *  InfoTip.css can align/space the trigger after a label. */
 export function InfoTip({ text, position = "top", label = "More info" }: InfoTipProps) {
-  const bubbleId = useId();
   return (
-    <span class={`gsv-tt ${POS_CLASS[position]} gsv-infotip`}>
-      <IconButton glyph="help" ghost size={16} ariaLabel={label} ariaDescribedBy={bubbleId} />
-      <span class="gsv-tt-bub gsv-sublabel" id={bubbleId} role="tooltip">
-        {text}
-        <span class="gsv-tt-arrow" />
-      </span>
+    <span class="gsv-infotip">
+      <Hint text={text} position={position}>
+        <IconButton glyph="help" ghost size={16} ariaLabel={label} />
+      </Hint>
     </span>
   );
 }

--- a/web/src/app/components/ui/ListRow.tsx
+++ b/web/src/app/components/ui/ListRow.tsx
@@ -1,6 +1,8 @@
 import type { ComponentChildren, JSX } from "preact";
 import { Icon } from "./Icon";
+import { IconButton } from "./IconButton";
 import { Tag, type TagTone } from "./Tag";
+import { Hint } from "./Tooltip";
 import "./ListRow.css";
 
 export type ListRowStatus = "online" | "error" | "idle" | "live" | "none" | "update" | "warn";
@@ -10,6 +12,9 @@ export type ListRowDensity = "default" | "compact";
 export interface ListRowProps {
   className?: string;
   label?: string;
+  /** Optional help tooltip (a "?" InfoTip) rendered after the label — use to
+   *  explain what the row's value means. */
+  labelInfo?: string;
   status?: ListRowStatus;
   statusLabel?: string;
   sub?: string;
@@ -52,6 +57,7 @@ const DOT_COLOR: Record<Exclude<ListRowStatus, "none">, string> = {
 export function ListRow({
   className = "",
   label = "Item",
+  labelInfo,
   status = "online",
   statusLabel = "",
   sub = "",
@@ -129,7 +135,16 @@ export function ListRow({
             color: "var(--text)",
           }}
         >
-          {label}
+          {labelInfo ? (
+            // Portaled Hint (not the in-DOM InfoTip bubble) so the tooltip
+            // escapes the row's `overflow: hidden` clipping.
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px", maxWidth: "100%" }}>
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>{label}</span>
+              <Hint text={labelInfo} position="top">
+                <IconButton glyph="help" ghost size={16} ariaLabel={`About ${label}`} />
+              </Hint>
+            </span>
+          ) : label}
         </div>
         {sub ? (
           <div

--- a/web/src/app/components/ui/MessageMeta.tsx
+++ b/web/src/app/components/ui/MessageMeta.tsx
@@ -1,4 +1,5 @@
 import type { ComponentChildren } from "preact";
+import { CopyGlyph } from "./lineGlyphs";
 import { Hint } from "./Tooltip";
 import "./MessageMeta.css";
 
@@ -48,12 +49,7 @@ export function CopyIconButton({
         aria-label={copyAriaLabel ?? copyLabel}
         onClick={onCopy}
       >
-        <svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true">
-          <g fill="none" stroke="currentColor" stroke-width="1.5">
-            <rect x="3" y="3" width="7" height="7" />
-            <rect x="6" y="6" width="7" height="7" />
-          </g>
-        </svg>
+        <CopyGlyph size={13} />
       </button>
     </Hint>
   );

--- a/web/src/app/components/ui/StatusBar.tsx
+++ b/web/src/app/components/ui/StatusBar.tsx
@@ -3,6 +3,9 @@ export interface StatusBarProps {
   context?: string;
   clock?: string;
   power?: string;
+  /** Tone for the `power` readout. When set, the power word takes its status
+   *  color; otherwise it keeps the neutral lavender. */
+  powerTone?: "online" | "loading" | "offline" | "error";
   statusLabel?: string;
   statusTone?: "online" | "loading" | "offline" | "error";
   /** When set, the bar renders this single line as its content instead of the
@@ -36,6 +39,7 @@ export function StatusBar({
   context = "CTX 50%",
   clock = "14:21:08",
   power = "SYNC",
+  powerTone,
   statusLabel = "GSV ONLINE",
   statusTone = "online",
   label,
@@ -75,7 +79,7 @@ export function StatusBar({
           </div>
           <div style={{ display: "flex", gap: "22px", alignItems: "center" }}>
             <span>{clock}</span>
-            <span style={{ color: "#bbb6ff" }}>{"⏻ "}{power}</span>
+            <span style={{ color: powerTone ? statusColor(powerTone) : "#bbb6ff" }}>{"⏻ "}{power}</span>
           </div>
         </>
       )}

--- a/web/src/app/components/ui/StatusDot.tsx
+++ b/web/src/app/components/ui/StatusDot.tsx
@@ -34,3 +34,36 @@ export function StatusDot({ tone = "online", size = 8, glow }: StatusDotProps) {
     />
   );
 }
+
+/** Status-label text color per tone, mirroring ListRow's treatment: idle stays
+ *  dim (var(--meta)) rather than tinted; every other tone takes its own color. */
+export const STATUS_TEXT: Record<StatusTone, string> = {
+  online: "var(--online)",
+  error: "var(--error)",
+  idle: "var(--meta)",
+  update: "var(--update)",
+  live: "var(--live)",
+  warn: "var(--warn)",
+};
+
+export interface StatusMetaProps {
+  tone: StatusTone;
+  label: string;
+  /** Dot diameter in px. */
+  dotSize?: number;
+}
+
+/** StatusMeta — a tone-colored status word with a leading StatusDot. The shared
+ *  header-level status treatment: used in page headers and section-card headers
+ *  so a status reads the same everywhere (and in step with the list rows). */
+export function StatusMeta({ tone, label, dotSize = 7 }: StatusMetaProps) {
+  return (
+    <span
+      class="gsv-status-meta gsv-sublabel"
+      style={{ display: "inline-flex", alignItems: "center", gap: "8px", letterSpacing: ".16em", color: STATUS_TEXT[tone] }}
+    >
+      <StatusDot tone={tone} size={dotSize} />
+      {label}
+    </span>
+  );
+}

--- a/web/src/app/components/ui/TextArea.tsx
+++ b/web/src/app/components/ui/TextArea.tsx
@@ -18,6 +18,9 @@ export interface TextAreaProps {
   status?: TextAreaStatus;
   message?: string;
   requirement?: TextAreaRequirement;
+  /** When true, reveal the required-empty error immediately (e.g. on a submit
+   *  attempt) even if the field hasn't been blurred yet. */
+  forceValidate?: boolean;
   disabled?: boolean;
   readonly?: boolean;
   maxLength?: number;
@@ -46,6 +49,7 @@ export function TextArea(props: TextAreaProps) {
     status = "none",
     message = "",
     requirement = "none",
+    forceValidate = false,
     disabled = false,
     readonly = false,
     maxLength = 0,
@@ -55,13 +59,24 @@ export function TextArea(props: TextAreaProps) {
 
   const fieldId = useId();
   const [internalValue, setInternalValue] = useState(props.value ?? "");
+  const [blurred, setBlurred] = useState(false);
   const controlled = props.value !== undefined;
 
   const value = controlled ? props.value ?? "" : internalValue;
 
-  const rawStatus = status && status !== "none" ? status : "";
+  // Systemic required enforcement (see TextInput): a required field left empty
+  // shows "REQUIRED" once blurred or on a forced submit-time validation; a
+  // caller-supplied `status` always wins.
+  const requiredEmpty = requirement === "required" && String(value).trim().length === 0;
+  const showRequiredError = requiredEmpty && (blurred || forceValidate);
+  const effectiveStatus: TextAreaStatus =
+    status !== "none" ? status : showRequiredError ? "error" : "none";
+  const effectiveMessage =
+    status !== "none" ? message : showRequiredError ? "REQUIRED" : message;
+
+  const rawStatus = effectiveStatus && effectiveStatus !== "none" ? effectiveStatus : "";
   const statusKey = rawStatus === "warning" ? "warn" : rawStatus;
-  const hasStatusMsg = !!rawStatus && message.length > 0;
+  const hasStatusMsg = !!rawStatus && effectiveMessage.length > 0;
 
   const showCounter = maxLength > 0 && !hasStatusMsg;
   const counterText = maxLength > 0 ? `${String(value).length} / ${maxLength}` : "";
@@ -110,15 +125,19 @@ export function TextArea(props: TextAreaProps) {
         spellcheck={false}
         aria-labelledby={hasLabelRow && label.length > 0 ? `${fieldId}-label` : undefined}
         aria-describedby={describedBy}
-        aria-invalid={status === "error" ? true : undefined}
+        aria-invalid={effectiveStatus === "error" ? true : undefined}
         onInput={(e) => emit((e.target as HTMLTextAreaElement).value)}
+        onBlur={(e) => {
+          setBlurred(true);
+          textareaProps?.onBlur?.(e);
+        }}
       />
       {hasStatusRow ? (
         <div class="gsv-ta-statusrow">
           {hasStatusMsg ? (
             <span class="gsv-ta-right">
               <span class="gsv-ta-dot" />
-              <span class="gsv-ta-msg gsv-sublabel" id={`${fieldId}-msg`}>{message}</span>
+              <span class="gsv-ta-msg gsv-sublabel" id={`${fieldId}-msg`}>{effectiveMessage}</span>
             </span>
           ) : null}
           {showCounter ? <span class="gsv-ta-counter gsv-sublabel">{counterText}</span> : null}

--- a/web/src/app/components/ui/TextInput.tsx
+++ b/web/src/app/components/ui/TextInput.tsx
@@ -17,6 +17,9 @@ export interface TextInputProps {
   status?: TextInputStatus;
   message?: string;
   requirement?: TextInputRequirement;
+  /** When true, reveal the required-empty error immediately (e.g. on a submit
+   *  attempt) even if the field hasn't been blurred yet. */
+  forceValidate?: boolean;
   disabled?: boolean;
   readonly?: boolean;
   /** Leading affix — a short string, or any node (e.g. an Icon) for callers
@@ -50,6 +53,7 @@ export function TextInput(props: TextInputProps) {
     status = "none",
     message = "",
     requirement = "none",
+    forceValidate = false,
     disabled = false,
     readonly = false,
     prefix = "",
@@ -64,14 +68,26 @@ export function TextInput(props: TextInputProps) {
   const fieldId = useId();
   const [internalValue, setInternalValue] = useState(props.value ?? "");
   const [revealed, setRevealed] = useState(false);
+  const [blurred, setBlurred] = useState(false);
 
   const controlled = props.value !== undefined;
   const value = controlled ? props.value ?? "" : internalValue;
   const hasValue = String(value).length > 0;
 
-  const rawStatus = status && status !== "none" ? status : "";
+  // Systemic required enforcement: a `requirement="required"` field that's left
+  // empty surfaces a "REQUIRED" error once it's been blurred (or on a forced
+  // submit-time validation). A caller-supplied `status` always wins, so forms
+  // that drive their own validation are unaffected.
+  const requiredEmpty = requirement === "required" && String(value).trim().length === 0;
+  const showRequiredError = requiredEmpty && (blurred || forceValidate);
+  const effectiveStatus: TextInputStatus =
+    status !== "none" ? status : showRequiredError ? "error" : "none";
+  const effectiveMessage =
+    status !== "none" ? message : showRequiredError ? "REQUIRED" : message;
+
+  const rawStatus = effectiveStatus && effectiveStatus !== "none" ? effectiveStatus : "";
   const statusKey = rawStatus === "warning" ? "warn" : rawStatus;
-  const hasStatusMsg = !!rawStatus && message.length > 0;
+  const hasStatusMsg = !!rawStatus && effectiveMessage.length > 0;
 
   const showCounter = maxLength > 0 && !hasStatusMsg;
   const counterText = maxLength > 0 ? `${String(value).length} / ${maxLength}` : "";
@@ -122,8 +138,12 @@ export function TextInput(props: TextInputProps) {
           readOnly={readonly}
           aria-labelledby={hasLabelRow && label.length > 0 ? `${fieldId}-label` : undefined}
           aria-describedby={describedBy}
-          aria-invalid={status === "error" ? true : undefined}
+          aria-invalid={effectiveStatus === "error" ? true : undefined}
           onInput={(e) => emit((e.target as HTMLInputElement).value)}
+          onBlur={(e) => {
+            setBlurred(true);
+            inputProps?.onBlur?.(e);
+          }}
         />
         {showClear ? (
           <button type="button" class="gsv-ti-x" aria-label="Clear input" onClick={() => emit("")}>
@@ -152,7 +172,7 @@ export function TextInput(props: TextInputProps) {
           {hasStatusMsg ? (
             <>
               <span class="gsv-fld-dot" />
-              <span class="gsv-fld-msg gsv-sublabel" id={`${fieldId}-msg`}>{message}</span>
+              <span class="gsv-fld-msg gsv-sublabel" id={`${fieldId}-msg`}>{effectiveMessage}</span>
             </>
           ) : null}
           {showCounter ? <span class="gsv-ti-counter gsv-sublabel">{counterText}</span> : null}

--- a/web/src/app/components/ui/Tile.tsx
+++ b/web/src/app/components/ui/Tile.tsx
@@ -1,15 +1,20 @@
 import type { JSX } from "preact";
 import { Icon } from "./Icon";
 import { OBJECT_GLYPH_ICON, type ObjectGlyph } from "./objectGlyph";
+import { Hint } from "./Tooltip";
 import "./Tile.css";
 
 export type TileGlyph = ObjectGlyph;
-export type TileStatus = "online" | "error" | "idle" | "warn" | "live" | "update";
+export type TileStatus = "online" | "error" | "idle" | "warn" | "live" | "update" | "accent";
 
 export interface TileProps {
   label?: string;
   glyph?: TileGlyph;
   status?: TileStatus;
+  /** Hover tooltip explaining what the corner dot means. Overrides the tone
+   *  fallback — pass a live status ("3/5 ONLINE") or a selector affordance
+   *  ("Select MAC") so the dot's meaning is legible. */
+  statusHint?: string;
   selected?: boolean;
   anchor?: boolean;
   iconSrc?: string;
@@ -26,6 +31,20 @@ const STATUS_VAR: Record<TileStatus, string> = {
   warn: "var(--warn)",
   live: "var(--live)",
   update: "var(--update)",
+  // Selection accent — matches the Tag "accent" tone so a selected selector
+  // tile's dot reads as chosen, not as a live status.
+  accent: "#b3aeff",
+};
+
+// Fallback tooltip word per tone, used when the caller passes no `statusHint`.
+const STATUS_WORD: Record<TileStatus, string> = {
+  online: "Online",
+  error: "Error",
+  idle: "Idle",
+  warn: "Warning",
+  live: "Live",
+  update: "Update",
+  accent: "Selected",
 };
 
 
@@ -35,6 +54,7 @@ export function Tile({
   label,
   glyph = "machines",
   status = "online",
+  statusHint,
   selected = false,
   anchor = false,
   iconSrc,
@@ -43,6 +63,7 @@ export function Tile({
   onClick,
 }: TileProps) {
   const dc = STATUS_VAR[status] ?? STATUS_VAR.online;
+  const dotHint = statusHint ?? STATUS_WORD[status] ?? STATUS_WORD.online;
   const labelText = label ?? (anchor ? "GSV" : "MACHINES");
   const labelColor = anchor ? "var(--text-hi)" : selected ? "var(--text-hi)" : "#cdd2e0";
 
@@ -128,40 +149,44 @@ export function Tile({
 
   return (
     <div style={wrapperStyle}>
-      <div
-        onClick={onClick}
-        class="gsv-tile"
-        style={{
-          position: "relative",
-          width: "96px",
-          height: "96px",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          cursor: "pointer",
-          transition: "transform .2s,background .2s,border-color .2s,box-shadow .2s",
-          ...tileSkin,
-        }}
-      >
-        <span style={dotStyle} />
-        <span style={{ display: "flex", color: iconColor }}>
-          {iconMaskStyle ? (
-            <span
-              class="gsv-icon"
-              role="img"
-              aria-label={iconTitle ?? labelText}
-              style={iconMaskStyle}
-            />
-          ) : (
-            <Icon
-              name={OBJECT_GLYPH_ICON[glyph] ?? OBJECT_GLYPH_ICON.machines}
-              size={iconSize}
-              dotMatrix={16}
-              title={iconTitle ?? labelText}
-            />
-          )}
-        </span>
-      </div>
+      {/* Hint wraps the whole tile square (not the 8px dot) so the hover target
+          is generous; the dot still positions against .gsv-tile below. */}
+      <Hint text={dotHint} position="top">
+        <div
+          onClick={onClick}
+          class="gsv-tile"
+          style={{
+            position: "relative",
+            width: "96px",
+            height: "96px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: "pointer",
+            transition: "transform .2s,background .2s,border-color .2s,box-shadow .2s",
+            ...tileSkin,
+          }}
+        >
+          <span style={dotStyle} />
+          <span style={{ display: "flex", color: iconColor }}>
+            {iconMaskStyle ? (
+              <span
+                class="gsv-icon"
+                role="img"
+                aria-label={iconTitle ?? labelText}
+                style={iconMaskStyle}
+              />
+            ) : (
+              <Icon
+                name={OBJECT_GLYPH_ICON[glyph] ?? OBJECT_GLYPH_ICON.machines}
+                size={iconSize}
+                dotMatrix={16}
+                title={iconTitle ?? labelText}
+              />
+            )}
+          </span>
+        </div>
+      </Hint>
       <span class="gsv-label" style={{ letterSpacing: ".16em", color: labelColor }}>{labelText}</span>
     </div>
   );

--- a/web/src/app/components/ui/Tooltip.css
+++ b/web/src/app/components/ui/Tooltip.css
@@ -93,7 +93,7 @@
 }
 /* Portaled bubble arrow — driven entirely by the resolved-side class + the
    inline `--gsv-tt-arrow-offset` (px along the shared edge, set from placement).
-   Scoped to `.gsv-tt-portal` so InfoTip's static, wrapper-anchored arrows above
+   Scoped to `.gsv-tt-portal` so any non-portaled, wrapper-anchored arrows above
    are untouched. The side class is the post-flip side, so the arrow always sits
    on the edge nearest the trigger and points at it. */
 .gsv-tt-portal.gsv-tt-side-top .gsv-tt-arrow {

--- a/web/src/app/components/ui/lineGlyphs.tsx
+++ b/web/src/app/components/ui/lineGlyphs.tsx
@@ -98,6 +98,18 @@ export function ArrowLeftGlyph({ size = 14 }: LineGlyphProps) {
   );
 }
 
+/** Two overlapping rounded squares — the traditional "copy to clipboard"
+ *  glyph. Shared by every copy action so the symbol reads the same wherever it
+ *  appears (front sheet over a back sheet peeking top-left). */
+export function CopyGlyph({ size = 14 }: LineGlyphProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect x="8" y="8" width="13" height="13" rx="2.5" />
+      <path d="M16 8 V5 a2 2 0 0 0-2-2 H5 a2 2 0 0 0-2 2 v9 a2 2 0 0 0 2 2 h3" />
+    </svg>
+  );
+}
+
 /** Processor chip — the saved model profiles. */
 export function ModelChipGlyph({ size = 14 }: LineGlyphProps) {
   return (

--- a/web/src/app/features/chat/components/ChatDock.css
+++ b/web/src/app/features/chat/components/ChatDock.css
@@ -328,6 +328,13 @@
   opacity: 0.72;
 }
 
+.gsv-chat-min-dot {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 6px;
+  vertical-align: 1px;
+}
+
 .gsv-shell-root .gsv-chat {
   background: #070612;
   box-shadow: -18px 0 52px rgba(0, 0, 0, 0.52);

--- a/web/src/app/features/chat/components/ChatDock.tsx
+++ b/web/src/app/features/chat/components/ChatDock.tsx
@@ -7,7 +7,7 @@ import { Counter } from "../../../components/ui/Counter";
 import { Icon } from "../../../components/ui/Icon";
 import { IconButton } from "../../../components/ui/IconButton";
 import { MessageInput, type MessageInputAttachment } from "../../../components/ui/MessageInput";
-import type { StatusTone } from "../../../components/ui/StatusDot";
+import { StatusDot, type StatusTone } from "../../../components/ui/StatusDot";
 import { Hint, closeAllTooltips } from "../../../components/ui/Tooltip";
 import type { JSX } from "preact";
 import {
@@ -1029,6 +1029,7 @@ export function ChatDock({
         <span class="gsv-chat-min-copy">
           <strong class="gsv-prose-heading">{activeAgent.name}</strong>
           <small class="gsv-label">
+            <span class="gsv-chat-min-dot"><StatusDot tone={effectiveStatus} size={7} /></span>
             {activeAgent.activity}
             <i />
           </small>

--- a/web/src/app/features/chat/components/ChatReasoningPanel.css
+++ b/web/src/app/features/chat/components/ChatReasoningPanel.css
@@ -95,6 +95,14 @@
   color: var(--meta);
   letter-spacing: 0.14em;
 }
+/* Attention states tone the status word (matching the title's error recolor);
+   done/running stay dim so a long reasoning list doesn't read as noise. */
+.gsv-chat-rp-entry.is-error .gsv-chat-rp-entry-status {
+  color: var(--error);
+}
+.gsv-chat-rp-entry.is-warning .gsv-chat-rp-entry-status {
+  color: var(--warn);
+}
 
 .gsv-chat-rp-detail-toggle {
   appearance: none;

--- a/web/src/app/features/chat/components/ChatTranscript.tsx
+++ b/web/src/app/features/chat/components/ChatTranscript.tsx
@@ -2,6 +2,7 @@ import type { ComponentChildren } from "preact";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
 import DOMPurify from "dompurify";
 import { parse as parseMarkdown } from "marked";
+import { CopyGlyph } from "../../../components/ui/lineGlyphs";
 import { CopyIconButton, MessageMeta } from "../../../components/ui/MessageMeta";
 import { ReasoningGlyph } from "../../../components/ui/ReasoningGlyph";
 import { ActionRail, SwipeRow, TranscriptMobileContext, useTranscriptMobile } from "./SwipeRow";
@@ -253,12 +254,7 @@ function CopyButton({
         onClick={onCopy}
         aria-label={copied ? `Copied ${roleLabel(role).toLowerCase()} message` : `Copy ${roleLabel(role).toLowerCase()} message`}
       >
-        <svg width="11" height="11" viewBox="0 0 16 16" aria-hidden="true">
-          <g fill="none" stroke="currentColor" stroke-width="1.5">
-            <rect x="3" y="3" width="7" height="7" />
-            <rect x="6" y="6" width="7" height="7" />
-          </g>
-        </svg>
+        <CopyGlyph size={11} />
       </button>
     </Hint>
   );

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
@@ -141,14 +141,9 @@
   overflow: hidden;
 }
 
-.gsv-console-detail-bar-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-/* Destructive action footer — pinned to the bottom-left of the page (margin-top
-   auto pushes it below all content), isolated from the top action bar. */
+/* Action footer — pinned to the bottom of the page (margin-top auto pushes it
+   below all content). The destructive action sits bottom-left; the regular /
+   primary actions group is pushed bottom-right. */
 .gsv-console-detail-footer {
   margin-top: auto;
   display: flex;
@@ -158,6 +153,15 @@
   padding: 18px 26px;
   padding-inline: max(26px, var(--gsv-gutter));
   border-top: 1px solid var(--rule-section);
+}
+
+/* Regular/primary actions — pushed to the right edge of the footer. When there
+   is no destructive action, margin-left:auto still right-aligns the group. */
+.gsv-console-detail-footer-actions {
+  margin-left: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .gsv-console-detail-actions {

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.css
@@ -147,6 +147,19 @@
   gap: 12px;
 }
 
+/* Destructive action footer — pinned to the bottom-left of the page (margin-top
+   auto pushes it below all content), isolated from the top action bar. */
+.gsv-console-detail-footer {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 26px;
+  padding-inline: max(26px, var(--gsv-gutter));
+  border-top: 1px solid var(--rule-section);
+}
+
 .gsv-console-detail-actions {
   min-width: 0;
   display: contents;

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
@@ -27,12 +27,14 @@ export type ConsoleDetailSection = {
 };
 
 type ConsoleDetailPageProps = {
+  /** Regular/secondary actions. Rendered bottom-right in the page footer,
+   *  alongside the primary button and opposite `dangerAction`. */
   actions?: ComponentChildren;
   blurb: string;
   children?: ComponentChildren;
-  /** Destructive action (FORGET / REMOVE / DISCONNECT / KILL). Rendered in a
-   *  footer pinned to the bottom-left of the page, isolated from the top action
-   *  bar's regular/primary actions. */
+  /** Destructive action (FORGET / REMOVE / DISCONNECT / KILL). Rendered at the
+   *  bottom-left of the page footer, opposite the regular/primary `actions`
+   *  which sit bottom-right. */
   dangerAction?: ComponentChildren;
   icon: string;
   /** Back navigation. For surfaces whose detail is reflected in the shell
@@ -114,19 +116,6 @@ export function ConsoleDetailPage({
             ) : null}
           </p>
         </div>
-        {hasActions ? (
-          <div class="gsv-console-detail-bar-actions">
-            {actions}
-            {primaryLabel ? (
-              <Button
-                variant="primary"
-                label={primaryLabel}
-                disabled={!onPrimary}
-                onClick={onPrimary}
-              />
-            ) : null}
-          </div>
-        ) : null}
       </div>
 
       <div class="gsv-console-detail-shell">
@@ -176,8 +165,23 @@ export function ConsoleDetailPage({
         ) : null}
       </div>
 
-      {hasDanger ? (
-        <footer class="gsv-console-detail-footer">{dangerAction}</footer>
+      {hasDanger || hasActions ? (
+        <footer class="gsv-console-detail-footer">
+          {hasDanger ? dangerAction : null}
+          {hasActions ? (
+            <div class="gsv-console-detail-footer-actions">
+              {actions}
+              {primaryLabel ? (
+                <Button
+                  variant="primary"
+                  label={primaryLabel}
+                  disabled={!onPrimary}
+                  onClick={onPrimary}
+                />
+              ) : null}
+            </div>
+          ) : null}
+        </footer>
       ) : null}
     </section>
   );

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
@@ -10,6 +10,8 @@ export type ConsoleDetailRow = {
   id: string;
   icon?: string;
   label: string;
+  /** Optional "?" help tooltip explaining the row's value. */
+  labelInfo?: string;
   status?: ListRowStatus;
   statusLabel?: string;
   sub: string;
@@ -141,6 +143,7 @@ export function ConsoleDetailPage({
                         icon={row.icon}
                         key={row.id}
                         label={row.label}
+                        labelInfo={row.labelInfo}
                         status={row.status ?? "none"}
                         statusDotPlacement="trailing"
                         statusLabel={row.statusLabel}

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
@@ -30,6 +30,10 @@ type ConsoleDetailPageProps = {
   actions?: ComponentChildren;
   blurb: string;
   children?: ComponentChildren;
+  /** Destructive action (FORGET / REMOVE / DISCONNECT / KILL). Rendered in a
+   *  footer pinned to the bottom-left of the page, isolated from the top action
+   *  bar's regular/primary actions. */
+  dangerAction?: ComponentChildren;
   icon: string;
   /** Back navigation. For surfaces whose detail is reflected in the shell
    *  breadcrumb this is handled there (so `showBack` stays off); non-route-backed
@@ -54,6 +58,7 @@ export function ConsoleDetailPage({
   actions,
   blurb,
   children,
+  dangerAction,
   icon,
   onBack,
   onPrimary,
@@ -68,6 +73,7 @@ export function ConsoleDetailPage({
 }: ConsoleDetailPageProps) {
   const hasSections = sections.some((section) => section.rows.length > 0);
   const hasActions = Boolean(primaryLabel) || (actions != null && actions !== false);
+  const hasDanger = dangerAction != null && dangerAction !== false;
   // Break the description into two lines: the trailing " · " segment (e.g.
   // "last seen 2m ago", "connected over sse") drops to a second line.
   const descSep = blurb.lastIndexOf(" · ");
@@ -169,6 +175,10 @@ export function ConsoleDetailPage({
           </div>
         ) : null}
       </div>
+
+      {hasDanger ? (
+        <footer class="gsv-console-detail-footer">{dangerAction}</footer>
+      ) : null}
     </section>
   );
 }

--- a/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
+++ b/web/src/app/features/gsv-console/components/ConsoleDetailPage.tsx
@@ -3,7 +3,7 @@ import { Button } from "../../../components/ui/Button";
 import { Icon } from "../../../components/ui/Icon";
 import { ListRow, type ListRowStatus } from "../../../components/ui/ListRow";
 import { SectionHeader } from "../../../components/ui/SectionHeader";
-import type { StatusTone } from "../../../components/ui/StatusDot";
+import { StatusMeta, type StatusTone } from "../../../components/ui/StatusDot";
 import "./ConsoleDetailPage.css";
 
 export type ConsoleDetailRow = {
@@ -18,6 +18,9 @@ export type ConsoleDetailRow = {
 export type ConsoleDetailSection = {
   title: string;
   meta?: string;
+  /** When set, `meta` is a status word: render it tone-colored with a dot
+   *  (like the page header) instead of the dim default. */
+  metaTone?: StatusTone;
   rows: readonly ConsoleDetailRow[];
 };
 
@@ -59,6 +62,7 @@ export function ConsoleDetailPage({
   showBack = false,
   statusLabel,
   title,
+  tone,
 }: ConsoleDetailPageProps) {
   const hasSections = sections.some((section) => section.rows.length > 0);
   const hasActions = Boolean(primaryLabel) || (actions != null && actions !== false);
@@ -75,13 +79,14 @@ export function ConsoleDetailPage({
           <span aria-hidden="true">←</span> {parentLabel}
         </button>
       ) : null}
-      {/* Row 2 — full-width page header (title + status), like the list pages. */}
+      {/* Row 2 — full-width page header (title + status), like the list pages.
+          Status carries its tone color + dot, matching the list rows. */}
       <SectionHeader
         className="gsv-console-detail-header"
         title={title}
-        meta={statusLabel}
         divider
         headingLevel={2}
+        actions={statusLabel ? <StatusMeta tone={tone} label={statusLabel} /> : undefined}
       />
 
       {/* Row 3 — action bar: icon tile + description, with the action below.
@@ -122,7 +127,14 @@ export function ConsoleDetailPage({
             {sections.map((section) => (
               section.rows.length > 0 ? (
                 <section class="gsv-console-detail-section" key={section.title}>
-                  <SectionHeader title={section.title} meta={section.meta} divider />
+                  <SectionHeader
+                    title={section.title}
+                    meta={section.metaTone ? undefined : section.meta}
+                    actions={section.metaTone && section.meta ? (
+                      <StatusMeta tone={section.metaTone} label={section.meta} />
+                    ) : undefined}
+                    divider
+                  />
                   <div>
                     {section.rows.map((row) => (
                       <ListRow

--- a/web/src/app/features/gsv-console/components/consoleDetailRows.ts
+++ b/web/src/app/features/gsv-console/components/consoleDetailRows.ts
@@ -6,7 +6,7 @@ export function detailRow(
   id: string,
   label: string,
   value: string | number | boolean | null | undefined,
-  options: Pick<ConsoleDetailRow, "icon" | "status" | "statusLabel"> = {},
+  options: Pick<ConsoleDetailRow, "icon" | "status" | "statusLabel" | "labelInfo"> = {},
 ): ConsoleDetailRow | null {
   const sub = typeof value === "boolean"
     ? (value ? "YES" : "NO")

--- a/web/src/app/features/gsv-console/connect-flows/ConnectFlowShell.tsx
+++ b/web/src/app/features/gsv-console/connect-flows/ConnectFlowShell.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "../../../components/ui/Icon";
 import { SectionHeader } from "../../../components/ui/SectionHeader";
+import { StatusMeta } from "../../../components/ui/StatusDot";
 import { Stepper } from "../../../components/ui/Stepper";
 import type { ConnectFlowDef, ConnectNav } from "./connectFlowTypes";
 import "./ConnectFlowShell.css";
@@ -40,8 +41,16 @@ export function ConnectFlowShell({ flow, current, onStep }: ConnectFlowShellProp
   return (
     <div class="gsv-cf">
       {/* Page header — title + status. The breadcrumb trail is supplied by the
-          shell's top bar (ConsoleHeader), not duplicated here. */}
-      <SectionHeader divider title={flow.title} meta={step.status} headingLevel={2} />
+          shell's top bar (ConsoleHeader), not duplicated here. The step status
+          carries its tone color + dot (falls back to a plain dim meta if a step
+          declares no tone). */}
+      <SectionHeader
+        divider
+        title={flow.title}
+        headingLevel={2}
+        meta={step.tone || !step.status ? undefined : step.status}
+        actions={step.tone && step.status ? <StatusMeta tone={step.tone} label={step.status} /> : undefined}
+      />
 
       {/* Action bar — icon tile + 2-line description, with the stepper below. */}
       <div class="gsv-cf-bar">

--- a/web/src/app/features/gsv-console/connect-flows/machineConnectMock.tsx
+++ b/web/src/app/features/gsv-console/connect-flows/machineConnectMock.tsx
@@ -1,5 +1,6 @@
 import { Button } from "../../../components/ui/Button";
 import { Icon } from "../../../components/ui/Icon";
+import { CopyGlyph } from "../../../components/ui/lineGlyphs";
 import { ListRow } from "../../../components/ui/ListRow";
 import { Spinner } from "../../../components/ui/Spinner";
 import { Tag } from "../../../components/ui/Tag";
@@ -35,7 +36,7 @@ function CommandBlock({ title, meta, value }: { title: string; meta: string; val
         <span class="gsv-cf-cmd-title gsv-sublabel">{title}</span>
         <span class="gsv-cf-cmd-meta gsv-sublabel">{meta}</span>
         <button type="button" class="gsv-cf-cmd-copy">
-          <Icon name="bookmark" size={12} />
+          <CopyGlyph size={12} />
           <span>COPY</span>
         </button>
       </header>
@@ -91,7 +92,8 @@ export const machineConnectFlow: ConnectFlowDef = {
                     iconSrc={`/icons/doticons/${option.dotIcon}.svg`}
                     iconTitle={option.label}
                     iconSize={36}
-                    status={selected ? "update" : "idle"}
+                    status={selected ? "accent" : "idle"}
+                    statusHint={`Select ${option.label}`}
                     selected={selected}
                   />
                   <span class="gsv-sublabel" style={{ letterSpacing: ".1em", color: "#8c86c8" }}>

--- a/web/src/app/features/gsv-console/domain/uniqueName.ts
+++ b/web/src/app/features/gsv-console/domain/uniqueName.ts
@@ -1,0 +1,16 @@
+/** Case-insensitive, whitespace-trimmed uniqueness check shared by the console
+ *  create flows to block duplicate object names / ids (machine device-ids,
+ *  integration names, package names, agent usernames, …) before hitting the
+ *  gateway. The gateway stays the authoritative check; this is a pre-submit UX
+ *  guard so the user sees the collision inline instead of a thrown error.
+ *
+ *  `existing` is the list of already-taken identity strings; `candidate` is the
+ *  value being entered. An empty/blank candidate is never "taken" (that's the
+ *  required-field concern, handled separately). */
+export function isNameTaken(existing: readonly string[], candidate: string): boolean {
+  const needle = candidate.trim().toLowerCase();
+  if (!needle) {
+    return false;
+  }
+  return existing.some((value) => value.trim().toLowerCase() === needle);
+}

--- a/web/src/app/features/gsv-console/integrations/IntegrationDetailPage.tsx
+++ b/web/src/app/features/gsv-console/integrations/IntegrationDetailPage.tsx
@@ -41,7 +41,7 @@ export function IntegrationDetailPage({
   return (
     <>
       <ConsoleDetailPage
-        actions={(
+        dangerAction={(
           <div class="gsv-console-detail-actions">
             <Button
               variant="dangerGhost"

--- a/web/src/app/features/gsv-console/integrations/IntegrationOnboardingFlow.tsx
+++ b/web/src/app/features/gsv-console/integrations/IntegrationOnboardingFlow.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "../../../components/ui/Spinner";
 import { Surface } from "../../../components/ui/Surface";
 import { TextInput } from "../../../components/ui/TextInput";
 import type { ConsoleMcpServer } from "../domain/consoleModels";
+import { isNameTaken } from "../domain/uniqueName";
 import { useAddConsoleMcpServer } from "../hooks/useConsoleData";
 import { ConnectFlowShell } from "../connect-flows/ConnectFlowShell";
 import type { ConnectFlowDef } from "../connect-flows/connectFlowTypes";
@@ -128,7 +129,9 @@ export function IntegrationOnboardingFlow({
   const transport = MCP_TRANSPORT_OPTIONS[transportIndex] ?? "auto";
   const urlReady = validUrl(url);
   const headersResult = headersFromDrafts(headers);
-  const canSubmit = name.trim().length > 0 && urlReady && headersResult.ok && !addServer.isPending;
+  const nameTaken = isNameTaken(servers.map((server) => server.name), name);
+  const canSubmit =
+    name.trim().length > 0 && !nameTaken && urlReady && headersResult.ok && !addServer.isPending;
   const ready = created?.state === "ready";
   const failed = !!created && (created.state === "failed" || created.error.length > 0);
   let progressMessage = "";
@@ -229,6 +232,8 @@ export function IntegrationOnboardingFlow({
                 label="NAME"
                 info="Display name agents will see."
                 requirement="required"
+                status={nameTaken ? "error" : "none"}
+                message={nameTaken ? "That name is already in use" : ""}
                 value={name}
                 placeholder="GitHub"
                 clearable

--- a/web/src/app/features/gsv-console/integrations/integrationPresentation.ts
+++ b/web/src/app/features/gsv-console/integrations/integrationPresentation.ts
@@ -85,6 +85,7 @@ export function mcpServerDetailSections(server: ConsoleMcpServer): ConsoleDetail
     {
       title: "CONNECTION",
       meta: statusForMcpServer(server),
+      metaTone: toneForMcpServer(server),
       rows: liveRows([
         detailRow("server-id", "SERVER ID", server.serverId),
         detailRow("url", "URL", server.url),

--- a/web/src/app/features/gsv-console/machines/MachineDetailPage.tsx
+++ b/web/src/app/features/gsv-console/machines/MachineDetailPage.tsx
@@ -34,7 +34,7 @@ export function MachineDetailPage({
   return (
     <>
       <ConsoleDetailPage
-        actions={(
+        dangerAction={(
           <div class="gsv-console-detail-actions">
             <Button
               variant="dangerGhost"

--- a/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
+++ b/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "preact/hooks";
 import { useUnsavedGuard } from "../../gsv-shell/unsaved/unsavedGuard";
 import { Button } from "../../../components/ui/Button";
 import { Icon } from "../../../components/ui/Icon";
+import { InfoTip } from "../../../components/ui/InfoTip";
 import { CopyGlyph } from "../../../components/ui/lineGlyphs";
 import { ListRow } from "../../../components/ui/ListRow";
 import { Spinner } from "../../../components/ui/Spinner";
@@ -383,6 +384,7 @@ export function MachineProvisionFlow({
             <div class="gsv-cf-fields">
               <TextInput
                 label={isBrowserTarget ? "BROWSER NAME" : "MACHINE NAME"}
+                info="A friendly name so you can spot this machine in your list."
                 value={machineName}
                 placeholder={isBrowserTarget ? "Chrome" : "Studio MacBook"}
                 clearable
@@ -393,6 +395,7 @@ export function MachineProvisionFlow({
               <TextInput
                 key={`device-${deviceId}`}
                 label="DEVICE ID"
+                info="The unique id that identifies this machine. It's filled in from the name — leave it as-is unless you need to change it."
                 value={deviceId}
                 placeholder={isBrowserTarget ? "chrome" : "studio-macbook"}
                 clearable
@@ -405,6 +408,7 @@ export function MachineProvisionFlow({
               <TextInput
                 key={`expires-${expiresDays}`}
                 label="TOKEN EXPIRY"
+                info="How many days the machine's access stays valid before it needs to reconnect with a new token."
                 value={expiresDays}
                 suffix="DAYS"
                 status="info"
@@ -521,6 +525,12 @@ export function MachineProvisionFlow({
         render: () => (
           <>
             {!issuedToken ? (
+              <>
+              <p class="gsv-cf-desc" style={{ margin: 0 }}>
+                {isBrowserTarget
+                  ? "Create a secure key, then paste the connection details into the browser extension to pair it."
+                  : "Create a secure key for this machine, then run the command it generates on the machine to bring it online."}
+              </p>
               <div class="machine-issue-token">
                 <StatusDot tone={createToken.isPending ? "live" : "update"} size={9} />
                 <div>
@@ -528,6 +538,7 @@ export function MachineProvisionFlow({
                     {createToken.isPending
                       ? `ISSUING ${isBrowserTarget ? "DRIVER" : "NODE"} TOKEN`
                       : `ISSUE ${isBrowserTarget ? "DRIVER" : "NODE"} TOKEN`}
+                    <InfoTip text="Creates the secure key this machine uses to connect to GSV." />
                   </strong>
                   <span>
                     The token is scoped to {deviceId || "this device"} and expires in {expires} days.
@@ -535,6 +546,7 @@ export function MachineProvisionFlow({
                   </span>
                 </div>
               </div>
+              </>
             ) : isBrowserTarget && browserConfig ? (
               <>
                 <p class="gsv-cf-desc" style={{ margin: 0 }}>
@@ -575,6 +587,7 @@ export function MachineProvisionFlow({
                 <div class="machine-run-mode">
                   <Toggle
                     label="ONE-SHOT RUN"
+                    info="The machine will not reconnect if the computer turns off or the terminal is closed."
                     size="small"
                     on={oneShotRun}
                     status={oneShotRun ? "info" : "none"}

--- a/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
+++ b/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
@@ -185,8 +185,10 @@ export function MachineProvisionFlow({
   const validDeviceId = parseDeviceId(deviceId);
   // Block provisioning a machine whose display name or device-id already exists
   // (the gateway is authoritative, but pre-check inline so the user sees it).
-  const nameTaken = isNameTaken(targets.targets.map((target) => target.label), machineName);
-  const deviceIdTaken = deviceId.trim().length > 0 && knownTarget !== null;
+  // Only while composing a NEW machine: once a token is issued the just-created
+  // device registers and would otherwise match itself if the user steps back.
+  const nameTaken = !issuedToken && isNameTaken(targets.targets.map((target) => target.label), machineName);
+  const deviceIdTaken = !issuedToken && deviceId.trim().length > 0 && knownTarget !== null;
   const detailsReady =
     machineName.trim().length > 0 && validDeviceId !== null && !nameTaken && !deviceIdTaken;
   const release = snapshot.server?.release ?? "dev";

--- a/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
+++ b/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "preact/hooks";
 import { useUnsavedGuard } from "../../gsv-shell/unsaved/unsavedGuard";
 import { Button } from "../../../components/ui/Button";
 import { Icon } from "../../../components/ui/Icon";
+import { CopyGlyph } from "../../../components/ui/lineGlyphs";
 import { ListRow } from "../../../components/ui/ListRow";
 import { Spinner } from "../../../components/ui/Spinner";
 import { StatusDot } from "../../../components/ui/StatusDot";
@@ -114,7 +115,7 @@ function CommandBlock({
         <span class="gsv-cf-cmd-title">{title}</span>
         <span class="gsv-cf-cmd-meta">{meta}</span>
         <button type="button" class="gsv-cf-cmd-copy" onClick={onCopy}>
-          <Icon name="bookmark" size={12} />
+          <CopyGlyph size={12} />
           <span>{copied ? "COPIED" : "COPY"}</span>
         </button>
       </header>
@@ -142,7 +143,7 @@ function ExtensionValueRow({
         <code>{value}</code>
       </div>
       <button type="button" class="gsv-cf-cmd-copy" onClick={onCopy}>
-        <Icon name="bookmark" size={12} />
+        <CopyGlyph size={12} />
         <span>{copied ? "COPIED" : "COPY"}</span>
       </button>
     </div>
@@ -343,7 +344,6 @@ export function MachineProvisionFlow({
                   class={`machine-platform-tile-button${platform === option.id ? " is-selected" : ""}`}
                   key={option.id}
                   aria-pressed={platform === option.id ? "true" : "false"}
-                  title={`${option.label}: ${option.meta}`}
                   onClick={() => selectPlatform(option.id)}
                 >
                   <Tile
@@ -352,7 +352,8 @@ export function MachineProvisionFlow({
                     iconSrc={`/icons/doticons/${option.dotIcon}.svg`}
                     iconTitle={option.label}
                     iconSize={36}
-                    status={platform === option.id ? "update" : "idle"}
+                    status={platform === option.id ? "accent" : "idle"}
+                    statusHint={`Select ${option.label}`}
                     selected={platform === option.id}
                   />
                   <span class="machine-platform-meta gsv-prose-sm">{option.meta}</span>

--- a/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
+++ b/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
@@ -18,6 +18,7 @@ import type { IssuedMachineNodeToken } from "../backend/consoleService";
 import { ConnectFlowShell } from "../connect-flows/ConnectFlowShell";
 import type { ConnectFlowDef } from "../connect-flows/connectFlowTypes";
 import type { ConsoleTarget } from "../domain/consoleModels";
+import { isNameTaken } from "../domain/uniqueName";
 import { useConsoleTargets, useCreateMachineNodeToken } from "../hooks/useConsoleData";
 import {
   MACHINE_PLATFORM_OPTIONS,
@@ -160,8 +161,8 @@ export function MachineProvisionFlow({
   const createToken = useCreateMachineNodeToken();
   const [step, setStep] = useState<MachineProvisionStep>("platform");
   const [platform, setPlatform] = useState<MachineProvisionPlatform>("mac");
-  const [machineName, setMachineName] = useState(defaultMachineName("mac"));
-  const [deviceId, setDeviceId] = useState(machineDeviceIdFromName(defaultMachineName("mac")));
+  const [machineName, setMachineName] = useState("");
+  const [deviceId, setDeviceId] = useState("");
   const [expiresDays, setExpiresDays] = useState("30");
   const [nameTouched, setNameTouched] = useState(false);
   const [deviceIdTouched, setDeviceIdTouched] = useState(false);
@@ -182,7 +183,12 @@ export function MachineProvisionFlow({
   const knownTarget = targets.targets.find((target) => target.deviceId === deviceId.trim()) ?? null;
   const expires = normalizeExpiresDays(expiresDays);
   const validDeviceId = parseDeviceId(deviceId);
-  const detailsReady = machineName.trim().length > 0 && validDeviceId !== null;
+  // Block provisioning a machine whose display name or device-id already exists
+  // (the gateway is authoritative, but pre-check inline so the user sees it).
+  const nameTaken = isNameTaken(targets.targets.map((target) => target.label), machineName);
+  const deviceIdTaken = deviceId.trim().length > 0 && knownTarget !== null;
+  const detailsReady =
+    machineName.trim().length > 0 && validDeviceId !== null && !nameTaken && !deviceIdTaken;
   const release = snapshot.server?.release ?? "dev";
   const installCommand = buildMachineInstallCommand(platform, release);
   const extensionDownloadUrl = browserExtensionDownloadUrl(release);
@@ -244,14 +250,9 @@ export function MachineProvisionFlow({
   };
 
   const selectPlatform = (nextPlatform: MachineProvisionPlatform) => {
+    // Name/device-id are the user's to type (placeholder only) — don't seed a
+    // default when the platform changes.
     setPlatform(nextPlatform);
-    if (!nameTouched) {
-      const nextName = defaultMachineName(nextPlatform);
-      setMachineName(nextName);
-      if (!deviceIdTouched) {
-        setDeviceId(machineDeviceIdFromName(nextName));
-      }
-    }
     resetToken();
   };
 
@@ -386,10 +387,13 @@ export function MachineProvisionFlow({
                 label={isBrowserTarget ? "BROWSER NAME" : "MACHINE NAME"}
                 info="A friendly name so you can spot this machine in your list."
                 value={machineName}
-                placeholder={isBrowserTarget ? "Chrome" : "Studio MacBook"}
+                placeholder={defaultMachineName(platform)}
                 clearable
-                status={machineName.trim() ? "success" : "warning"}
-                message={machineName.trim() ? "Display label ready" : `${isBrowserTarget ? "Browser" : "Machine"} name required`}
+                requirement="required"
+                status={nameTaken ? "error" : machineName.trim() ? "success" : "none"}
+                message={nameTaken
+                  ? `That ${isBrowserTarget ? "browser" : "machine"} name is already in use`
+                  : machineName.trim() ? "Display label ready" : ""}
                 onChange={updateMachineName}
               />
               <TextInput
@@ -397,12 +401,15 @@ export function MachineProvisionFlow({
                 label="DEVICE ID"
                 info="The unique id that identifies this machine. It's filled in from the name — leave it as-is unless you need to change it."
                 value={deviceId}
-                placeholder={isBrowserTarget ? "chrome" : "studio-macbook"}
+                placeholder={machineDeviceIdFromName(defaultMachineName(platform))}
                 clearable
-                status={validDeviceId ? "success" : "warning"}
-                message={validDeviceId
+                requirement="required"
+                status={deviceIdTaken ? "error" : validDeviceId ? "success" : deviceId.trim() ? "error" : "none"}
+                message={deviceIdTaken
+                  ? "That device id is already in use"
+                  : validDeviceId
                   ? (isBrowserTarget ? "Use this exact value in the extension" : "Used by CLI and routing")
-                  : deviceId.trim() ? DEVICE_ID_FORMAT_DESCRIPTION : "Device id required"}
+                  : deviceId.trim() ? DEVICE_ID_FORMAT_DESCRIPTION : ""}
                 onChange={updateDeviceId}
               />
               <TextInput

--- a/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
+++ b/web/src/app/features/gsv-console/machines/MachineProvisionFlow.tsx
@@ -171,6 +171,10 @@ export function MachineProvisionFlow({
   const origin = window.location.origin;
   const selectedPlatform = platformOption(platform);
   const isBrowserTarget = platform === "browser";
+  // Icon for the selected target across the flow's action bar, preview rows, and
+  // success screen. Browser → the chrome doticon (matching the step-1 tile);
+  // everything else → the computer glyph. `chrome` exists only as a doticon.
+  const targetIcon = isBrowserTarget ? "doticons/chrome" : "computer";
   const stepLabels = isBrowserTarget
     ? ["TARGET", "DETAILS", "EXTENSION", "PAIR", "SUCCESS"]
     : MACHINE_PROVISION_STEP_LABELS;
@@ -320,7 +324,7 @@ export function MachineProvisionFlow({
     key: "machines",
     navLabel: "MACHINES",
     parentLabel: "MACHINES",
-    icon: isBrowserTarget ? "bookmark" : "computer",
+    icon: targetIcon,
     title: isBrowserTarget ? "Connect browser extension" : "Connect machine",
     blurb: isBrowserTarget
       ? "Provision a driver token and attach the GSV browser extension to the fleet · Chrome, Brave, Edge, or another Chromium browser."
@@ -413,7 +417,7 @@ export function MachineProvisionFlow({
             </div>
             <div class="gsv-cf-framed">
               <ListRow
-                icon={isBrowserTarget ? "bookmark" : "computer"}
+                icon={targetIcon}
                 label={machineName || "New machine"}
                 sub={`${deviceId || "device-id"} / ${selectedPlatform.commandLabel}`}
                 status={detailsReady ? "online" : "warn"}
@@ -631,7 +635,7 @@ export function MachineProvisionFlow({
           <>
             <div class="gsv-cf-cap">
               <span class="gsv-cf-cap-mark">
-                <Icon name={isBrowserTarget ? "bookmark" : "computer"} size={26} />
+                <Icon name={targetIcon} size={26} />
               </span>
               <div class="gsv-cf-cap-text">
                 <span class="gsv-cf-cap-title">{machineName || deviceId} is connected</span>
@@ -645,7 +649,7 @@ export function MachineProvisionFlow({
             <div class="gsv-cf-framed">
               {knownTarget ? (
                 <ListRow
-                  icon={isBrowserTarget ? "bookmark" : "computer"}
+                  icon={targetIcon}
                   label={knownTarget.label}
                   sub={targetSub(knownTarget)}
                   status={knownTarget.online ? "online" : "idle"}
@@ -654,7 +658,7 @@ export function MachineProvisionFlow({
                 />
               ) : (
                 <ListRow
-                  icon={isBrowserTarget ? "bookmark" : "computer"}
+                  icon={targetIcon}
                   label={machineName || deviceId}
                   sub={deviceId}
                   status="online"

--- a/web/src/app/features/gsv-console/machines/machinePresentation.ts
+++ b/web/src/app/features/gsv-console/machines/machinePresentation.ts
@@ -49,7 +49,9 @@ export function machineDetailSections(target: ConsoleTarget): ConsoleDetailSecti
         detailRow("platform", "PLATFORM", target.platform),
         detailRow("version", "VERSION", target.version),
         detailRow("owner", "OWNER", target.ownerUsername || uidLabel(target.ownerUid)),
-        detailRow("last-seen", "LAST SEEN", target.lastSeenAt === null ? "" : formatAge(target.lastSeenAt)),
+        detailRow("last-seen", "LAST SEEN", target.lastSeenAt === null ? "" : formatAge(target.lastSeenAt), {
+          labelInfo: "When this machine last connected or disconnected. For an online machine it's when the current session began; for an offline one, when it dropped.",
+        }),
       ]),
     },
     {

--- a/web/src/app/features/gsv-console/machines/machinePresentation.ts
+++ b/web/src/app/features/gsv-console/machines/machinePresentation.ts
@@ -42,6 +42,7 @@ export function machineDetailSections(target: ConsoleTarget): ConsoleDetailSecti
     {
       title: "MACHINE",
       meta: statusForTarget(target),
+      metaTone: toneForTarget(target),
       rows: liveRows([
         detailRow("platform", "PLATFORM", target.platform),
         detailRow("version", "VERSION", target.version),

--- a/web/src/app/features/gsv-console/machines/machinePresentation.ts
+++ b/web/src/app/features/gsv-console/machines/machinePresentation.ts
@@ -9,7 +9,9 @@ import { compactText, formatAge, uidLabel } from "../domain/consoleFormat";
 import type { ConsoleTarget } from "../domain/consoleModels";
 
 export function iconForTarget(target: ConsoleTarget): string {
-  if (target.kind === "browser") return "bookmark";
+  // Browser targets use the chrome doticon (matching the step-1 platform tile);
+  // `chrome` exists only as a doticon, so route through the `doticons/` prefix.
+  if (target.kind === "browser") return "doticons/chrome";
   return "computer";
 }
 

--- a/web/src/app/features/gsv-console/messengers/MessengerDetailPage.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerDetailPage.tsx
@@ -48,7 +48,7 @@ export function MessengerDetailPage({
   return (
     <>
       <ConsoleDetailPage
-        actions={(
+        dangerAction={(
           <div class="gsv-console-detail-actions">
             <Button
               variant="dangerGhost"

--- a/web/src/app/features/gsv-console/messengers/MessengerIdentityLinks.tsx
+++ b/web/src/app/features/gsv-console/messengers/MessengerIdentityLinks.tsx
@@ -4,6 +4,7 @@ import { Button } from "../../../components/ui/Button";
 import { ConfirmModal } from "../../../components/ui/ConfirmModal";
 import { ListRow } from "../../../components/ui/ListRow";
 import { SectionHeader } from "../../../components/ui/SectionHeader";
+import { StatusMeta } from "../../../components/ui/StatusDot";
 import {
   labelForConsoleAccountRelation,
 } from "../domain/agentPresentation";
@@ -72,11 +73,9 @@ export function MessengerIdentityLinks({
 }) {
   const removeLink = useRemoveIdentityLink();
   const [confirmUnlink, setConfirmUnlink] = useState<ConsoleIdentityLink | null>(null);
-  const meta = errorText
-    ? "ERROR"
-    : refreshing
-      ? "SYNCING"
-      : `${links.length} ${links.length === 1 ? "LINK" : "LINKS"}`;
+  const meta = refreshing
+    ? "SYNCING"
+    : `${links.length} ${links.length === 1 ? "LINK" : "LINKS"}`;
 
   const unlink = async (link: ConsoleIdentityLink) => {
     await removeLink.mutateAsync({
@@ -90,7 +89,12 @@ export function MessengerIdentityLinks({
   return (
     <>
       <section class="gsv-console-detail-section gsv-messenger-identity-section">
-        <SectionHeader title="LINKED IDENTITIES" meta={meta} divider />
+        <SectionHeader
+          title="LINKED IDENTITIES"
+          meta={errorText ? undefined : meta}
+          actions={errorText ? <StatusMeta tone="error" label="ERROR" /> : undefined}
+          divider
+        />
         <div class="gsv-messenger-identity-list">
           {errorText ? (
             <div class="gsv-messenger-identity-empty gsv-sublabel">IDENTITY LINKS UNAVAILABLE / {errorText}</div>

--- a/web/src/app/features/gsv-console/messengers/messengerPresentation.ts
+++ b/web/src/app/features/gsv-console/messengers/messengerPresentation.ts
@@ -97,6 +97,7 @@ export function adapterDetailSections(adapter: ConsoleAdapterAccount): ConsoleDe
     {
       title: "MESSENGER",
       meta: statusForAdapter(adapter),
+      metaTone: toneForAdapter(adapter),
       rows: liveRows([
         detailRow("adapter", "ADAPTER", formatTokenLabel(adapter.adapter)),
         detailRow("account", "ACCOUNT", adapter.accountId),

--- a/web/src/app/features/gsv-console/packages/ApplicationImportFlow.tsx
+++ b/web/src/app/features/gsv-console/packages/ApplicationImportFlow.tsx
@@ -118,7 +118,7 @@ export function ApplicationImportFlow({
   const importedApplication = flow.importedPackage
     ? isConsoleApplicationPackage(flow.importedPackage)
     : true;
-  const importReady = isPackageImportDraftReady(flow.draft);
+  const importReady = isPackageImportDraftReady(flow.draft) && !flow.duplicateSource;
   const canEnable = Boolean(flow.importedPackage)
     && !flow.importMutation.isPending
     && !flow.reviewMutation.isPending
@@ -191,8 +191,10 @@ export function ApplicationImportFlow({
           value={flow.draft.source}
           placeholder="https://github.com/team/package.git"
           clearable
-          status={flow.draft.source.trim() ? "success" : "warning"}
-          message={flow.draft.source.trim() ? "Source ready" : "Repository or remote URL required"}
+          status={flow.duplicateSource ? "error" : flow.draft.source.trim() ? "success" : "warning"}
+          message={flow.duplicateSource
+            ? "That package is already imported"
+            : flow.draft.source.trim() ? "Source ready" : "Repository or remote URL required"}
           onChange={(source) => flow.updateDraft({ source })}
         />
         <TextInput

--- a/web/src/app/features/gsv-console/packages/PackageDetailPage.tsx
+++ b/web/src/app/features/gsv-console/packages/PackageDetailPage.tsx
@@ -84,14 +84,16 @@ export function PackageDetailPage({
                 setConfirmAction("checkout");
               }}
             />
-            <Button
-              variant="dangerGhost"
-              label={lifecycle.removeMutation.isPending ? "REMOVING" : "REMOVE PACKAGE"}
-              disabled={pending}
-              onClick={() => setConfirmAction("remove")}
-            />
             {error ? <span class="gsv-console-detail-action-error">{error.message}</span> : null}
           </div>
+        )}
+        dangerAction={(
+          <Button
+            variant="dangerGhost"
+            label={lifecycle.removeMutation.isPending ? "REMOVING" : "REMOVE PACKAGE"}
+            disabled={pending}
+            onClick={() => setConfirmAction("remove")}
+          />
         )}
         icon={pkg.uiEntrypoints.length > 0 ? "stars" : "pencil"}
         title={pkg.name}

--- a/web/src/app/features/gsv-console/packages/packagePresentation.ts
+++ b/web/src/app/features/gsv-console/packages/packagePresentation.ts
@@ -83,6 +83,7 @@ export function packageDetailSections(pkg: ConsolePackage): ConsoleDetailSection
     {
       title: "PACKAGE",
       meta: statusForPackage(pkg),
+      metaTone: toneForPackage(pkg),
       rows: liveRows([
         detailRow("package-id", "PACKAGE ID", pkg.packageId),
         detailRow("status", "STATUS", statusForPackage(pkg), {

--- a/web/src/app/features/gsv-console/packages/usePackageImportFlow.ts
+++ b/web/src/app/features/gsv-console/packages/usePackageImportFlow.ts
@@ -102,8 +102,20 @@ export function usePackageImportFlow({ knownPackages }: UsePackageImportFlowOpti
     return await enableMutation.mutateAsync(importedPackage);
   };
 
+  // Block importing the exact same source again (repo + ref + subdir) — that
+  // package already exists. Different subdirs/refs of the same repo are distinct
+  // packages, so compare the full triple. The gateway stays authoritative.
+  const normalizedDraft = normalizePackageImportDraft(draft);
+  const duplicateSource =
+    normalizedDraft.source.length > 0 &&
+    knownPackages.some((pkg) =>
+      pkg.sourceRepo.trim().toLowerCase() === normalizedDraft.source.toLowerCase() &&
+      pkg.sourceRef.trim().toLowerCase() === normalizedDraft.ref.toLowerCase() &&
+      pkg.sourceSubdir.trim().toLowerCase() === normalizedDraft.subdir.toLowerCase());
+
   return {
     draft,
+    duplicateSource,
     enableImportedPackage,
     enableMutation,
     importApplication,

--- a/web/src/app/features/gsv-console/pages/ConsoleAgentPage.tsx
+++ b/web/src/app/features/gsv-console/pages/ConsoleAgentPage.tsx
@@ -336,6 +336,7 @@ function NewAgentEditorSurface({
             avatarSrc={draftAvatar}
             avatarCover
             containerWidth={width || undefined}
+            reservedNames={accounts.flatMap((account) => [account.displayName, account.username])}
             initialRole="AGENT"
             initialDescription=""
             initialApprovalPolicy={defaultApprovalPolicy}

--- a/web/src/app/features/gsv-console/runtime/RuntimeDetailPage.tsx
+++ b/web/src/app/features/gsv-console/runtime/RuntimeDetailPage.tsx
@@ -57,14 +57,16 @@ export function RuntimeDetailPage({ onBack, process }: RuntimeDetailPageProps) {
               disabled={pending}
               onClick={() => setConfirmAction("reset")}
             />
-            <Button
-              variant="dangerGhost"
-              label={pending && action.variables?.action === "kill" ? "KILLING" : "KILL TASK"}
-              disabled={pending}
-              onClick={() => setConfirmAction("kill")}
-            />
             {action.isError ? <span class="gsv-runtime-task-action-error">{action.error.message}</span> : null}
           </div>
+        )}
+        dangerAction={(
+          <Button
+            variant="dangerGhost"
+            label={pending && action.variables?.action === "kill" ? "KILLING" : "KILL TASK"}
+            disabled={pending}
+            onClick={() => setConfirmAction("kill")}
+          />
         )}
         icon={iconForProcess(process)}
         title={process.label}

--- a/web/src/app/features/gsv-console/runtime/runtimePresentation.ts
+++ b/web/src/app/features/gsv-console/runtime/runtimePresentation.ts
@@ -58,6 +58,7 @@ export function processDetailSections(process: ConsoleProcess): ConsoleDetailSec
     {
       title: "STATE",
       meta: statusForProcess(process),
+      metaTone: toneForProcess(process),
       rows: liveRows([
         detailRow("state", "CURRENT STATE", process.rawState || statusForProcess(process), {
           status: listRowStatusForTone(toneForProcess(process)),

--- a/web/src/app/features/gsv-shell/GsvShell.tsx
+++ b/web/src/app/features/gsv-shell/GsvShell.tsx
@@ -131,6 +131,17 @@ function systemLoadLabel(
   return "IDLE";
 }
 
+/** Tone for the system-load readout: only the genuine status states
+ *  (error/offline/loading) take a color; counts and IDLE stay neutral. */
+function systemLoadTone(
+  resource: ConsoleResourceState<ConsoleOverviewData>,
+): "error" | "offline" | "loading" | undefined {
+  if (resource.isError) return "error";
+  if (resource.isUnavailable) return "offline";
+  if (resource.isLoading) return "loading";
+  return undefined;
+}
+
 function CollapsedDesktop() {
   return (
     <div class="gsv-collapsed-desktop" aria-hidden="true">
@@ -181,6 +192,10 @@ export function GsvShell({
   const statusSystemLabel = useMemo(
     () => systemLoadLabel(consoleOverview.counts, consoleOverview.resource),
     [consoleOverview.counts, consoleOverview.resource],
+  );
+  const statusSystemTone = useMemo(
+    () => systemLoadTone(consoleOverview.resource),
+    [consoleOverview.resource],
   );
   const desktopObjects = useMemo(
     () => buildDesktopObjectsFromConsole(consoleOverview.data),
@@ -670,6 +685,7 @@ export function GsvShell({
         context={shell.statusContext}
         clock={clock}
         systemLoadLabel={statusSystemLabel}
+        systemLoadTone={statusSystemTone}
         sessionUsername={sessionUsername}
         mobileHomeDate={mobileHomeDate}
         notificationOpenSurface={notificationOpenSurface}

--- a/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
+++ b/web/src/app/features/gsv-shell/desktop/GsvDesktop.tsx
@@ -5,7 +5,7 @@ import { GsvMark } from "../../../components/ui/GsvMark";
 import { DesktopHint } from "./DesktopHint";
 import { IconMenu } from "../../../components/ui/IconMenu";
 import { ObjectCard } from "../../../components/ui/ObjectCard";
-import { StatusDot } from "../../../components/ui/StatusDot";
+import { StatusDot, STATUS_TEXT } from "../../../components/ui/StatusDot";
 import { Tile } from "../../../components/ui/Tile";
 import {
   type DesktopChildObject,
@@ -173,6 +173,19 @@ export function GsvDesktop({
       : inventoryReady
         ? "SYSTEM MAP"
         : inventoryState.toUpperCase();
+  // Tone for the HUD status readout: a selected object carries its own status
+  // tone; a not-ready inventory maps error/offline/loading to their tones (same
+  // mapping as the inventory-state dot below). Neutral chrome ("SYSTEM MAP",
+  // "GSV / CONTROL") stays uncolored (dim default).
+  const hudTone: ShellStatus | null = selectedObject
+    ? selectedObject.status
+    : gsvOpen || inventoryReady
+      ? null
+      : inventoryState === "error"
+        ? "error"
+        : inventoryState === "offline"
+          ? "idle"
+          : "warn";
 
   // When a node is selected, settle the view so its objects are readable: scroll
   // up to centre the strip, but never past the point where the tiles row sits at
@@ -271,7 +284,7 @@ export function GsvDesktop({
               : inventoryMessage}
           </small>
         </div>
-        <p>{hudStatus}</p>
+        <p style={hudTone ? { color: STATUS_TEXT[hudTone] } : undefined}>{hudStatus}</p>
       </header>
 
       <div class="gsv-space-scroll" ref={sectionRef}>
@@ -344,7 +357,6 @@ export function GsvDesktop({
                     type="button"
                     class={`gsv-space-tile-button${selectedObjectId === object.id ? " is-selected" : ""}${activeObjectId === object.id ? " is-active" : ""}`}
                     aria-pressed={selectedObjectId === object.id ? "true" : "false"}
-                    title={`${object.label}: ${object.meta}, ${object.statusLabel}`}
                     onMouseEnter={() => setHoveredObjectId(object.id)}
                     onMouseLeave={() => setHoveredObjectId((current) => (current === object.id ? null : current))}
                     onClick={(event) => {
@@ -356,6 +368,7 @@ export function GsvDesktop({
                       label={object.label}
                       glyph={object.glyph}
                       status={object.status}
+                      statusHint={object.statusLabel}
                       selected={selectedObjectId === object.id}
                     />
                   </button>

--- a/web/src/app/features/gsv-shell/navigation/ShellStatusBar.tsx
+++ b/web/src/app/features/gsv-shell/navigation/ShellStatusBar.tsx
@@ -5,6 +5,7 @@ type ShellStatusBarProps = {
   context: string;
   clock: string;
   systemLoadLabel: string;
+  systemLoadTone?: "error" | "offline" | "loading";
   sessionUsername: string;
   mobileHomeDate: string;
   notificationOpenSurface: NotificationSurface | null;
@@ -35,6 +36,7 @@ export function ShellStatusBar({
   context,
   clock,
   systemLoadLabel,
+  systemLoadTone,
   sessionUsername,
   mobileHomeDate,
   notificationOpenSurface,
@@ -48,6 +50,7 @@ export function ShellStatusBar({
         clock={clock}
         context={context}
         power={systemLoadLabel}
+        powerTone={systemLoadTone}
         showModel={false}
         showStatus={false}
       />

--- a/web/src/design-system/previews.tsx
+++ b/web/src/design-system/previews.tsx
@@ -139,6 +139,9 @@ function DetailPreview() {
           blurb="linux x86_64 · v0.80.2 · root · last seen 2m ago"
           parentLabel="MACHINES"
           onBack={noop}
+          actions={<Button variant="secondary" label="REFRESH" onClick={noop} />}
+          primaryLabel="OPEN CONSOLE"
+          onPrimary={noop}
           dangerAction={<Button variant="dangerGhost" label="FORGET MACHINE" onClick={noop} />}
           sections={[
             {

--- a/web/src/design-system/previews.tsx
+++ b/web/src/design-system/previews.tsx
@@ -149,6 +149,7 @@ function DetailPreview() {
                 { id: "platform", label: "PLATFORM", sub: "linux x86_64" },
                 { id: "version", label: "VERSION", sub: "v0.80.2" },
                 { id: "owner", label: "OWNER", sub: "root" },
+                { id: "last-seen", label: "LAST SEEN", labelInfo: "When this machine last connected or disconnected. For an online machine it's when the current session began; for an offline one, when it dropped.", sub: "2m ago" },
               ],
             },
             {

--- a/web/src/design-system/previews.tsx
+++ b/web/src/design-system/previews.tsx
@@ -4,6 +4,7 @@ import { ListTemplate, type ListTemplateRow } from "../app/features/gsv-console/
 import { CardListTemplate } from "../app/features/gsv-console/card-template/CardListTemplate";
 import { ConsolePage } from "../app/features/gsv-console/components/ConsolePageTemplate";
 import { ConsoleDetailPage } from "../app/features/gsv-console/components/ConsoleDetailPage";
+import { Button } from "../app/components/ui/Button";
 import { SettingsOverviewDashboard } from "../app/features/gsv-console/pages/ConsoleOverviewPanels";
 import type {
   ConsoleAccount,
@@ -138,6 +139,7 @@ function DetailPreview() {
           blurb="linux x86_64 · v0.80.2 · root · last seen 2m ago"
           parentLabel="MACHINES"
           onBack={noop}
+          dangerAction={<Button variant="dangerGhost" label="FORGET MACHINE" onClick={noop} />}
           sections={[
             {
               title: "MACHINE",

--- a/web/src/design-system/previews.tsx
+++ b/web/src/design-system/previews.tsx
@@ -142,6 +142,7 @@ function DetailPreview() {
             {
               title: "MACHINE",
               meta: "ONLINE",
+              metaTone: "online",
               rows: [
                 { id: "device", label: "DEVICE ID", sub: "rearden-prime" },
                 { id: "status", icon: "computer", label: "STATUS", status: "online", statusLabel: "ONLINE", sub: "reachable" },

--- a/web/src/design-system/stories/LineGlyphs.story.tsx
+++ b/web/src/design-system/stories/LineGlyphs.story.tsx
@@ -3,6 +3,7 @@ import {
   SpeakerOffGlyph,
   ArchiveFolderGlyph,
   ArrowLeftGlyph,
+  CopyGlyph,
   FreeContextGlyph,
   ModelChipGlyph,
   MoreVerticalGlyph,
@@ -18,6 +19,7 @@ const GLYPHS: { label: string; node: (size: number) => ComponentChildren }[] = [
   { label: "speaker-off", node: (s) => <SpeakerOffGlyph size={s} /> },
   { label: "archive", node: (s) => <ArchiveFolderGlyph size={s} /> },
   { label: "free-context", node: (s) => <FreeContextGlyph size={s} /> },
+  { label: "copy", node: (s) => <CopyGlyph size={s} /> },
   { label: "plus", node: (s) => <PlusGlyph size={s} /> },
   { label: "task-list", node: (s) => <TaskListGlyph size={s} /> },
   { label: "model-chip", node: (s) => <ModelChipGlyph size={s} /> },
@@ -29,7 +31,7 @@ const GLYPHS: { label: string; node: (size: number) => ComponentChildren }[] = [
 const story: Story = {
   title: "Line glyphs",
   group: "Chrome",
-  blurb: "Inline outline glyphs (crisp at small sizes) · speaker on/off · archive · free-context · plus · task-list · model-chip · more-vertical · arrow-left · reasoning",
+  blurb: "Inline outline glyphs (crisp at small sizes) · speaker on/off · archive · free-context · copy · plus · task-list · model-chip · more-vertical · arrow-left · reasoning",
   render: () => (
     <div class="ds-col">
       <div class="ds-cell">

--- a/web/src/design-system/stories/ListRow.story.tsx
+++ b/web/src/design-system/stories/ListRow.story.tsx
@@ -25,6 +25,7 @@ const story: Story = {
           <ListRow label="PRIMARY NODE" status="online" sub="192.168.1.42 · 8 CORES" />
           <ListRow label="BUILD NODE" status="online" tag="UPDATE" />
           <ListRow label="EDGE NODE" status="online" statusLabel="ONLINE" chevron onClick={() => {}} />
+          <ListRow label="LAST SEEN" labelInfo="Explains what this field means on hover." status="none" sub="2m ago" />
         </div>
       </div>
       <div class="ds-cell">

--- a/web/src/design-system/stories/StatusBar.story.tsx
+++ b/web/src/design-system/stories/StatusBar.story.tsx
@@ -29,6 +29,15 @@ const story: Story = {
         </div>
       </div>
       <div class="ds-cell">
+        <div class="ds-label">Power tone (powerTone — colors the ⏻ system readout)</div>
+        <div class="ds-col" style={{ width: "760px", maxWidth: "100%" }}>
+          <StatusBar showStatus={false} power="3 RUNS" />
+          <StatusBar showStatus={false} power="SYNCING" powerTone="loading" />
+          <StatusBar showStatus={false} power="OFFLINE" powerTone="offline" />
+          <StatusBar showStatus={false} power="ERROR" powerTone="error" />
+        </div>
+      </div>
+      <div class="ds-cell">
         <div class="ds-label">Hide model / status (showModel · showStatus)</div>
         <div class="ds-col" style={{ width: "760px", maxWidth: "100%" }}>
           <StatusBar showModel={false} />

--- a/web/src/design-system/stories/TextInput.story.tsx
+++ b/web/src/design-system/stories/TextInput.story.tsx
@@ -27,6 +27,7 @@ const story: Story = {
       <div class="ds-cell">
         <div class="ds-label">States & extras</div>
         <div class="ds-col">
+          <TextInput label="WITH INFO" info="A short help tooltip shown on the ? after the label." placeholder="hover the ?" />
           <TextInput label="REQUIRED" requirement="required" description="Shown above the field." placeholder="role" />
           <TextInput label="OPTIONAL" requirement="optional" placeholder="nickname" />
           <TextInput label="WITH COUNTER" maxLength={24} value="hello" />

--- a/web/src/design-system/stories/Tile.story.tsx
+++ b/web/src/design-system/stories/Tile.story.tsx
@@ -4,7 +4,7 @@ import type { Story } from "../story";
 const story: Story = {
   title: "Tile",
   group: "Data Display",
-  blurb: "96px object tile · glyph · corner status dot · selected · anchor",
+  blurb: "96px object tile · glyph · corner status dot (hover for its meaning) · selected · anchor",
   render: () => (
     <div class="ds-col">
       <div class="ds-cell">
@@ -32,6 +32,7 @@ const story: Story = {
         <div class="ds-row">
           <Tile label="MACHINES" glyph="machines" selected />
           <Tile label="INTEGRATIONS" glyph="integrations" selected status="live" />
+          <Tile label="SELECTOR" glyph="machines" selected status="accent" statusHint="Select MAC" />
         </div>
       </div>
       <div class="ds-cell">


### PR DESCRIPTION
Console + machines papercuts: tooltips that don't get clipped, forms that don't lie about their state, and a consistent detail-page action footer.

## Tooltips
- Field/label help tooltips now render through the **portaled `Hint`** instead of the in-DOM `InfoTip` bubble, so they escape any `overflow:hidden` ancestor (this was clipping the LAST SEEN and connect-flow tooltips). `InfoTip` was rewritten internally to wrap `Hint` + the `help` `IconButton`, keeping its API and `gsv-infotip` spacing — so **every** consumer (TextInput, Toggle, Select, TextArea, Checkbox, Radio, Counter, Segmented, Slider) is fixed in one place.
- Earlier papercuts along the way: `(?)` tooltip on LAST SEEN, browser target uses the Chrome icon (not a bookmark), copy glyph, status colors, tile tooltip.

## Forms: placeholders aren't defaults, required means required
- `TextInput`/`TextArea` now **enforce** `requirement="required"`: an empty required field surfaces a `REQUIRED` error on blur (or via a new `forceValidate` prop). A caller-supplied `status` still wins, so existing hand-rolled validation is unaffected.
- The connect-new-machine flow no longer **seeds** MACHINE NAME / DEVICE ID with derived defaults — they start empty with platform-contextual placeholders (`Mac workstation` / `mac-workstation`, `Linux machine` / `linux-machine`, …) and the user must type them. Genuine defaults (git `ref: main`, `subdir: .`, token expiry `30`) are kept.

## Uniqueness on create (all object types)
- New shared `isNameTaken(existing, candidate)` helper (trim + case-insensitive). Wired into create flows so you can't create an object whose identity already exists — gateway stays authoritative, this is an inline pre-check:
  - **Machines**: duplicate device-id (and display label) blocked before token issuance.
  - **Integrations**: duplicate MCP server name.
  - **Packages**: duplicate import source (repo + ref + subdir).
  - **Agents**: duplicate name/username, via a new `reservedNames` prop on `AgentEditor`.

## Detail-page action footer
- The destructive action (FORGET / REMOVE / DISCONNECT / KILL) and the regular secondary/primary actions now all live in a **bottom footer** on every console detail page — destructive left-aligned, secondary + primary right-aligned. The top action bar is now just the icon + description.

## Verification
- `tsc --noEmit` clean; `277/277` unit tests pass (one unrelated pre-existing `ChatTranscript.test.ts` DOMPurify-mock failure, untouched here).
- Verified in the `/design` catalog: InfoTip bubble portals to `<body>`; required TextInput shows `REQUIRED` on blur-while-empty and clears on type; detail-template footer renders destructive-left / actions-right.
- Reviewed by three parallel passes; the one substantive finding (post-provision back-nav flagging the machine as a duplicate of itself) is fixed by scoping the check to pre-issuance.
