### PR TITLE
Make WhatsApp lease refresh seamless

### DIFF
--- a/adapters/whatsapp/README.md
+++ b/adapters/whatsapp/README.md
@@ -65,11 +65,13 @@ While connected, the outbound WhatsApp WebSocket prevents the account Durable
 Object from being evicted. Cloudflare limits that keepalive effect to 15 minutes
 per outbound connection; the WebSocket itself may continue after that point.
 GSV therefore schedules an alarm ten minutes after each successful connection.
-When the alarm fires, the account closes the old transport and reconnects with
-its saved linked-device credentials, establishing a fresh outbound-connection
-lease before the 15-minute keepalive cap. The alarm is the scheduled trigger,
-not the mechanism that keeps the object alive, and this reconnect is not a
-WhatsApp logout or a new pairing.
+When the alarm fires, the account opens a replacement with its saved
+linked-device credentials while the current transport keeps handling messages.
+Only after the replacement authenticates does it become active and close the
+old transport, establishing a fresh outbound-connection lease before the
+15-minute keepalive cap. The alarm is the scheduled trigger, not the mechanism
+that keeps the object alive, and this reconnect is not a WhatsApp logout or a
+new pairing.
 
 This design targets the free Workers and Durable Objects plan; it does not
 require Containers. The account alarm also arbitrates pairing expiry,

--- a/adapters/whatsapp/src/auth-store.ts
+++ b/adapters/whatsapp/src/auth-store.ts
@@ -181,6 +181,7 @@ export async function useDOAuthState(
   } else {
     creds = initAuthCreds();
   }
+  let localBaseline = cloneAuthenticationCreds(creds);
 
   return {
     authReset,
@@ -189,12 +190,71 @@ export async function useDOAuthState(
       keys: createDOSignalKeyStore(storage, authEpoch),
     },
     saveCreds: async () => {
+      const desired = cloneAuthenticationCreds(creds);
       await storage.transaction(async (txn) => {
         await assertAuthEpoch(txn, authEpoch);
-        await txn.put(CREDS_KEY, serializeAuthValue(creds));
+        const latest = storedAuthenticationCreds(
+          await txn.get<string>(CREDS_KEY),
+          localBaseline,
+        );
+        await txn.put(
+          CREDS_KEY,
+          serializeAuthValue(mergeCredentialChanges(localBaseline, desired, latest)),
+        );
       });
+      // Keep this socket's own baseline, not the merged durable value. Another
+      // overlapping socket may have changed fields that are absent from this
+      // socket's in-memory snapshot; treating those as local removals on the
+      // next save would reintroduce the stale-snapshot race.
+      localBaseline = desired;
     },
   };
