### PR TITLE
compose adapter deployment runtimes

### DIFF
--- a/deployment/src/adapter.ts
+++ b/deployment/src/adapter.ts
@@ -1,3 +1,5 @@
+import * as Config from "effect/Config";
+import * as Schema from "effect/Schema";
 import * as Cloudflare from "alchemy/Cloudflare";
 import { retain } from "alchemy/RemovalPolicy";
 import type {
@@ -12,15 +14,36 @@ export type GsvAdapterWorkerProps = {
   adapter: AdapterDeploymentManifest;
   deployment: AdapterWorkerDeploymentManifest;
   env?: Cloudflare.Workers.WorkerBindingProps;
+  secrets?: Readonly<
+    Record<string, { env: string; pattern?: RegExp }>
+  >;
   compatibility?: typeof GSV_WORKER_COMPATIBILITY;
   workersDev?: boolean | Cloudflare.Workers.WorkersDevConfig;
   observability?: Cloudflare.Workers.WorkerObservability;
 };
 
-export const GsvAdapterWorker = (props: GsvAdapterWorkerProps) => {
+export type GsvAdapterWorkerRuntime = {
+  Cloudflare: typeof Cloudflare;
+  Config: typeof Config;
+  Schema: typeof Schema;
+  retain: typeof retain;
+};
+
+const defaultRuntime: GsvAdapterWorkerRuntime = {
+  Cloudflare,
+  Config,
+  Schema,
+  retain,
+};
+
+export const GsvAdapterWorker = (
+  props: GsvAdapterWorkerProps,
+  runtime: GsvAdapterWorkerRuntime = defaultRuntime,
+) => {
   const env = props.env ?? {};
+  const secrets = props.secrets ?? {};
   for (const secret of props.deployment.requiredSecrets) {
-    if (!(secret in env)) {
+    if (!(secret in secrets)) {
       throw new Error(
         `${props.adapter.displayName} requires deployment secret ${secret}`,
       );
@@ -29,16 +52,30 @@ export const GsvAdapterWorker = (props: GsvAdapterWorkerProps) => {
   const workerEnv: Cloudflare.Workers.WorkerBindingProps = Object.fromEntries(
     props.deployment.durableObjects.map((durableObject) => [
       durableObject.binding,
-      Cloudflare.DurableObject(durableObject.binding, {
+      runtime.Cloudflare.DurableObject(durableObject.binding, {
         className: durableObject.className,
       }),
     ]),
   );
   if (props.deployment.selfUrlBinding) {
-    workerEnv[props.deployment.selfUrlBinding] = Cloudflare.Worker.URL;
+    workerEnv[props.deployment.selfUrlBinding] = runtime.Cloudflare.Worker.URL;
+  }
+  for (const [binding, secret] of Object.entries(secrets)) {
+    if (binding in env) {
+      throw new Error(
+        `${binding} cannot be both an environment value and a secret`,
+      );
+    }
+    const valueSchema = secret.pattern
+      ? runtime.Schema.String.check(runtime.Schema.isPattern(secret.pattern))
+      : runtime.Schema.NonEmptyString;
+    workerEnv[binding] = runtime.Config.schema(
+      runtime.Schema.Redacted(valueSchema),
+      secret.env,
+    );
   }
   Object.assign(workerEnv, env);
-  return Cloudflare.Worker(props.logicalId, {
+  return runtime.Cloudflare.Worker(props.logicalId, {
     name: props.workerName,
     main: props.deployment.main,
     bundle: props.deployment.bundle,
@@ -46,5 +83,5 @@ export const GsvAdapterWorker = (props: GsvAdapterWorkerProps) => {
     workersDev: props.workersDev ?? false,
     observability: props.observability ?? { enabled: true },
     env: workerEnv,
-  }).pipe(retain());
+  }).pipe(runtime.retain());
 };


### PR DESCRIPTION
## Summary

- construct adapter secrets inside the active deployment runtime
- inject the host Alchemy runtime when composing nested deployment packages
- keep required adapter secrets redacted and validate their configured patterns

## Validation

- deployment typecheck and tests
- repository lint for the changed deployment boundary
- infrastructure typecheck
- staging Alchemy plan: 5 updates, 22 no-ops, no creates/replacements/deletes