### PR TITLE
make telegram actor allowlist optional

### DIFF
--- a/adapters/telegram/adapter.json
+++ b/adapters/telegram/adapter.json
@@ -37,8 +37,7 @@
     ],
     "requiredSecrets": [
       "TELEGRAM_BOT_TOKEN",
-      "TELEGRAM_WEBHOOK_SECRET",
-      "TELEGRAM_ALLOWED_ACTOR_IDS"
+      "TELEGRAM_WEBHOOK_SECRET"
     ]
   }
 }


### PR DESCRIPTION
Production managed Telegram is authenticated by webhook secret and signed-in pairing, so it must accept unpaired public actors without an operator-maintained allowlist. Staging can continue supplying TELEGRAM_ALLOWED_ACTOR_IDS as an optional deployment secret.

Validation:
- npm run adapters:check
- npm run deployment:check
- Telegram managed typecheck and tests