### PR TITLE
fix desktop transcriber linking

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -8022,9 +8022,9 @@ dependencies = [
 
 [[package]]
 name = "transcribe-cpp"
-version = "0.1.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3c4d6136eeccf56cfe8a6669e2d63770d1ef051c7cafd2cb9226218c66cded"
+checksum = "ecd41195b6132c83911a05344fdc0fd58807a86ccd796176828d4bdaf9943128"
 dependencies = [
  "log",
  "thiserror 2.0.20",
@@ -8033,9 +8033,9 @@ dependencies = [
 
 [[package]]
 name = "transcribe-cpp-sys"
-version = "0.1.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278fd6a6da4d9d8d5f2716bd6761a76ea55c129fda6ba57856b80249a8570ed4"
+checksum = "67f209e316800d400b02f6a07e0dc5d96e52dae8ad849d4df080d6c2ce5e9516"
 dependencies = [
  "cmake",
  "serde_json",

--- a/host/helpers/transcriber/Cargo.toml
+++ b/host/helpers/transcriber/Cargo.toml
@@ -10,11 +10,11 @@ crossbeam-channel = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-transcribe-cpp = { version = "=0.1.3", default-features = false }
+transcribe-cpp = { version = "=0.2.2", default-features = false }
 ureq = { version = "2.12", default-features = false, features = ["tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-transcribe-cpp = { version = "=0.1.3", default-features = false, features = ["metal"] }
+transcribe-cpp = { version = "=0.2.2", default-features = false, features = ["metal"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/host/helpers/transcriber/src/model.rs
+++ b/host/helpers/transcriber/src/model.rs
@@ -48,7 +48,7 @@ impl Engine {
             &model_path,
             &ModelOptions {
                 backend,
-                gpu_device: 0,
+                device: None,
             },
         )
         .map_err(|_| {


### PR DESCRIPTION
Fixes the Linux x64 Desktop release link failure caused by transcribe-cpp-sys 0.1.3 emitting system BLAS as a non-transitive raw linker argument. Upgrades to 0.2.2, which exports conventional native libraries through Cargo link metadata, and preserves the current CPU/opt-in Metal backend policy.\n\nValidated:\n- cargo check --locked --package transcriber\n- cargo test --locked --package transcriber\n- cargo clippy --locked --package transcriber --all-targets -- -D warnings\n- cargo fmt --package desktop --package transcriber --check\n- cargo build --locked --release --target x86_64-unknown-linux-gnu --package desktop --package transcriber