### PR TITLE
preserve adapter rpc receivers

### DIFF
--- a/gateway/src/kernel/adapter-handlers.test.ts
+++ b/gateway/src/kernel/adapter-handlers.test.ts
@@ -4703,6 +4703,27 @@ describe("managed adapter pairing", () => {
     };
   }
 
+  it("invokes pairing methods through their RPC receiver", async () => {
+    const service = pairingService();
+    Object.defineProperty(service.adapterPairingInfo, "bind", {
+      get() {
+        throw new Error("RPC methods cannot be rebound");
+      },
+    });
+    const ctx = makeContext(
+      { CHANNEL_TELEGRAM: service },
+      { upsert: vi.fn(), list: vi.fn(() => []) },
+      directUserOptions(),
+    );
+
+    await expect(handleAdapterPairInfo({ adapter: "telegram" }, ctx)).resolves.toEqual({
+      adapter: "telegram",
+      accountId: "managed",
+      configured: true,
+      botUsername: "official_gsv_bot",
+    });
+  });
+
   it("discovers the platform bot and confirms the displayed Telegram identity", async () => {
     const service = pairingService();
     let currentLink: IdentityLinkRecord | null = null;

--- a/gateway/src/kernel/adapter-handlers.ts
+++ b/gateway/src/kernel/adapter-handlers.ts
@@ -2388,12 +2388,12 @@ function requirePairingService(
     throw new Error(`Adapter does not support managed pairing: ${adapter}`);
   }
   return {
-    adapterPairingInfo: service.adapterPairingInfo.bind(service),
-    adapterPairingInspect: service.adapterPairingInspect.bind(service),
-    adapterPairingPrepare: service.adapterPairingPrepare.bind(service),
-    adapterPairingActivate: service.adapterPairingActivate.bind(service),
-    adapterPairingFinalize: service.adapterPairingFinalize.bind(service),
-    adapterPairingDisconnect: service.adapterPairingDisconnect.bind(service),
+    adapterPairingInfo: (...args) => service.adapterPairingInfo!(...args),
+    adapterPairingInspect: (...args) => service.adapterPairingInspect!(...args),
+    adapterPairingPrepare: (...args) => service.adapterPairingPrepare!(...args),
+    adapterPairingActivate: (...args) => service.adapterPairingActivate!(...args),
+    adapterPairingFinalize: (...args) => service.adapterPairingFinalize!(...args),
+    adapterPairingDisconnect: (...args) => service.adapterPairingDisconnect!(...args),
   };
 }
 


### PR DESCRIPTION
## Summary
- invoke managed pairing RPCs through their Cloudflare service-binding receiver
- remove local Function.bind calls against RPC method proxies
- cover a non-bindable RPC method in the pairing handler tests

## Validation
- gateway `npx tsc --noEmit`
- adapter handler suite: 91 tests
- root `npm run lint`
- `git diff --check`