### PR TITLE
disable just-bash dns guard on gsv

### DIFF
--- a/gateway/src/drivers/native/shell.test.ts
+++ b/gateway/src/drivers/native/shell.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
 import { Bash } from "just-bash";
-import { handleShellExec } from "./shell";
+import { handleShellExec, NATIVE_SHELL_NETWORK_CONFIG } from "./shell";
 import {
   handleFsCopy,
   handleFsRead,
@@ -430,6 +430,27 @@ describe("native shell execution", () => {
 
       expect(result).toMatchObject({ status: "completed", exitCode: 0 });
       expect(stored.body && await bodyToBytes(stored.body)).toEqual(bytes);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("routes curl through Worker fetch without the unsupported DNS guard", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("worker network ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const result = await handleShellExec({
+        input: "curl -s https://example.test/data",
+      }, makeContext());
+
+      expect(NATIVE_SHELL_NETWORK_CONFIG.denyPrivateRanges).toBe(false);
+      expect(result).toMatchObject({
+        status: "completed",
+        exitCode: 0,
+        stdout: "worker network ok",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0]?.[0]).toBe("https://example.test/data");
     } finally {
       vi.unstubAllGlobals();
     }

--- a/gateway/src/drivers/native/shell.ts
+++ b/gateway/src/drivers/native/shell.ts
@@ -9,7 +9,7 @@
  */
 
 import { Bash } from "just-bash";
-import type { BashExecResult } from "just-bash";
+import type { BashExecResult, NetworkConfig } from "just-bash";
 import { resolveUserPath } from "../../fs";
 import type { KernelContext } from "../../kernel/context";
 import type { ShellExecArgs, ShellExecResult } from "../../syscalls/shell";
@@ -19,6 +19,15 @@ import {
   buildCustomCommands,
   type NativeShellCommandOptions,
 } from "./shell/commands";
+
+export const NATIVE_SHELL_NETWORK_CONFIG = {
+  dangerouslyAllowFullInternetAccess: true,
+  // just-bash enables this production guard through node:dns.lookup, which
+  // Cloudflare Workers does not implement. Native gsv requests use global
+  // fetch rather than a private-network binding, so let the runtime resolve
+  // public hostnames instead of failing before fetch.
+  denyPrivateRanges: false,
+} satisfies NetworkConfig;
 
 export async function handleShellExec(
   args: ShellExecArgs,
@@ -160,7 +169,7 @@ function createBash(
       gid: identity.gid,
     },
     network: networkEnabled
-      ? { dangerouslyAllowFullInternetAccess: true }
+      ? NATIVE_SHELL_NETWORK_CONFIG
       : undefined,
     executionLimits: {
       maxCommandCount: 1000,


### PR DESCRIPTION
## Summary

- explicitly disable the just-bash private-range DNS guard for the native gsv shell
- keep the current just-bash release instead of rolling back unrelated fixes
- add a Worker-runtime regression test proving curl reaches global fetch

## Why

just-bash enables denyPrivateRanges in production and calls node:dns.lookup before fetch. Cloudflare Workers does not implement lookup, so every public hostname fails with DNS resolution failed for private IP check.

This intentionally disables that DNS/private-range preflight on the gsv target. Connected-machine shell targets are unchanged.

## Validation

- npm run gsv:build
- cd gateway && npx tsc --noEmit
- cd gateway && npx vitest run src/drivers/native/shell.test.ts (96 passed)
- cd gateway && npm run test:run (1252 passed, 5 skipped)
- cd gateway && npx wrangler deploy --dry-run