### PR TITLE
relay inbound email byte streams

### DIFF
--- a/adapters/email/src/index.ts
+++ b/adapters/email/src/index.ts
@@ -2,7 +2,6 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import {
   isAdapterInstallationContext,
   type AdapterInstallationContext,
-  type BinaryBody,
   type ListManagedMailIntakesInput,
   type ManagedMailIntakeDiagnostic,
   type ManagedMailIntakePage,
@@ -129,22 +128,34 @@ export async function handleIncomingMail(
     return;
   }
 
-  const body: BinaryBody = {
-    stream: message.raw,
-    length: message.rawSize,
-  };
   const installation = env.MAIL_INSTALLATIONS.getByName(
     recipient.installation.installationId,
   );
-  const result = await installation.intake(
+  const transport = new FixedLengthStream(message.rawSize);
+  const relayController = new AbortController();
+  const relay = message.raw.pipeTo(transport.writable, {
+    signal: relayController.signal,
+  });
+  const intake = installation.intake(
     recipient.installation,
     {
       from: message.from,
       to: message.to,
       rawSize: message.rawSize,
     },
-    body,
+    {
+      stream: transport.readable,
+      length: message.rawSize,
+    },
   );
+  let result: Awaited<typeof intake>;
+  try {
+    [result] = await Promise.all([intake, relay]);
+  } catch (error) {
+    relayController.abort(error);
+    await Promise.allSettled([intake, relay]);
+    throw error;
+  }
   if (result.status === "rejected") {
     message.setReject(result.reason === "quota"
       ? "Mailbox quota exceeded"

--- a/adapters/email/test/handler.test.ts
+++ b/adapters/email/test/handler.test.ts
@@ -147,6 +147,8 @@ describe("managed mail email handler", () => {
       body: Parameters<typeof bodyToBytes>[0],
     ) => {
       expect(installation).toEqual({ installationId: "installation_hank" });
+      const byob = body.stream.getReader({ mode: "byob" });
+      byob.releaseLock();
       expect(await bodyToBytes(body)).toEqual(raw);
       return { status: "accepted" as const, intakeId: "mail_test" };
     });


### PR DESCRIPTION
## Summary
- relay email-event bodies through a byte-oriented fixed-length stream before Durable Object RPC
- await both the stream relay and durable intake so ownership reaches one terminal outcome
- cover the RPC-compatible byte-stream boundary in the handler test

## Validation
- `npm run typecheck` in `adapters/email`
- `npm test` in `adapters/email` (61 tests)
- `git diff --check`