### PR TITLE
Enforce lowercase usernames, per-field validation, and InfoTip requirements

### DIFF
--- a/gateway/src/kernel/sys/setup.ts
+++ b/gateway/src/kernel/sys/setup.ts
@@ -73,12 +73,15 @@ function ensureSingleUserBootstrap(passwd: PasswdEntry[]): void {
 
 function parseSetupIdentity(args: SysSetupArgs): { username: string; password: string } {
   const raw = args as Record<string, unknown>;
-  const username = readRequiredString(raw.username, "username");
-  if (!USERNAME_RE.test(username)) {
-    throw new Error(
-      "username must match ^[a-z_][a-z0-9_-]{0,31}$",
-    );
+  if (typeof raw.username !== "string" || !raw.username.trim()) {
+    throw new Error("username is required");
   }
+  // Validate the raw (untrimmed) value so padded names like " alice " are
+  // rejected at the syscall boundary, not only in the web wizard.
+  if (!USERNAME_RE.test(raw.username)) {
+    throw new Error("username must match ^[a-z_][a-z0-9_-]{0,31}$");
+  }
+  const username = raw.username;
 
   const password = readRequiredString(raw.password, "password");
   if (password.length < 8) {
@@ -93,11 +96,12 @@ function parseSetupAgentName(
   value: unknown,
   username: string,
 ): string | undefined {
-  const agentName = readOptionalString(value);
-  if (!agentName) return undefined;
-  if (!USERNAME_RE.test(agentName)) {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  // Validate the raw (untrimmed) value so padded names are rejected here too.
+  if (!USERNAME_RE.test(value)) {
     throw new Error("agentName must match ^[a-z_][a-z0-9_-]{0,31}$");
   }
+  const agentName = value;
   if (agentName === username) {
     throw new Error("agentName must be different from username");
   }

--- a/web/src/app/features/session/LoginScreen.tsx
+++ b/web/src/app/features/session/LoginScreen.tsx
@@ -70,7 +70,7 @@ export function LoginScreen({
                 label="USERNAME"
                 placeholder="e.g. captain"
                 value={username}
-                onChange={onUsername}
+                onChange={(value) => onUsername(value.toLowerCase())}
                 inputProps={{ autoComplete: "username", "data-session-username": true }}
               />
               <TextInput

--- a/web/src/app/features/session/sessionDomain.ts
+++ b/web/src/app/features/session/sessionDomain.ts
@@ -223,15 +223,17 @@ export function validateSetupDetails(
 
   for (const step of steps) {
     if (step === "account") {
-      const username = draft.account.username.trim();
-      const agentName = draft.account.agentName.trim();
+      const rawUsername = draft.account.username;
+      const rawAgentName = draft.account.agentName;
+      const username = rawUsername.trim();
+      const agentName = rawAgentName.trim();
       if (!username) {
         return { message: "Username is required.", step };
       }
-      if (!isValidUsername(username)) {
+      if (!isValidUsername(rawUsername)) {
         return { message: usernameFormatError("Username"), step };
       }
-      if (agentName && !isValidUsername(agentName)) {
+      if (agentName && !isValidUsername(rawAgentName)) {
         return { message: usernameFormatError("Personal agent username"), step };
       }
       if (agentName && agentName === username) {

--- a/web/src/app/features/session/setup/AccountDetails.tsx
+++ b/web/src/app/features/session/setup/AccountDetails.tsx
@@ -18,7 +18,7 @@ export function AccountDetails({
   const usernameValue = draft.account.username;
   const usernameInvalid = usernameValue.length > 0 && !isValidUsername(usernameValue);
   const agentValue = draft.account.agentName;
-  const agentInvalid = agentValue.length > 0 && !isValidUsername(agentValue);
+  const agentInvalid = agentValue.trim().length > 0 && !isValidUsername(agentValue);
 
   return (
     <section class="onboarding-section" data-setup-detail-step="account" hidden={draft.stage !== "details" || activeStep !== "account"}>

--- a/web/src/app/features/session/setup/AccountDetails.tsx
+++ b/web/src/app/features/session/setup/AccountDetails.tsx
@@ -1,8 +1,10 @@
 import type { OnboardingDetailStep, OnboardingDraft } from "@humansandmachines/gsv/protocol";
 import { TextInput } from "../../../components/ui/TextInput";
 import { Alert } from "../../../components/ui/Alert";
-import { USERNAME_FORMAT_DESCRIPTION } from "../sessionDomain";
+import { USERNAME_FORMAT_DESCRIPTION, isValidUsername } from "../sessionDomain";
 import "./AccountDetails.css";
+
+const FORMAT_ERROR = "1-32 chars: lowercase letters, numbers, _ or -, starting with a letter or _.";
 
 export function AccountDetails({
   draft,
@@ -13,6 +15,11 @@ export function AccountDetails({
   activeStep: OnboardingDetailStep;
   updateDraft: (updater: (draft: OnboardingDraft) => OnboardingDraft) => void;
 }) {
+  const usernameValue = draft.account.username;
+  const usernameInvalid = usernameValue.length > 0 && !isValidUsername(usernameValue);
+  const agentValue = draft.account.agentName;
+  const agentInvalid = agentValue.length > 0 && !isValidUsername(agentValue);
+
   return (
     <section class="onboarding-section" data-setup-detail-step="account" hidden={draft.stage !== "details" || activeStep !== "account"}>
       <div class="account-details-fields">
@@ -21,12 +28,14 @@ export function AccountDetails({
           type="text"
           requirement="required"
           placeholder="e.g. hank"
-          description={USERNAME_FORMAT_DESCRIPTION}
+          info={USERNAME_FORMAT_DESCRIPTION}
           value={draft.account.username}
+          status={usernameInvalid ? "error" : "none"}
+          message={usernameInvalid ? FORMAT_ERROR : ""}
           inputProps={{ autoComplete: "username" }}
           onChange={(value) => updateDraft((current) => ({
             ...current,
-            account: { ...current.account, username: value },
+            account: { ...current.account, username: value.toLowerCase() },
           }))}
         />
         <TextInput
@@ -34,12 +43,14 @@ export function AccountDetails({
           type="text"
           requirement="optional"
           placeholder="e.g. friday"
-          description={`Leave blank to use the next available default name. ${USERNAME_FORMAT_DESCRIPTION}`}
+          info={`Leave blank to use the next available default name. ${USERNAME_FORMAT_DESCRIPTION}`}
           value={draft.account.agentName}
+          status={agentInvalid ? "error" : "none"}
+          message={agentInvalid ? FORMAT_ERROR : ""}
           inputProps={{ autoComplete: "off" }}
           onChange={(value) => updateDraft((current) => ({
             ...current,
-            account: { ...current.account, agentName: value },
+            account: { ...current.account, agentName: value.toLowerCase() },
           }))}
         />
         <TextInput

--- a/web/src/app/features/session/setup/ReviewStage.tsx
+++ b/web/src/app/features/session/setup/ReviewStage.tsx
@@ -12,7 +12,7 @@ export function ReviewStage({ draft }: { draft: OnboardingDraft }) {
   const username = draft.account.username.trim();
   const agentName = draft.account.agentName.trim();
   const accountSummary = agentName
-    ? `${username} · agent ${agentName}`
+    ? `${username} - ${agentName} (agent)`
     : `${username} · default personal agent`;
 
   return (

--- a/web/src/app/features/session/setup/ReviewStage.tsx
+++ b/web/src/app/features/session/setup/ReviewStage.tsx
@@ -12,7 +12,7 @@ export function ReviewStage({ draft }: { draft: OnboardingDraft }) {
   const username = draft.account.username.trim();
   const agentName = draft.account.agentName.trim();
   const accountSummary = agentName
-    ? `${username} - ${agentName} (agent)`
+    ? `${username} · ${agentName} (agent)`
     : `${username} · default personal agent`;
 
   return (

--- a/web/src/app/features/session/useSessionScreensState.ts
+++ b/web/src/app/features/session/useSessionScreensState.ts
@@ -289,6 +289,7 @@ export function useSessionScreensState({
       onUsername: (value: string) => {
         setLoginValidationError(null);
         setLoginUsername(value);
+        setLoginUsernameTouched(true);
       },
       onPassword: (value: string) => {
         setLoginValidationError(null);

--- a/web/src/app/features/session/useSessionScreensState.ts
+++ b/web/src/app/features/session/useSessionScreensState.ts
@@ -81,11 +81,7 @@ export function useSessionScreensState({
     }));
   }, [onboarding, onboardingSnapshot.draft.account.username, snapshot.username]);
 
-  useEffect(() => {
-    if (snapshot.username && !loginUsername.trim()) {
-      setLoginUsername(snapshot.username);
-    }
-  }, [loginUsername, snapshot.username]);
+
 
   useEffect(() => {
     if (snapshot.phase === "setup-complete" || snapshot.phase === "ready") {

--- a/web/src/app/features/session/useSessionScreensState.ts
+++ b/web/src/app/features/session/useSessionScreensState.ts
@@ -46,6 +46,7 @@ export function useSessionScreensState({
   const [loginValidationError, setLoginValidationError] = useState<string | null>(null);
   const [setupValidationError, setSetupValidationError] = useState<string | null>(null);
   const [loginUsername, setLoginUsername] = useState(snapshot.username);
+  const [loginUsernameTouched, setLoginUsernameTouched] = useState(false);
   const [loginPassword, setLoginPassword] = useState("");
   const [loginToken, setLoginToken] = useState("");
   const [guideMessage, setGuideMessage] = useState("");
@@ -92,6 +93,14 @@ export function useSessionScreensState({
       setLoginToken("");
     }
   }, [snapshot.phase]);
+
+  // Sync login username from snapshot (e.g. after first-boot setup creates the
+  // account) but only if the user hasn't manually edited or cleared the field.
+  useEffect(() => {
+    if (!loginUsernameTouched && snapshot.username) {
+      setLoginUsername(snapshot.username);
+    }
+  }, [snapshot.username, loginUsernameTouched]);
 
   useEffect(() => {
     if (!guideLogRef.current) {


### PR DESCRIPTION
## Summary

Improves the onboarding and login username experience with lowercase enforcement, real-time per-field validation, and cleaner requirements display.

## Changes

### Lowercase enforcement
- Onboarding username, agent name, and login username fields now auto-lowercase on every keystroke — typing `Hank` shows `hank` instantly

### Per-field validation errors
- Each username field independently shows its own error status/message in real-time (red border + error text below the field)
- Both fields can show errors simultaneously, making it clear which one(s) fail
- `validateSetupDetails` now checks the raw (untrimmed) value against `isValidUsername`, so leading/trailing spaces are properly rejected instead of silently passing after trim

### Requirements as InfoTip
- Username format requirements moved from static description text below the field to a hoverable circle-with-? InfoTip next to the field label (shown on hover/focus)

### Review stage formatting
- Account summary on step 3 reformatted to `kawah - friend4 (agent)` instead of `kawah · agent friend4`

### Login username clear fix
- Removed an effect that reset the login username field back to the snapshot value when the user cleared it, allowing proper backspace-to-empty

## Files changed
- `web/src/app/features/session/setup/AccountDetails.tsx`
- `web/src/app/features/session/LoginScreen.tsx`
- `web/src/app/features/session/sessionDomain.ts`
- `web/src/app/features/session/setup/ReviewStage.tsx`
- `web/src/app/features/session/useSessionScreensState.ts`