+}
+
+function storedAuthenticationCreds(
+  stored: string | undefined,
+  fallback: AuthenticationCreds,
+): AuthenticationCreds {
+  if (stored !== undefined) {
+    try {
+      const parsed = deserializeAuthValue(stored);
+      if (isAuthenticationCreds(parsed)) return parsed;
+    } catch {
+      // A valid local snapshot can repair a corrupt credential record below.
+    }
+  }
+  return cloneAuthenticationCreds(fallback);
+}
+
+/** Merge only this socket's changes onto the latest durable credential record. */
+function mergeCredentialChanges(
+  baseline: AuthenticationCreds,
+  desired: AuthenticationCreds,
+  latest: AuthenticationCreds,
+): AuthenticationCreds {
+  const merged = cloneAuthenticationCreds(latest);
+  const baselineRecord = baseline as unknown as Record<string, unknown>;
+  const desiredRecord = desired as unknown as Record<string, unknown>;
+  const mergedRecord = merged as unknown as Record<string, unknown>;
+  const keys = new Set([...Object.keys(baselineRecord), ...Object.keys(desiredRecord)]);
+
+  for (const key of keys) {
+    if (serializedField(baselineRecord[key]) === serializedField(desiredRecord[key])) continue;
+    if (Object.hasOwn(desiredRecord, key)) {
+      mergedRecord[key] = desiredRecord[key];
+    } else {
+      delete mergedRecord[key];
+    }
+  }
+  return merged;
+}
+
+function cloneAuthenticationCreds(creds: AuthenticationCreds): AuthenticationCreds {
+  return deserializeAuthValue(serializeAuthValue(creds)) as AuthenticationCreds;
+}
+
+function serializedField(value: unknown): string {
+  return serializeAuthValue({ value });
 }
 
 export async function clearAuthState(storage: DurableObjectStorage): Promise<number> {

--- a/adapters/whatsapp/src/lifecycle.ts
+++ b/adapters/whatsapp/src/lifecycle.ts
@@ -21,7 +21,7 @@ export function disconnectPolicy(statusCode: number | undefined): DisconnectPoli
     case DisconnectReason.loggedOut:
       return { action: "logged_out", clearAuth: true };
     case DisconnectReason.connectionReplaced:
-      return { action: "stop", clearAuth: false };
+      return { action: "reconnect", clearAuth: false };
     case DisconnectReason.badSession:
     case DisconnectReason.multideviceMismatch:
     case DisconnectReason.forbidden:

--- a/adapters/whatsapp/src/whatsapp-account.ts
+++ b/adapters/whatsapp/src/whatsapp-account.ts
@@ -746,18 +746,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
     }
 
     socket.ev.on("creds.update", () => {
-      if (this.isReplacementSocket(generation, socket)) {
-        const current = this.socketReplacement;
-        if (current) current.saveCreds = saveCreds;
-        return;
-      }
-      this.own(
-        "credentials_update",
-        this.sessionMutations.run(async () => {
-          if (!this.isCurrentSocket(generation, socket)) return;
-          await saveCreds();
-        }),
-      );
+      this.handleCredentialsUpdate(generation, socket, saveCreds);
     });
     socket.ev.on("connection.update", (update) => {
       if (update.connection === "open") this.authenticatedSockets.add(socket);
@@ -1903,6 +1892,23 @@ export class WhatsAppAccount extends DurableObject<Env> {
   private isReplacementSocket(generation: number, socket: WASocket): boolean {
     return this.socketReplacement?.generation === generation
       && this.socketReplacement.socket === socket;
+  }
+
+  private handleCredentialsUpdate(
+    generation: number,
+    socket: WASocket,
+    saveCreds: () => Promise<void>,
+  ): void {
+    if (this.isReplacementSocket(generation, socket)) {
+      const current = this.socketReplacement;
+      if (current) current.saveCreds = saveCreds;
+      return;
+    }
+    // Admit the update while the socket still owns the active generation. Once
+    // admitted, let it drain even if replacement promotion happens while the
+    // mutation queue is busy. Auth resets remain fenced by the store epoch.
+    if (!this.isCurrentSocket(generation, socket)) return;
+    this.own("credentials_update", this.sessionMutations.run(saveCreds));
   }
 
   private waitForQrOrConnection(

--- a/adapters/whatsapp/src/whatsapp-account.ts
+++ b/adapters/whatsapp/src/whatsapp-account.ts
@@ -1057,6 +1057,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
       || this.state.desired !== "connected"
     ) return;
 
+    const activeSocket = this.sock;
     const supersededLeaseDeadline = this.state.leaseRefreshAt;
     const replacement: SocketReplacement = {
       socket: null,
@@ -1066,6 +1067,23 @@ export class WhatsAppAccount extends DurableObject<Env> {
     this.socketReplacement = replacement;
     this.state.leaseRefreshAt = undefined;
     this.state.reconnectAt = undefined;
+    if (action === "recover") {
+      this.sock = null;
+      this.socketGeneration = replacement.generation;
+      this.authenticatedSockets.delete(activeSocket);
+      this.state.connected = false;
+      this.state.status = "reconnecting";
+      this.state.connectionDeadlineAt = undefined;
+      this.state.lastDisconnectedAt = Date.now();
+      this.own(
+        "unhealthy_socket_close",
+        withTimeout(
+          activeSocket.end(new Error("WhatsApp transport is unhealthy")),
+          SOCKET_CLOSE_WAIT_MS,
+          "WhatsApp unhealthy-socket close timed out",
+        ),
+      );
+    }
     this.own(
       "socket_lease_refresh",
       (async () => {

--- a/adapters/whatsapp/src/whatsapp-account.ts
+++ b/adapters/whatsapp/src/whatsapp-account.ts
@@ -119,6 +119,7 @@ const MAX_MEDIA_ITEMS = 20;
 const CONNECTION_OPEN_TIMEOUT_MS = 30_000;
 const CONNECT_WAIT_MS = 60_000;
 const SOCKET_OPEN_WAIT_MS = 25_000;
+const SOCKET_REPLACEMENT_WAIT_MS = 4 * 60_000;
 const SOCKET_CLOSE_WAIT_MS = 5_000;
 const TINY_JPEG_BASE64 =
   "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAEf/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABBQJ//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwF//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQAGPwJ//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPyF//9oADAMBAAIAAwAAABCf/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPxB//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPxB//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPxB//9k=";
@@ -135,6 +136,12 @@ type InboundIdentity = {
   isGroup: boolean;
 };
 
+type SocketReplacement = {
+  socket: WASocket | null;
+  generation: number;
+  saveCreds: (() => Promise<void>) | null;
+};
+
 class WhatsAppPreparationError extends Error {
   constructor(message: string, readonly retryable: boolean) {
     super(message);
@@ -144,9 +151,11 @@ class WhatsAppPreparationError extends Error {
 
 export class WhatsAppAccount extends DurableObject<Env> {
   private sock: WASocket | null = null;
+  private socketReplacement: SocketReplacement | null = null;
   private readonly authenticatedSockets = new WeakSet<object>();
   private socketGeneration = 0;
   private readonly socketOperations = new SocketOperationQueue();
+  private readonly sessionMutations = new SocketOperationQueue();
   private readonly deliveries: DeliveryLedger;
   private readonly inboundDeliveries: InboundDeliveryLedger<Uint8Array>;
   private readonly identities: WhatsAppIdentityStore;
@@ -190,7 +199,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
       this.state.disconnectReason = undefined;
       await this.persistStateAndSchedule();
       if (!this.sock) {
-        await this.startSocketLocked("connect");
+        await this.startSocket("connect");
       }
     });
 
@@ -462,39 +471,59 @@ export class WhatsAppAccount extends DurableObject<Env> {
     const now = Date.now();
     await this.inboundDeliveries.armIfPending(now + INBOUND_RETRY_DELAY_MS);
     try {
-      await this.socketOperations.run(async () => {
-        if (pairingSessionExpired(
-          this.state.authenticated,
-          this.state.pairingExpiresAt,
-          now,
-        )) {
+      if (pairingSessionExpired(
+        this.state.authenticated,
+        this.state.pairingExpiresAt,
+        now,
+      )) {
+        await this.socketOperations.run(async () => {
+          if (!pairingSessionExpired(
+            this.state.authenticated,
+            this.state.pairingExpiresAt,
+            now,
+          )) return;
           await this.expirePairingLocked();
-          return;
-        }
-        if (
-          this.state.connectionDeadlineAt !== undefined
-          && this.state.connectionDeadlineAt <= now
-          && !this.state.connected
-        ) {
+        });
+      }
+      if (
+        this.state.connectionDeadlineAt !== undefined
+        && this.state.connectionDeadlineAt <= now
+        && !this.state.connected
+      ) {
+        await this.socketOperations.run(async () => {
+          if (
+            this.state.connectionDeadlineAt === undefined
+            || this.state.connectionDeadlineAt > now
+            || this.state.connected
+          ) return;
           await this.failConnectionAttemptLocked("connection_timeout");
-        }
-        const leaseAction = this.state.desired === "connected"
-          ? socketLeaseAction(
-              this.state.leaseRefreshAt,
-              this.socketLeaseHealth(),
-              now,
-            )
-          : "wait";
-        if (leaseAction !== "wait") {
-          await this.refreshSocketLeaseLocked(leaseAction);
-        } else if (
-          this.state.desired === "connected"
-          && !this.sock
-          && (this.state.reconnectAt === undefined || this.state.reconnectAt <= now)
-        ) {
-          await this.startSocketLocked("alarm");
-        }
-      });
+        });
+      }
+      const leaseAction = this.state.desired === "connected"
+        ? socketLeaseAction(
+            this.state.leaseRefreshAt,
+            this.socketLeaseHealth(),
+            now,
+          )
+        : "wait";
+      if (leaseAction !== "wait" && this.sock) {
+        this.beginSocketLeaseRefresh(leaseAction);
+      } else if (
+        this.state.desired === "connected"
+        && !this.sock
+        && !this.socketReplacement
+        && (this.state.reconnectAt === undefined || this.state.reconnectAt <= now)
+      ) {
+        await this.socketOperations.run(async () => {
+          if (
+            this.state.desired !== "connected"
+            || this.sock
+            || this.socketReplacement
+            || (this.state.reconnectAt !== undefined && this.state.reconnectAt > now)
+          ) return;
+          await this.startSocket("alarm");
+        });
+      }
     } catch (error) {
       logWhatsApp("error", "alarm_lifecycle_failed", errorFields(error));
       await this.scheduleReconnectAfterFailure(error);
@@ -634,29 +663,42 @@ export class WhatsAppAccount extends DurableObject<Env> {
     await this.inboundDeliveries.armIfPending(Date.now() + INBOUND_RETRY_DELAY_MS);
   }
 
-  private async startSocketLocked(source: string): Promise<void> {
-    if (this.sock) return;
+  private async startSocket(
+    source: string,
+    replacement?: SocketReplacement,
+  ): Promise<void> {
+    if (replacement) {
+      if (this.socketReplacement !== replacement || replacement.socket) return;
+    } else if (this.sock || this.socketReplacement) {
+      return;
+    }
     const { state: authState, saveCreds, authReset } = await useDOAuthState(
       this.ctx.storage,
     );
+    if (replacement && this.socketReplacement !== replacement) return;
     if (authReset && this.state.authenticated) {
+      if (replacement) {
+        throw new Error("WhatsApp auth reset while preparing a replacement socket");
+      }
       await this.advanceProviderSessionLocked();
       this.clearSelfIdentity();
     }
     const sessionEpoch = this.state.sessionEpoch;
-    const generation = ++this.socketGeneration;
+    const generation = replacement?.generation ?? ++this.socketGeneration;
     const now = Date.now();
-    this.qrCode = null;
-    this.state.connected = false;
-    this.state.authenticated = authState.creds.registered;
-    this.state.status = this.state.reconnectAttempt > 0 ? "reconnecting" : "connecting";
-    this.state.reconnectAt = undefined;
-    this.state.leaseRefreshAt = undefined;
-    this.state.connectionDeadlineAt = now + CONNECTION_OPEN_TIMEOUT_MS;
-    this.state.pairingExpiresAt = authState.creds.registered
-      ? undefined
-      : now + PAIRING_WINDOW_MS;
-    await this.persistStateAndSchedule();
+    if (!replacement) {
+      this.qrCode = null;
+      this.state.connected = false;
+      this.state.authenticated = authState.creds.registered;
+      this.state.status = this.state.reconnectAttempt > 0 ? "reconnecting" : "connecting";
+      this.state.reconnectAt = undefined;
+      this.state.leaseRefreshAt = undefined;
+      this.state.connectionDeadlineAt = now + CONNECTION_OPEN_TIMEOUT_MS;
+      this.state.pairingExpiresAt = authState.creds.registered
+        ? undefined
+        : now + PAIRING_WINDOW_MS;
+      await this.persistStateAndSchedule();
+    }
 
     let socket: WASocket;
     try {
@@ -678,6 +720,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
         cachedGroupMetadata: async (jid) => this.groupMetadata.get(jid),
       });
     } catch (error) {
+      if (replacement) throw error;
       this.state.connectionDeadlineAt = undefined;
       if (this.state.desired === "connected") {
         this.state.status = "reconnecting";
@@ -692,12 +735,25 @@ export class WhatsAppAccount extends DurableObject<Env> {
       await this.persistStateAndSchedule();
       throw error;
     }
-    this.sock = socket;
+    if (replacement) {
+      if (this.socketReplacement !== replacement) {
+        await socket.end(new Error("WhatsApp socket replacement was cancelled"));
+        return;
+      }
+      replacement.socket = socket;
+    } else {
+      this.sock = socket;
+    }
 
     socket.ev.on("creds.update", () => {
+      if (this.isReplacementSocket(generation, socket)) {
+        const current = this.socketReplacement;
+        if (current) current.saveCreds = saveCreds;
+        return;
+      }
       this.own(
         "credentials_update",
-        this.socketOperations.run(async () => {
+        this.sessionMutations.run(async () => {
           if (!this.isCurrentSocket(generation, socket)) return;
           await saveCreds();
         }),
@@ -708,18 +764,16 @@ export class WhatsAppAccount extends DurableObject<Env> {
       if (update.connection === "close") this.authenticatedSockets.delete(socket);
       this.own(
         "connection_update",
-        this.socketOperations.run(async () =>
-          this.handleConnectionUpdate(generation, socket, update)
-        ),
+        this.handleConnectionUpdate(generation, socket, update),
       );
     });
     socket.ev.on("lid-mapping.update", (mapping) => {
       this.own(
         "lid_mapping",
-        this.socketOperations.run(async () => {
+        (async () => {
           if (!this.isCurrentSocket(generation, socket)) return;
           await this.rememberLidPnMapping(mapping);
-        }),
+        })(),
       );
     });
     socket.ev.on("messaging-history.set", ({ lidPnMappings }) => {
@@ -732,16 +786,25 @@ export class WhatsAppAccount extends DurableObject<Env> {
       this.own("messages_upsert", this.handleMessagesUpsert(sessionEpoch, event));
     });
     logWhatsApp("info", "socket_started", { generation, source });
+    const replacementReady = replacement
+      ? socket.waitForConnectionUpdate(
+          async (update) => update.connection === "open",
+          SOCKET_REPLACEMENT_WAIT_MS,
+        )
+      : Promise.resolve();
     try {
-      await withTimeout(
-        socket.waitForSocketOpen(),
-        SOCKET_OPEN_WAIT_MS,
-        "WhatsApp WebSocket upgrade timed out",
-      );
+      await Promise.all([
+        withTimeout(
+          socket.waitForSocketOpen(),
+          SOCKET_OPEN_WAIT_MS,
+          "WhatsApp WebSocket upgrade timed out",
+        ),
+        replacementReady,
+      ]);
     } catch (error) {
       const failure = toError(error, "WhatsApp WebSocket upgrade failed");
       const supersededConnectionDeadline = this.state.connectionDeadlineAt;
-      if (this.isCurrentSocket(generation, socket)) {
+      if (!replacement && this.isCurrentSocket(generation, socket)) {
         ++this.socketGeneration;
         this.sock = null;
         this.authenticatedSockets.delete(socket);
@@ -770,8 +833,71 @@ export class WhatsAppAccount extends DurableObject<Env> {
     socket: WASocket,
     update: Partial<BaileysEventMap["connection.update"]>,
   ): Promise<void> {
+    const replacement = this.socketReplacement;
+    if (
+      replacement?.generation === generation
+      && replacement.socket === socket
+    ) {
+      if (update.connection === "close") {
+        await this.failSocketReplacement(
+          replacement,
+          update.lastDisconnect?.error ?? new Error("WhatsApp replacement socket closed"),
+        );
+        return;
+      }
+      if (update.connection !== "open") return;
+      if (this.state.desired !== "connected") {
+        this.socketReplacement = null;
+        await withTimeout(
+          socket.end(new Error("WhatsApp socket replacement is no longer needed")),
+          SOCKET_CLOSE_WAIT_MS,
+          "WhatsApp replacement close timed out",
+        ).catch(() => undefined);
+        return;
+      }
+
+      const oldSocket = this.sock;
+      this.sock = socket;
+      this.socketGeneration = generation;
+      this.socketReplacement = null;
+      if (oldSocket) this.authenticatedSockets.delete(oldSocket);
+      const saveReplacementCreds = replacement.saveCreds;
+      if (saveReplacementCreds) {
+        this.own(
+          "credentials_update",
+          this.sessionMutations.run(saveReplacementCreds),
+        );
+      }
+      if (oldSocket && oldSocket !== socket) {
+        this.own(
+          "socket_replaced_close",
+          this.socketOperations.run(() =>
+            withTimeout(
+              oldSocket.end(new Error("WhatsApp outbound connection lease replaced")),
+              SOCKET_CLOSE_WAIT_MS,
+              "WhatsApp replaced-socket close timed out",
+            )
+          ),
+        );
+      }
+    }
     if (!this.isCurrentSocket(generation, socket)) return;
     const statusCode = providerStatusCode(update.lastDisconnect?.error);
+
+    if (
+      update.connection === "close"
+      && statusCode === 440
+      && this.socketReplacement
+    ) {
+      this.sock = null;
+      this.authenticatedSockets.delete(socket);
+      this.state.connected = false;
+      this.state.status = "reconnecting";
+      this.state.leaseRefreshAt = undefined;
+      this.state.connectionDeadlineAt = undefined;
+      this.state.reconnectAt = undefined;
+      return;
+    }
 
     if (update.qr) {
       if (pairingSessionExpired(
@@ -839,6 +965,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
       if (this.state.selfLid && this.state.selfJid && isWhatsAppPnJid(this.state.selfJid)) {
         await this.identities.bindLidPn(this.state.selfLid, this.state.selfJid);
       }
+      if (!this.isCurrentSocket(generation, socket)) return;
       await this.persistStateAndSchedule(supersededConnectionDeadline);
       this.resolvePairingWaiters({ connected: true });
       this.own("gateway_status", this.notifyGatewayStatus());
@@ -846,6 +973,9 @@ export class WhatsAppAccount extends DurableObject<Env> {
         generation,
         leaseRefreshInMs: SOCKET_LEASE_REFRESH_INTERVAL_MS,
       });
+      if (replacement?.generation === generation && replacement.socket === socket) {
+        logWhatsApp("info", "socket_lease_renewed", { generation });
+      }
     }
 
     if (update.connection !== "close") return;
@@ -879,17 +1009,24 @@ export class WhatsAppAccount extends DurableObject<Env> {
       if (policy.clearAuth) this.state.authenticated = false;
     } else {
       this.state.status = "reconnecting";
-      const attempt = this.state.reconnectAttempt++;
-      const delay = policy.action === "restart"
-        ? restartDelayMs(attempt)
-        : reconnectDelayMs(attempt);
-      this.state.reconnectAt = Date.now() + delay;
+      if (this.socketReplacement) {
+        this.state.reconnectAt = undefined;
+      } else {
+        const attempt = this.state.reconnectAttempt++;
+        const delay = policy.action === "restart"
+          ? restartDelayMs(attempt)
+          : reconnectDelayMs(attempt);
+        this.state.reconnectAt = Date.now() + delay;
+      }
     }
     if (policy.clearAuth) {
       await this.advanceProviderSessionLocked();
       await clearAuthState(this.ctx.storage);
       this.state.authenticated = false;
       this.clearSelfIdentity();
+    }
+    if (this.state.desired === "disconnected") {
+      this.cancelSocketReplacement("WhatsApp account is no longer connected");
     }
     await this.persistStateAndSchedule(supersededLifecycleDeadline);
     if (this.state.desired === "disconnected") this.resolvePairingWaiters({});
@@ -917,34 +1054,95 @@ export class WhatsAppAccount extends DurableObject<Env> {
     };
   }
 
-  private async refreshSocketLeaseLocked(
-    action: "refresh" | "recover",
-  ): Promise<void> {
+  private beginSocketLeaseRefresh(action: "refresh" | "recover"): void {
+    if (
+      this.socketReplacement
+      || !this.sock
+      || this.state.desired !== "connected"
+    ) return;
+
     const supersededLeaseDeadline = this.state.leaseRefreshAt;
-    const oldSocket = this.sock;
-    ++this.socketGeneration;
-    this.sock = null;
-    if (oldSocket) this.authenticatedSockets.delete(oldSocket);
-    this.groupMetadata.clear();
-    this.state.connected = false;
-    this.state.status = "reconnecting";
+    const replacement: SocketReplacement = {
+      socket: null,
+      generation: this.socketGeneration + 1,
+      saveCreds: null,
+    };
+    this.socketReplacement = replacement;
     this.state.leaseRefreshAt = undefined;
-    this.state.connectionDeadlineAt = undefined;
-    this.state.reconnectAt = Date.now();
-    await this.persistStateAndSchedule(supersededLeaseDeadline);
-    if (oldSocket) {
-      await withTimeout(
-        oldSocket.end(new Error("Refreshing WhatsApp outbound connection lease")),
-        SOCKET_CLOSE_WAIT_MS,
-        "WhatsApp lease-refresh close timed out",
-      ).catch(() => undefined);
-    }
-    await this.startSocketLocked(
-      action === "refresh" ? "lease_refresh" : "lease_recovery",
+    this.state.reconnectAt = undefined;
+    this.own(
+      "socket_lease_refresh",
+      (async () => {
+        try {
+          await this.persistStateAndSchedule(supersededLeaseDeadline);
+          await this.startSocket(
+            action === "refresh" ? "lease_refresh" : "lease_recovery",
+            replacement,
+          );
+        } catch (error) {
+          await this.failSocketReplacement(replacement, error);
+          throw error;
+        }
+      })(),
     );
-    logWhatsApp("info", "socket_lease_renewed", {
+    logWhatsApp("info", "socket_lease_refresh_started", {
       previousConnectionHealthy: action === "refresh",
     });
+  }
+
+  private async failSocketReplacement(
+    replacement: SocketReplacement,
+    error: unknown,
+  ): Promise<void> {
+    if (this.socketReplacement !== replacement) return;
+    this.socketReplacement = null;
+    if (replacement.socket) {
+      this.authenticatedSockets.delete(replacement.socket);
+    }
+
+    if (this.state.desired !== "connected") {
+      this.state.leaseRefreshAt = undefined;
+      this.state.reconnectAt = undefined;
+      await this.persistStateAndSchedule();
+      return;
+    }
+
+    const activeSocketHealthy = this.sock !== null
+      && this.state.connected
+      && this.authenticatedSockets.has(this.sock)
+      && this.sock.ws.isOpen === true;
+    if (activeSocketHealthy) {
+      this.state.leaseRefreshAt = Date.now()
+        + reconnectDelayMs(this.state.reconnectAttempt++);
+    } else {
+      if (this.sock) this.authenticatedSockets.delete(this.sock);
+      this.sock = null;
+      this.state.connected = false;
+      this.state.status = "reconnecting";
+      this.state.leaseRefreshAt = undefined;
+      this.state.connectionDeadlineAt = undefined;
+      this.state.reconnectAt = Date.now()
+        + reconnectDelayMs(this.state.reconnectAttempt++);
+    }
+    await this.persistStateAndSchedule();
+    logWhatsApp("warn", "socket_lease_refresh_failed", errorFields(error));
+  }
+
+  private cancelSocketReplacement(reason: string): void {
+    const replacement = this.socketReplacement;
+    if (!replacement) return;
+    this.socketReplacement = null;
+    const socket = replacement.socket;
+    if (!socket) return;
+    this.authenticatedSockets.delete(socket);
+    this.own(
+      "socket_replacement_cancelled",
+      withTimeout(
+        socket.end(new Error(reason)),
+        SOCKET_CLOSE_WAIT_MS,
+        "WhatsApp replacement cancellation timed out",
+      ),
+    );
   }
 
   private async failConnectionAttemptLocked(reason: string): Promise<void> {
@@ -1022,6 +1220,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
   }
 
   private async forceNewPairingLocked(): Promise<void> {
+    this.cancelSocketReplacement("Replacing WhatsApp linked-device session");
     this.state.desired = "disconnected";
     const providerError = await this.detachProviderSessionLocked(
       "force_logout",
@@ -1048,6 +1247,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
   }
 
   private async logoutLocked(): Promise<void> {
+    this.cancelSocketReplacement("GSV adapter disconnected");
     const supersededLifecycleDeadline = this.lifecycleDeadline();
     this.state.desired = "disconnected";
     this.state.leaseRefreshAt = undefined;
@@ -1096,7 +1296,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
 
     if (!socket && registered) {
       try {
-        await this.startSocketLocked(source);
+        await this.startSocket(source);
         socket = this.sock;
       } catch (error) {
         failure = toError(error, "WhatsApp logout connection failed");
@@ -1149,11 +1349,13 @@ export class WhatsAppAccount extends DurableObject<Env> {
   }
 
   private async advanceProviderSessionLocked(): Promise<void> {
-    await this.inboundDeliveries.clear();
-    await this.identities.clear();
-    await this.recentMessages.clear();
-    this.groupMetadata.clear();
     this.state.sessionEpoch += 1;
+    await this.sessionMutations.run(async () => {
+      await this.inboundDeliveries.clear();
+      await this.identities.clear();
+      await this.recentMessages.clear();
+      this.groupMetadata.clear();
+    });
   }
 
   private clearSelfIdentity(): void {
@@ -1175,12 +1377,14 @@ export class WhatsAppAccount extends DurableObject<Env> {
       Date.now() - APPEND_CATCH_UP_MAX_AGE_MS,
     );
     await enqueueThenDeliverInboundBatch(
-      async () => this.socketOperations.run(async () => {
+      async () => this.sessionMutations.run(async () => {
         if (expectedSessionEpoch !== this.state.sessionEpoch) return [];
         const accepted: Array<{ deliveryId: string; sessionEpoch: number }> = [];
         for (const message of messages) {
+          if (expectedSessionEpoch !== this.state.sessionEpoch) break;
           if (message.key.fromMe || !message.key.id) continue;
           const identity = await this.inboundIdentity(message);
+          if (expectedSessionEpoch !== this.state.sessionEpoch) break;
           if (!identity) continue;
           const deliveryId = await whatsAppInboundDeliveryIdForSession(
             expectedSessionEpoch,
@@ -1192,7 +1396,9 @@ export class WhatsAppAccount extends DurableObject<Env> {
               providerMessageId: message.key.id,
             },
           );
+          if (expectedSessionEpoch !== this.state.sessionEpoch) break;
           await this.recentMessages.put(message);
+          if (expectedSessionEpoch !== this.state.sessionEpoch) break;
           await this.inboundDeliveries.enqueueAndArm(
             deliveryId,
             proto.WebMessageInfo.encode(message).finish(),
@@ -1261,13 +1467,15 @@ export class WhatsAppAccount extends DurableObject<Env> {
     if (expectedSessionEpoch !== this.state.sessionEpoch) {
       return { terminal: true };
     }
-    const sessionContext = await this.socketOperations.run(async () => {
+    const sessionContext = await this.sessionMutations.run(async () => {
       if (expectedSessionEpoch !== this.state.sessionEpoch) return null;
       const identity = await this.inboundIdentity(message);
-      if (!identity) return null;
+      if (!identity || expectedSessionEpoch !== this.state.sessionEpoch) return null;
+      const actorHandle = await this.actorHandle(identity.actorJid);
+      if (expectedSessionEpoch !== this.state.sessionEpoch) return null;
       return {
         identity,
-        actorHandle: await this.actorHandle(identity.actorJid),
+        actorHandle,
         socket: this.sock,
       };
     });
@@ -1350,6 +1558,9 @@ export class WhatsAppAccount extends DurableObject<Env> {
         },
         media.body,
       );
+      if (expectedSessionEpoch !== this.state.sessionEpoch) {
+        return { terminal: true };
+      }
       const disposition = adapterInboundResultDisposition(result, {
         surface: inbound.surface,
         providerMessageId: inbound.messageId,
@@ -1365,7 +1576,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
       await this.persistStateAndSchedule();
       return disposition;
     };
-    return this.socketOperations.run(forward);
+    return forward();
   }
 
   private async inboundIdentity(message: WAMessage): Promise<InboundIdentity | null> {
@@ -1679,6 +1890,11 @@ export class WhatsAppAccount extends DurableObject<Env> {
 
   private isCurrentSocket(generation: number, socket: WASocket): boolean {
     return generation === this.socketGeneration && socket === this.sock;
+  }
+
+  private isReplacementSocket(generation: number, socket: WASocket): boolean {
+    return this.socketReplacement?.generation === generation
+      && this.socketReplacement.socket === socket;
   }
 
   private waitForQrOrConnection(

--- a/adapters/whatsapp/src/whatsapp-account.ts
+++ b/adapters/whatsapp/src/whatsapp-account.ts
@@ -770,16 +770,23 @@ export class WhatsAppAccount extends DurableObject<Env> {
     socket.ev.on("lid-mapping.update", (mapping) => {
       this.own(
         "lid_mapping",
-        (async () => {
-          if (!this.isCurrentSocket(generation, socket)) return;
-          await this.rememberLidPnMapping(mapping);
-        })(),
+        this.rememberLidPnMappings(
+          sessionEpoch,
+          generation,
+          socket,
+          [mapping],
+        ),
       );
     });
     socket.ev.on("messaging-history.set", ({ lidPnMappings }) => {
       this.own(
         "history_mappings",
-        this.rememberLidPnMappings(generation, socket, lidPnMappings),
+        this.rememberLidPnMappings(
+          sessionEpoch,
+          generation,
+          socket,
+          lidPnMappings,
+        ),
       );
     });
     socket.ev.on("messages.upsert", (event) => {
@@ -1831,6 +1838,7 @@ export class WhatsAppAccount extends DurableObject<Env> {
   }
 
   private async rememberLidPnMappings(
+    expectedSessionEpoch: number,
     generation: number,
     socket: WASocket,
     mappings: LIDMapping[] | undefined,
@@ -1839,18 +1847,18 @@ export class WhatsAppAccount extends DurableObject<Env> {
     const batchSize = 128;
     for (let index = 0; index < mappings.length; index += batchSize) {
       const batch = mappings.slice(index, index + batchSize);
-      const current = await this.socketOperations.run(async () => {
-        if (!this.isCurrentSocket(generation, socket)) return false;
+      const current = await this.sessionMutations.run(async () => {
+        if (
+          expectedSessionEpoch !== this.state.sessionEpoch
+          || !this.isCurrentSocket(generation, socket)
+        ) {
+          return false;
+        }
         await this.identities.bindLidPnMappings(batch);
-        return true;
+        return expectedSessionEpoch === this.state.sessionEpoch
+          && this.isCurrentSocket(generation, socket);
       });
       if (!current) return;
-    }
-  }
-
-  private async rememberLidPnMapping(mapping: LIDMapping): Promise<void> {
-    if (mapping.lid && mapping.pn) {
-      await this.identities.bindLidPn(mapping.lid, mapping.pn);
     }
   }
 

--- a/adapters/whatsapp/test/auth-store.test.ts
+++ b/adapters/whatsapp/test/auth-store.test.ts
@@ -138,6 +138,29 @@ describe("Durable Object WhatsApp auth", () => {
     expect(restored.state.creds.me?.id).toBe("12025550123@s.whatsapp.net");
   });
 
+  it("merges credential changes from overlapping socket snapshots", async () => {
+    const storage = new MemoryStorage();
+    const seeded = await useDOAuthState(storage as unknown as DurableObjectStorage);
+    seeded.state.creds.me = { id: "12025550123@s.whatsapp.net" };
+    seeded.state.creds.registered = true;
+    seeded.state.creds.accountSyncCounter = 1;
+    seeded.state.creds.lastAccountSyncTimestamp = 100;
+    await seeded.saveCreds();
+
+    const active = await useDOAuthState(storage as unknown as DurableObjectStorage);
+    const replacement = await useDOAuthState(storage as unknown as DurableObjectStorage);
+    active.state.creds.accountSyncCounter = 2;
+    await active.saveCreds();
+    replacement.state.creds.lastAccountSyncTimestamp = 200;
+    await replacement.saveCreds();
+
+    const restored = await useDOAuthState(
+      storage as unknown as DurableObjectStorage,
+    );
+    expect(restored.state.creds.accountSyncCounter).toBe(2);
+    expect(restored.state.creds.lastAccountSyncTimestamp).toBe(200);
+  });
+
   it("hydrates persisted app state keys as Baileys protobuf values", async () => {
     const storage = new MemoryStorage();
     const auth = await useDOAuthState(storage as unknown as DurableObjectStorage);

--- a/adapters/whatsapp/test/lifecycle.test.ts
+++ b/adapters/whatsapp/test/lifecycle.test.ts
@@ -60,7 +60,7 @@ describe("WhatsApp lifecycle policy", () => {
       clearAuth: false,
     });
     expect(disconnectPolicy(DisconnectReason.connectionReplaced)).toEqual({
-      action: "stop",
+      action: "reconnect",
       clearAuth: false,
     });
     expect(disconnectPolicy(DisconnectReason.loggedOut)).toEqual({

--- a/adapters/whatsapp/test/whatsapp-account.test.ts
+++ b/adapters/whatsapp/test/whatsapp-account.test.ts
@@ -8,7 +8,10 @@ vi.mock("cloudflare:workers", () => ({
   DurableObject: class {},
 }));
 
-import { SOCKET_LEASE_REFRESH_INTERVAL_MS } from "../src/lifecycle";
+import {
+  SOCKET_LEASE_REFRESH_INTERVAL_MS,
+  SocketOperationQueue,
+} from "../src/lifecycle";
 import { defaultWhatsAppAccountState } from "../src/types";
 import { WhatsAppAccount } from "../src/whatsapp-account";
 
@@ -23,6 +26,14 @@ type HandleConnectionUpdate = (
   generation: number,
   socket: WASocket,
   update: Partial<BaileysEventMap["connection.update"]>,
+) => Promise<void>;
+
+type RememberLidPnMappings = (
+  this: WhatsAppAccount,
+  expectedSessionEpoch: number,
+  generation: number,
+  socket: WASocket,
+  mappings: BaileysEventMap["messaging-history.set"]["lidPnMappings"],
 ) => Promise<void>;
 
 const accountMethod = <T>(name: string): T =>
@@ -239,5 +250,57 @@ describe("WhatsApp account socket lease", () => {
     expect(state).toEqual(connectedState);
     expect(accountField(account, "sock")).toBe(candidate);
     await Promise.all(owned);
+  });
+});
+
+describe("WhatsApp account session identity", () => {
+  it("drops LID mappings from a superseded provider session", async () => {
+    const sessionMutations = new SocketOperationQueue();
+    let releaseMutation: () => void = () => undefined;
+    const mutationGate = new Promise<void>((resolve) => {
+      releaseMutation = resolve;
+    });
+    const precedingMutation = sessionMutations.run(() => mutationGate);
+    const socket = {} as WASocket;
+    const bindLidPnMappings = vi.fn(async () => undefined);
+    const state = {
+      ...defaultWhatsAppAccountState(),
+      sessionEpoch: 4,
+    };
+    const account = fakeAccount({
+      sock: socket,
+      socketGeneration: 7,
+      sessionMutations,
+      identities: { bindLidPnMappings },
+      state,
+    });
+    const rememberMappings = accountMethod<RememberLidPnMappings>(
+      "rememberLidPnMappings",
+    );
+    const staleMapping = {
+      lid: "123456789@lid",
+      pn: "31612345678@s.whatsapp.net",
+    };
+
+    const staleWrite = rememberMappings.call(
+      account,
+      4,
+      7,
+      socket,
+      [staleMapping],
+    );
+    state.sessionEpoch = 5;
+    releaseMutation();
+    await Promise.all([precedingMutation, staleWrite]);
+
+    expect(bindLidPnMappings).not.toHaveBeenCalled();
+
+    const currentMapping = {
+      lid: "987654321@lid",
+      pn: "31687654321@s.whatsapp.net",
+    };
+    await rememberMappings.call(account, 5, 7, socket, [currentMapping]);
+    expect(bindLidPnMappings).toHaveBeenCalledOnce();
+    expect(bindLidPnMappings).toHaveBeenCalledWith([currentMapping]);
   });
 });

--- a/adapters/whatsapp/test/whatsapp-account.test.ts
+++ b/adapters/whatsapp/test/whatsapp-account.test.ts
@@ -122,6 +122,61 @@ describe("WhatsApp account socket lease", () => {
     );
   });
 
+  it("retires an unhealthy socket before starting its recovery", async () => {
+    const oldSocket = {
+      ws: { isOpen: false },
+      end: vi.fn(async () => undefined),
+    } as unknown as WASocket;
+    const state = {
+      ...defaultWhatsAppAccountState(),
+      desired: "connected" as const,
+      status: "connected" as const,
+      connected: true,
+      authenticated: true,
+      leaseRefreshAt: 60_000,
+    };
+    const authenticatedSockets = new WeakSet<object>();
+    authenticatedSockets.add(oldSocket);
+    const started = vi.fn(async () => undefined);
+    const owned: Promise<unknown>[] = [];
+    const account = fakeAccount({
+      sock: oldSocket,
+      socketReplacement: null,
+      socketGeneration: 7,
+      authenticatedSockets,
+      inboundDeliveries: { armIfPending: vi.fn(async () => false) },
+      socketOperations: { run: vi.fn() },
+      state,
+      persistStateAndSchedule: vi.fn(async () => undefined),
+      startSocket: started,
+      retryPendingInbound: vi.fn(async () => undefined),
+      scheduleNextAlarm: vi.fn(async () => undefined),
+      scheduleReconnectAfterFailure: vi.fn(async () => undefined),
+      own: vi.fn((_event: string, promise: Promise<unknown>) => {
+        owned.push(promise);
+      }),
+    });
+
+    await account.alarm();
+
+    const replacement = accountField<SocketReplacement>(
+      account,
+      "socketReplacement",
+    );
+    expect(accountField(account, "sock")).toBeNull();
+    expect(accountField(account, "socketGeneration")).toBe(8);
+    expect(replacement).toMatchObject({ socket: null, generation: 8 });
+    expect(state.connected).toBe(false);
+    expect(state.status).toBe("reconnecting");
+    expect(state.authenticated).toBe(true);
+    expect(authenticatedSockets.has(oldSocket)).toBe(false);
+    expect(oldSocket.end).toHaveBeenCalledOnce();
+
+    await Promise.all(owned);
+    expect(started).toHaveBeenCalledOnce();
+    expect(started).toHaveBeenCalledWith("lease_recovery", replacement);
+  });
+
   it("keeps the active socket when its replacement fails", async () => {
     const now = 1_000;
     vi.spyOn(Date, "now").mockReturnValue(now);

--- a/adapters/whatsapp/test/whatsapp-account.test.ts
+++ b/adapters/whatsapp/test/whatsapp-account.test.ts
@@ -12,185 +12,232 @@ import { SOCKET_LEASE_REFRESH_INTERVAL_MS } from "../src/lifecycle";
 import { defaultWhatsAppAccountState } from "../src/types";
 import { WhatsAppAccount } from "../src/whatsapp-account";
 
-type LeaseHarness = {
-  sock: WASocket | null;
-  socketGeneration: number;
-  authenticatedSockets: WeakSet<object>;
-  groupMetadata: { clear(): void };
-  state: ReturnType<typeof defaultWhatsAppAccountState>;
-  qrCode: string | null;
-  inboundDeliveries: { armIfPending(deadline: number): Promise<boolean> };
-  socketOperations: { run<T>(operation: () => Promise<T>): Promise<T> };
-  identities: { bindLidPn(lid: string, pn: string): Promise<void> };
-  persistStateAndSchedule(supersededDeadline?: number): Promise<void>;
-  startSocketLocked(source: string): Promise<void>;
-  socketLeaseHealth(): {
-    hasSocket: boolean;
-    stateConnected: boolean;
-    socketAuthenticated: boolean;
-    webSocketOpen: boolean;
-  };
-  refreshSocketLeaseLocked(action: "refresh" | "recover"): Promise<void>;
-  failConnectionAttemptLocked(reason: string): Promise<void>;
-  retryPendingInbound(): Promise<void>;
-  scheduleNextAlarm(): Promise<void>;
-  scheduleReconnectAfterFailure(error: unknown): Promise<void>;
-  isCurrentSocket(generation: number, socket: WASocket): boolean;
-  resolvePairingWaiters(result: {
-    connected?: boolean;
-    qr?: string;
-    expiresAt?: number;
-  }): void;
-  notifyGatewayStatus(): Promise<void>;
-  own(event: string, promise: Promise<unknown>): void;
+type SocketReplacement = {
+  socket: WASocket | null;
+  generation: number;
+  saveCreds: (() => Promise<void>) | null;
 };
 
-type AlarmMethod = (this: LeaseHarness) => Promise<void>;
-type RefreshLeaseMethod = (
-  this: LeaseHarness,
-  action: "refresh" | "recover",
-) => Promise<void>;
-type ConnectionUpdateMethod = (
-  this: LeaseHarness,
+type HandleConnectionUpdate = (
+  this: WhatsAppAccount,
   generation: number,
   socket: WASocket,
   update: Partial<BaileysEventMap["connection.update"]>,
 ) => Promise<void>;
-type IsCurrentSocketMethod = (
-  this: LeaseHarness,
-  generation: number,
-  socket: WASocket,
-) => boolean;
-type SocketLeaseHealthMethod = (this: LeaseHarness) => {
-  hasSocket: boolean;
-  stateConnected: boolean;
-  socketAuthenticated: boolean;
-  webSocketOpen: boolean;
-};
 
 const accountMethod = <T>(name: string): T =>
   Reflect.get(WhatsAppAccount.prototype, name) as T;
+
+const accountField = <T>(account: WhatsAppAccount, name: string): T =>
+  Reflect.get(account, name) as T;
+
+function fakeAccount(fields: Record<string, unknown>): WhatsAppAccount {
+  return Object.assign(Object.create(WhatsAppAccount.prototype), fields);
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("WhatsApp account socket lease", () => {
-  it("refreshes a due lease through the alarm and fences the old socket", async () => {
+  it("starts one replacement without closing or blocking the active socket", async () => {
+    const oldSocket = {
+      ws: { isOpen: true },
+      end: vi.fn(async () => undefined),
+    } as unknown as WASocket;
+    const state = {
+      ...defaultWhatsAppAccountState(),
+      desired: "connected" as const,
+      status: "connected" as const,
+      connected: true,
+      authenticated: true,
+      leaseRefreshAt: 1_000,
+    };
+    let releasePersist: (() => void) | undefined;
+    const persist = new Promise<void>((resolve) => {
+      releasePersist = resolve;
+    });
+    const started = vi.fn(async () => undefined);
+    const owned: Promise<unknown>[] = [];
+    const authenticatedSockets = new WeakSet<object>();
+    authenticatedSockets.add(oldSocket);
+    const socketOperations = { run: vi.fn() };
+    const account = fakeAccount({
+      sock: oldSocket,
+      socketReplacement: null,
+      socketGeneration: 7,
+      authenticatedSockets,
+      inboundDeliveries: { armIfPending: vi.fn(async () => false) },
+      socketOperations,
+      state,
+      persistStateAndSchedule: vi.fn(() => persist),
+      startSocket: started,
+      retryPendingInbound: vi.fn(async () => undefined),
+      scheduleNextAlarm: vi.fn(async () => undefined),
+      scheduleReconnectAfterFailure: vi.fn(async () => undefined),
+      own: vi.fn((_event: string, promise: Promise<unknown>) => {
+        owned.push(promise);
+      }),
+    });
+
+    await account.alarm();
+    await account.alarm();
+
+    expect(accountField(account, "sock")).toBe(oldSocket);
+    expect(accountField(account, "socketReplacement")).toMatchObject({
+      socket: null,
+      generation: 8,
+    });
+    expect(state.connected).toBe(true);
+    expect(state.status).toBe("connected");
+    expect(oldSocket.end).not.toHaveBeenCalled();
+    expect(owned).toHaveLength(1);
+    expect(started).not.toHaveBeenCalled();
+    expect(socketOperations.run).not.toHaveBeenCalled();
+
+    releasePersist?.();
+    await Promise.all(owned);
+    expect(started).toHaveBeenCalledTimes(1);
+    expect(started).toHaveBeenCalledWith(
+      "lease_refresh",
+      accountField(account, "socketReplacement"),
+    );
+  });
+
+  it("keeps the active socket when its replacement fails", async () => {
     const now = 1_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     vi.spyOn(console, "log").mockImplementation(() => undefined);
-
-    const events: string[] = [];
-    const oldSocket = {
-      ws: { isOpen: true },
-      end: vi.fn(async () => {
-        events.push("old_closed");
-      }),
-    } as unknown as WASocket;
-    const freshSocket = {
-      ws: { isOpen: true },
-      user: undefined,
-    } as unknown as WASocket;
+    const oldSocket = { ws: { isOpen: true } } as unknown as WASocket;
+    const candidate = { ws: { isOpen: false } } as unknown as WASocket;
     const authenticatedSockets = new WeakSet<object>();
     authenticatedSockets.add(oldSocket);
-    let scheduledDeadline: number | undefined;
-
-    const refreshLease = accountMethod<RefreshLeaseMethod>(
-      "refreshSocketLeaseLocked",
-    );
-    const handleConnectionUpdate = accountMethod<ConnectionUpdateMethod>(
-      "handleConnectionUpdate",
-    );
-    const isCurrentSocket = accountMethod<IsCurrentSocketMethod>(
-      "isCurrentSocket",
-    );
-    const socketLeaseHealth = accountMethod<SocketLeaseHealthMethod>(
-      "socketLeaseHealth",
-    );
-
-    const harness: LeaseHarness = {
+    const state = {
+      ...defaultWhatsAppAccountState(),
+      desired: "connected" as const,
+      status: "connected" as const,
+      connected: true,
+      authenticated: true,
+    };
+    const replacement: SocketReplacement = {
+      socket: candidate,
+      generation: 8,
+      saveCreds: null,
+    };
+    const account = fakeAccount({
       sock: oldSocket,
+      socketReplacement: replacement,
       socketGeneration: 7,
       authenticatedSockets,
       groupMetadata: { clear: vi.fn() },
-      state: {
-        ...defaultWhatsAppAccountState(),
-        accountId: "primary",
-        desired: "connected",
-        status: "connected",
-        connected: true,
-        authenticated: true,
-        leaseRefreshAt: now,
-      },
-      qrCode: null,
-      inboundDeliveries: {
-        armIfPending: vi.fn(async () => false),
-      },
-      socketOperations: {
-        run: async (operation) => operation(),
-      },
-      identities: {
-        bindLidPn: vi.fn(async () => undefined),
-      },
+      state,
       persistStateAndSchedule: vi.fn(async () => undefined),
-      startSocketLocked: async (source) => {
-        expect(source).toBe("lease_refresh");
-        expect(events).toEqual(["old_closed"]);
-        events.push("fresh_started");
-        harness.socketGeneration += 1;
-        harness.sock = freshSocket;
-        harness.authenticatedSockets.add(freshSocket);
-      },
-      socketLeaseHealth() {
-        return socketLeaseHealth.call(harness);
-      },
-      async refreshSocketLeaseLocked(action) {
-        await refreshLease.call(harness, action);
-        await handleConnectionUpdate.call(
-          harness,
-          harness.socketGeneration,
-          freshSocket,
-          { connection: "open" },
-        );
-      },
-      failConnectionAttemptLocked: vi.fn(async () => undefined),
-      retryPendingInbound: vi.fn(async () => undefined),
-      scheduleNextAlarm: vi.fn(async () => {
-        scheduledDeadline = harness.state.leaseRefreshAt;
-      }),
-      scheduleReconnectAfterFailure: vi.fn(async () => undefined),
-      isCurrentSocket(generation, socket) {
-        return isCurrentSocket.call(harness, generation, socket);
-      },
-      resolvePairingWaiters: vi.fn(),
       notifyGatewayStatus: vi.fn(async () => undefined),
-      own: vi.fn((_event, promise) => {
+      own: vi.fn((_event: string, promise: Promise<unknown>) => {
         void promise;
       }),
-    };
+    });
 
-    const alarm = WhatsAppAccount.prototype.alarm as unknown as AlarmMethod;
-    await alarm.call(harness);
-
-    expect(events).toEqual(["old_closed", "fresh_started"]);
-    expect(oldSocket.end).toHaveBeenCalledTimes(1);
-    expect(harness.sock).toBe(freshSocket);
-    expect(harness.state.connected).toBe(true);
-    expect(harness.state.leaseRefreshAt).toBe(
-      now + SOCKET_LEASE_REFRESH_INTERVAL_MS,
-    );
-    expect(scheduledDeadline).toBe(now + SOCKET_LEASE_REFRESH_INTERVAL_MS);
-    expect(harness.socketGeneration).toBe(9);
-
-    const connectedState = { ...harness.state };
-    await handleConnectionUpdate.call(
-      harness,
-      7,
-      oldSocket,
+    await accountMethod<HandleConnectionUpdate>("handleConnectionUpdate").call(
+      account,
+      8,
+      candidate,
       { connection: "close" },
     );
-    expect(harness.state).toEqual(connectedState);
-    expect(harness.sock).toBe(freshSocket);
+
+    expect(accountField(account, "sock")).toBe(oldSocket);
+    expect(accountField(account, "socketReplacement")).toBeNull();
+    expect(state.connected).toBe(true);
+    expect(state.status).toBe("connected");
+    expect(state.reconnectAt).toBeUndefined();
+    expect(state.leaseRefreshAt).toBeGreaterThanOrEqual(now + 2_000);
+    expect(state.leaseRefreshAt).toBeLessThan(now + 3_000);
+
+    authenticatedSockets.delete(oldSocket);
+    await accountMethod<HandleConnectionUpdate>("handleConnectionUpdate").call(
+      account,
+      7,
+      oldSocket,
+      {
+        connection: "close",
+        lastDisconnect: {
+          error: { output: { statusCode: 440 } } as unknown as Error,
+          date: new Date(now),
+        },
+      },
+    );
+    expect(state.desired).toBe("connected");
+    expect(state.status).toBe("reconnecting");
+    expect(state.reconnectAt).toBeGreaterThan(now);
+  });
+
+  it("promotes the replacement and ignores the displaced socket", async () => {
+    const now = 1_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const oldSocket = {
+      ws: { isOpen: false },
+      end: vi.fn(async () => undefined),
+    } as unknown as WASocket;
+    const candidate = {
+      ws: { isOpen: true },
+      user: {},
+    } as unknown as WASocket;
+    const authenticatedSockets = new WeakSet<object>();
+    authenticatedSockets.add(candidate);
+    const state = {
+      ...defaultWhatsAppAccountState(),
+      desired: "connected" as const,
+      status: "connected" as const,
+      connected: true,
+      authenticated: true,
+      leaseRefreshAt: now,
+    };
+    const replacement: SocketReplacement = {
+      socket: candidate,
+      generation: 8,
+      saveCreds: null,
+    };
+    const owned: Promise<unknown>[] = [];
+    const account = fakeAccount({
+      sock: oldSocket,
+      socketReplacement: replacement,
+      socketGeneration: 7,
+      authenticatedSockets,
+      groupMetadata: { clear: vi.fn() },
+      identities: { bindLidPn: vi.fn(async () => undefined) },
+      socketOperations: { run: <T>(operation: () => Promise<T>) => operation() },
+      state,
+      persistStateAndSchedule: vi.fn(async () => undefined),
+      resolvePairingWaiters: vi.fn(),
+      notifyGatewayStatus: vi.fn(async () => undefined),
+      own: vi.fn((_event: string, promise: Promise<unknown>) => {
+        owned.push(promise);
+      }),
+    });
+    const handleUpdate = accountMethod<HandleConnectionUpdate>("handleConnectionUpdate");
+
+    await handleUpdate.call(account, 8, candidate, { connection: "open" });
+    expect(accountField(account, "sock")).toBe(candidate);
+    expect(accountField(account, "socketGeneration")).toBe(8);
+    expect(accountField(account, "socketReplacement")).toBeNull();
+    expect(state.connected).toBe(true);
+    expect(state.status).toBe("connected");
+    expect(state.leaseRefreshAt).toBe(
+      now + SOCKET_LEASE_REFRESH_INTERVAL_MS,
+    );
+    expect(oldSocket.end).toHaveBeenCalledTimes(1);
+
+    const connectedState = { ...state };
+    await handleUpdate.call(account, 7, oldSocket, {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: 440 } } as unknown as Error,
+        date: new Date(now),
+      },
+    });
+    expect(state).toEqual(connectedState);
+    expect(accountField(account, "sock")).toBe(candidate);
+    await Promise.all(owned);
   });
 });

--- a/adapters/whatsapp/test/whatsapp-account.test.ts
+++ b/adapters/whatsapp/test/whatsapp-account.test.ts
@@ -28,6 +28,13 @@ type HandleConnectionUpdate = (
   update: Partial<BaileysEventMap["connection.update"]>,
 ) => Promise<void>;
 
+type HandleCredentialsUpdate = (
+  this: WhatsAppAccount,
+  generation: number,
+  socket: WASocket,
+  saveCreds: () => Promise<void>,
+) => void;
+
 type RememberLidPnMappings = (
   this: WhatsAppAccount,
   expectedSessionEpoch: number,
@@ -250,6 +257,42 @@ describe("WhatsApp account socket lease", () => {
     expect(state).toEqual(connectedState);
     expect(accountField(account, "sock")).toBe(candidate);
     await Promise.all(owned);
+  });
+
+  it("persists active credential updates admitted before promotion", async () => {
+    const sessionMutations = new SocketOperationQueue();
+    let releaseMutation: () => void = () => undefined;
+    const mutationGate = new Promise<void>((resolve) => {
+      releaseMutation = resolve;
+    });
+    const precedingMutation = sessionMutations.run(() => mutationGate);
+    const oldSocket = {} as WASocket;
+    const replacementSocket = {} as WASocket;
+    const saveCreds = vi.fn(async () => undefined);
+    const owned: Promise<unknown>[] = [];
+    const account = fakeAccount({
+      sock: oldSocket,
+      socketReplacement: null,
+      socketGeneration: 7,
+      sessionMutations,
+      own: vi.fn((_event: string, promise: Promise<unknown>) => {
+        owned.push(promise);
+      }),
+    });
+    const handleCredentials = accountMethod<HandleCredentialsUpdate>(
+      "handleCredentialsUpdate",
+    );
+
+    handleCredentials.call(account, 7, oldSocket, saveCreds);
+    expect(saveCreds).not.toHaveBeenCalled();
+    Reflect.set(account, "sock", replacementSocket);
+    Reflect.set(account, "socketGeneration", 8);
+    releaseMutation();
+    await Promise.all([precedingMutation, ...owned]);
+
+    expect(saveCreds).toHaveBeenCalledOnce();
+    handleCredentials.call(account, 7, oldSocket, saveCreds);
+    expect(saveCreds).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## Summary

- open and authenticate a replacement socket before retiring the active WhatsApp connection
- keep inbound message admission and gateway forwarding independent from socket lifecycle and outbound work
- recover cleanly from replacement failures, timeouts, duplicate starts, and connection-replaced events
- preserve promoted credentials and document the make-before-break refresh behavior

## Validation

- `cd adapters/whatsapp && npm run check` (57 tests)
- `cd adapters/whatsapp && npm run bundle`
- `git diff --check origin/main...HEAD`