### PR TITLE
fix routed shell reliability

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -108,7 +108,7 @@ Default policies:
 | `config/server/name` | `gsv` | Server name used by hostname-style tools and client metadata. |
 | `config/server/timezone` | `UTC` | Runtime timezone value. |
 | `config/server/version` | current `VERSION` | Semantic server version exposed to runtime tools. |
-| `config/shell/timeout_ms` | `30000` | Default native shell timeout. |
+| `config/shell/timeout_ms` | `120000` | Default native shell timeout. |
 | `config/shell/network_enabled` | `true` | Enables network tools in native shell execution. |
 | `config/shell/max_output_bytes` | `524288` | Maximum captured shell output. |
 | `config/process/max_per_user` | `0` | Maximum processes per user. `0` means unlimited. |

--- a/docs/reference/syscalls.md
+++ b/docs/reference/syscalls.md
@@ -195,6 +195,10 @@ It does not derive either value from an agent-supplied hostname.
 
 Runtime behavior:
 
+New commands default to a two-minute maximum runtime. Callers may set
+`timeout` explicitly; the native `gsv` default can also be changed through
+`config/shell/timeout_ms`.
+
 | Syscall | Handler | Behavior |
 |---|---|---|
 | `shell.exec` | `handleShellExec`; CLI `Bash` | Native runs `just-bash` over `GsvFs` with process identity env and built-in commands such as `codemode`, `mail`, `mcp`, and `wiki`. Device targets run a real local shell through the CLI. Device start calls return within a runtime-owned wait budget. If the command is still running, the result includes a `sessionId`; later calls with that `sessionId` poll or write stdin. |
@@ -207,6 +211,7 @@ type ShellSyscalls = {
       cwd?: string;
       input: string;
       sessionId?: string;
+      timeout?: number;
     };
     result:
       | { status: "completed"; output: string; exitCode: number; sessionId?: string; truncated?: boolean }

--- a/docs/reference/syscalls.md
+++ b/docs/reference/syscalls.md
@@ -197,7 +197,9 @@ Runtime behavior:
 
 New commands default to a two-minute maximum runtime. Callers may set
 `timeout` explicitly; the native `gsv` default can also be changed through
-`config/shell/timeout_ms`.
+`config/shell/timeout_ms`. When `timeout` is omitted, the JavaScript SDK leaves
+the execution deadline to the handler instead of imposing the protocol default
+as a transport timeout.
 
 | Syscall | Handler | Behavior |
 |---|---|---|

--- a/extension/package.json
+++ b/extension/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@humansandmachines/gsv": "file:../packages/gsv",
-    "just-bash": "^2.12.6"
+    "just-bash": "^3.4.2"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.34",

--- a/extension/src/background/driver.ts
+++ b/extension/src/background/driver.ts
@@ -36,10 +36,11 @@ export function createBrowserTargetDriver(
             data: await shell.exec(request.args, {
               currentTargetId: currentTargetId(context),
               abortSignal: context.abortSignal,
-              copyTargetFile: async (source, destination) => await context.client.call("fs.copy", {
-                source,
-                destination,
-              }),
+              copyTargetFile: async (source, destination, signal) => (await context.client.request(
+                "fs.copy",
+                { source, destination },
+                { signal },
+              )).data,
             }),
           };
         } else if (request.call.startsWith("fs.")) {

--- a/extension/src/target/commands/tabs.test.ts
+++ b/extension/src/target/commands/tabs.test.ts
@@ -34,6 +34,31 @@ describe("tabs open", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it("passes request cancellation to remote file copies", async () => {
+    const controller = new AbortController();
+    const copyTargetFile = vi.fn(async () => {
+      throw new Error("copy stopped");
+    });
+    const ctx = context(vi.fn(), {
+      fs: { mkdir: vi.fn() } as unknown as TargetFileSystem,
+      currentTargetId: "browser",
+      abortSignal: controller.signal,
+      copyTargetFile,
+    });
+
+    const result = await runTabs(["open", "machine:/report.txt"], ctx);
+
+    expect(copyTargetFile).toHaveBeenCalledWith(
+      { target: "machine", path: "/report.txt" },
+      {
+        target: "browser",
+        path: expect.stringMatching(/^\/tmp\/render\/\d{14}-[a-f0-9]{8}-report\.txt$/),
+      },
+      controller.signal,
+    );
+    expect(result).toMatchObject({ exitCode: 1, stderr: expect.stringContaining("copy stopped") });
+  });
+
 });
 
 describe("page screenshot", () => {
@@ -81,20 +106,21 @@ describe("page screenshot", () => {
   });
 });
 
-async function runTabs(args: string[]) {
+async function runTabs(args: string[], ctx = context()) {
   const command = tabCommands[0];
   if (!command) {
     throw new Error("tabs command is unavailable");
   }
-  return await command.run(args, context());
+  return await command.run(args, ctx);
 }
 
-function context(write = vi.fn()): CommandContext {
+function context(write = vi.fn(), overrides: Partial<CommandContext> = {}): CommandContext {
   return {
     cwd: "/",
     stdin: "",
     fs: { write } as unknown as TargetFileSystem,
     now: () => 0,
+    ...overrides,
   };
 }
 

--- a/extension/src/target/commands/tabs.ts
+++ b/extension/src/target/commands/tabs.ts
@@ -9,6 +9,7 @@ import {
 } from "../../shared/chrome";
 import { inferContentType } from "../../shared/content-types";
 import { basename, normalizePath } from "../../shared/paths";
+import { throwIfAborted } from "../abort";
 import type { BrowserCommand, CommandContext, CommandResult, FileStat, TargetCopyEndpoint } from "../types";
 import { commandError, commandJson, commandOk } from "../types";
 import { hasHelpFlag, requiredInteger, splitOption } from "./args";
@@ -323,7 +324,8 @@ async function renderableFromTargetEndpoint(
     copy = await ctx.copyTargetFile(endpoint, {
       target: ctx.currentTargetId,
       path: destination,
-    });
+    }, ctx.abortSignal);
+    throwIfAborted(ctx.abortSignal);
   } catch (error) {
     throw new Error(remoteCopyErrorMessage(error));
   }

--- a/extension/src/target/just-bash-stdin.ts
+++ b/extension/src/target/just-bash-stdin.ts
@@ -1,0 +1,21 @@
+import type { CommandContext } from "just-bash/browser";
+
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
+
+export function decodeJustBashStdin(stdin: CommandContext["stdin"]): string {
+  const value = stdin as unknown as string;
+  let hasHighByte = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code > 0xff) return value;
+    if (code > 0x7f) hasHighByte = true;
+  }
+  if (!hasHighByte) return value;
+
+  const bytes = Uint8Array.from(value, (character) => character.charCodeAt(0));
+  try {
+    return utf8Decoder.decode(bytes);
+  } catch {
+    return value;
+  }
+}

--- a/extension/src/target/media-recorder.ts
+++ b/extension/src/target/media-recorder.ts
@@ -7,6 +7,7 @@ import {
   type OffscreenMediaMessage,
   type OffscreenMediaResponse,
 } from "./media-recorder-protocol";
+import { throwIfAborted } from "./abort";
 import type { CommandContext, TargetCopyEndpoint, TargetFileSystem } from "./types";
 
 export const DEFAULT_RECORDING_MAX_DURATION_MS = 10 * 60 * 1000;
@@ -266,7 +267,8 @@ async function copyCompletedRecording(
     path: status.localPath,
   };
   try {
-    const copy = await ctx.copyTargetFile(source, status.destination);
+    const copy = await ctx.copyTargetFile(source, status.destination, ctx.abortSignal);
+    throwIfAborted(ctx.abortSignal);
     if (copySucceeded(copy)) {
       await acknowledgeRecordingCopy(status.id, copy).catch(() => undefined);
     }

--- a/extension/src/target/shell.test.ts
+++ b/extension/src/target/shell.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { pageCommand } from "./commands/page";
-import { BrowserTargetShell } from "./shell";
+import { BrowserTargetShell, DEFAULT_BROWSER_SHELL_TIMEOUT_MS } from "./shell";
 import type { BrowserCommand, CommandResult, TargetFileSystem } from "./types";
 
 afterEach(() => vi.unstubAllGlobals());
 
 describe("BrowserTargetShell", () => {
+  it("uses a two-minute default runtime", () => {
+    expect(DEFAULT_BROWSER_SHELL_TIMEOUT_MS).toBe(120_000);
+  });
+
   it("exposes browser commands through help and structured discovery", async () => {
     const commands: BrowserCommand[] = [{
       name: "example",
@@ -135,6 +139,103 @@ describe("BrowserTargetShell", () => {
     running.resolve(undefined);
     await expect(within(next)).resolves.toMatchObject({ status: "completed" });
     expect(laterRuns).toBe(1);
+  });
+
+  it("stops later pipeline stages and keeps the active stage fenced", async () => {
+    const running = deferred<void>();
+    const started = deferred<void>();
+    let pipelineLaterRuns = 0;
+    let nextRuns = 0;
+    const commands: BrowserCommand[] = [
+      {
+        name: "block",
+        summary: "Block the active pipeline stage.",
+        async run() {
+          started.resolve(undefined);
+          await running.promise;
+          return { stdout: "left\n", stderr: "", exitCode: 0 };
+        },
+      },
+      {
+        name: "pipeline-later",
+        summary: "Record a later pipeline stage.",
+        run() {
+          pipelineLaterRuns += 1;
+          return commandResult();
+        },
+      },
+      {
+        name: "next",
+        summary: "Record the next execution.",
+        run() {
+          nextRuns += 1;
+          return commandResult();
+        },
+      },
+    ];
+    const shell = new BrowserTargetShell(directoryOnlyFileSystem(), commands);
+    const controller = new AbortController();
+    const active = shell.exec(
+      { input: "block | pipeline-later" },
+      { abortSignal: controller.signal },
+    );
+    await expect(within(started.promise)).resolves.toBeUndefined();
+
+    const next = shell.exec({ input: "next" });
+    controller.abort(new Error("Route expired"));
+    await expect(within(active)).resolves.toMatchObject({ status: "failed" });
+    expect(pipelineLaterRuns).toBe(0);
+    expect(nextRuns).toBe(0);
+
+    running.resolve(undefined);
+    await expect(within(next)).resolves.toMatchObject({ status: "completed" });
+    expect(pipelineLaterRuns).toBe(0);
+    expect(nextRuns).toBe(1);
+  });
+
+  it("honors an explicit runtime timeout through the command signal", async () => {
+    let observedAbort = false;
+    const command: BrowserCommand = {
+      name: "wait-for-abort",
+      summary: "Wait for cancellation.",
+      async run(_args, ctx) {
+        await new Promise<void>((resolve) => {
+          ctx.abortSignal?.addEventListener("abort", () => {
+            observedAbort = true;
+            resolve();
+          }, { once: true });
+        });
+        return commandResult();
+      },
+    };
+    const shell = new BrowserTargetShell(directoryOnlyFileSystem(), [command]);
+
+    await expect(within(shell.exec({
+      input: "wait-for-abort",
+      timeout: 10,
+    }))).resolves.toMatchObject({
+      status: "failed",
+      error: "Command timed out after 10ms",
+    });
+    expect(observedAbort).toBe(true);
+  });
+
+  it("decodes UTF-8 stdin for browser commands", async () => {
+    let stdin = "";
+    const command: BrowserCommand = {
+      name: "capture-stdin",
+      summary: "Capture text from stdin.",
+      run(_args, ctx) {
+        stdin = ctx.stdin;
+        return commandResult();
+      },
+    };
+    const shell = new BrowserTargetShell(directoryOnlyFileSystem(), [command]);
+
+    await expect(shell.exec({
+      input: "printf 'café ☕' | capture-stdin",
+    })).resolves.toMatchObject({ status: "completed" });
+    expect(stdin).toBe("café ☕");
   });
 
   it("cancels a long page wait, stops polling, and runs the next command", async () => {

--- a/extension/src/target/shell.test.ts
+++ b/extension/src/target/shell.test.ts
@@ -94,6 +94,46 @@ describe("BrowserTargetShell", () => {
     expect(laterRuns).toBe(1);
   });
 
+  it("releases the queue when an active custom command ignores cancellation", async () => {
+    const running = deferred<void>();
+    const started = deferred<void>();
+    let laterRuns = 0;
+    const commands: BrowserCommand[] = [
+      {
+        name: "block",
+        summary: "Ignore cancellation until released.",
+        async run() {
+          started.resolve(undefined);
+          await running.promise;
+          return commandResult();
+        },
+      },
+      {
+        name: "later",
+        summary: "Record execution.",
+        run() {
+          laterRuns += 1;
+          return commandResult();
+        },
+      },
+    ];
+    const shell = new BrowserTargetShell(directoryOnlyFileSystem(), commands);
+    const controller = new AbortController();
+    const active = shell.exec({ input: "block" }, { abortSignal: controller.signal });
+    await expect(within(Promise.race([
+      started.promise.then(() => "started"),
+      active.then(() => "finished"),
+    ]))).resolves.toBe("started");
+
+    const next = shell.exec({ input: "later" });
+    controller.abort(new Error("Route expired"));
+
+    await expect(within(active)).resolves.toMatchObject({ status: "failed" });
+    await expect(within(next)).resolves.toMatchObject({ status: "completed" });
+    expect(laterRuns).toBe(1);
+    running.resolve(undefined);
+  });
+
   it("cancels a long page wait, stops polling, and runs the next command", async () => {
     const firstPoll = deferred<void>();
     const executeScript = vi.fn(async () => {

--- a/extension/src/target/shell.test.ts
+++ b/extension/src/target/shell.test.ts
@@ -94,7 +94,7 @@ describe("BrowserTargetShell", () => {
     expect(laterRuns).toBe(1);
   });
 
-  it("releases the queue when an active custom command ignores cancellation", async () => {
+  it("keeps a cancelled custom command fenced until its operation stops", async () => {
     const running = deferred<void>();
     const started = deferred<void>();
     let laterRuns = 0;
@@ -129,9 +129,12 @@ describe("BrowserTargetShell", () => {
     controller.abort(new Error("Route expired"));
 
     await expect(within(active)).resolves.toMatchObject({ status: "failed" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(laterRuns).toBe(0);
+
+    running.resolve(undefined);
     await expect(within(next)).resolves.toMatchObject({ status: "completed" });
     expect(laterRuns).toBe(1);
-    running.resolve(undefined);
   });
 
   it("cancels a long page wait, stops polling, and runs the next command", async () => {

--- a/extension/src/target/shell.ts
+++ b/extension/src/target/shell.ts
@@ -127,7 +127,10 @@ export class BrowserTargetShell {
             copyTargetFile: this.activeExecContext.copyTargetFile,
           };
           try {
-            return await command.run(args, commandContext);
+            return await abortable(
+              Promise.resolve(command.run(args, commandContext)),
+              commandContext.abortSignal,
+            );
           } catch (error) {
             return commandError(error instanceof Error ? error.message : String(error));
           }

--- a/extension/src/target/shell.ts
+++ b/extension/src/target/shell.ts
@@ -16,13 +16,18 @@ type BrowserBash = InstanceType<typeof Bash>;
 export type BrowserShellExecContext = {
   currentTargetId?: string;
   abortSignal?: AbortSignal;
-  copyTargetFile?: (source: TargetCopyEndpoint, destination: TargetCopyEndpoint) => Promise<unknown>;
+  copyTargetFile?: (
+    source: TargetCopyEndpoint,
+    destination: TargetCopyEndpoint,
+    signal: AbortSignal | undefined,
+  ) => Promise<unknown>;
 };
 
 export class BrowserTargetShell {
   private bash: BrowserBash | null = null;
   private ready: Promise<void> | null = null;
   private activeExecContext: BrowserShellExecContext = {};
+  private activeCommandCompletion: Promise<void> | null = null;
   private execQueue: Promise<void> = Promise.resolve();
 
   constructor(
@@ -45,7 +50,15 @@ export class BrowserTargetShell {
       return failedResult(error);
     } finally {
       if (acquired) {
-        release();
+        // Cancellation can settle Bash before a custom command's owned work; do not let
+        // the next command overlap that work while it reaches its terminal boundary.
+        const completion = this.activeCommandCompletion;
+        this.activeCommandCompletion = null;
+        if (completion) {
+          void completion.then(release);
+        } else {
+          release();
+        }
       } else {
         void previous.then(release);
       }
@@ -127,8 +140,13 @@ export class BrowserTargetShell {
             copyTargetFile: this.activeExecContext.copyTargetFile,
           };
           try {
+            const execution = Promise.resolve(command.run(args, commandContext));
+            this.activeCommandCompletion = execution.then(
+              () => undefined,
+              () => undefined,
+            );
             return await abortable(
-              Promise.resolve(command.run(args, commandContext)),
+              execution,
               commandContext.abortSignal,
             );
           } catch (error) {

--- a/extension/src/target/shell.ts
+++ b/extension/src/target/shell.ts
@@ -1,6 +1,8 @@
 import { Bash, defineCommand, type BashExecResult } from "just-bash/browser";
+import { DEFAULT_SHELL_EXEC_TIMEOUT_MS } from "@humansandmachines/gsv/protocol";
 import { abortable, throwIfAborted } from "./abort";
 import { JustBashFileSystemAdapter } from "./fs-adapter";
+import { decodeJustBashStdin } from "./just-bash-stdin";
 import type {
   BrowserCommand,
   CommandContext,
@@ -12,6 +14,9 @@ import { commandError } from "./types";
 import { commandCatalog, helpText } from "./commands";
 
 type BrowserBash = InstanceType<typeof Bash>;
+
+export const DEFAULT_BROWSER_SHELL_TIMEOUT_MS = DEFAULT_SHELL_EXEC_TIMEOUT_MS;
+const JUST_BASH_EXTENSION_CLEANUP_TIME_MS = 100;
 
 export type BrowserShellExecContext = {
   currentTargetId?: string;
@@ -27,7 +32,7 @@ export class BrowserTargetShell {
   private bash: BrowserBash | null = null;
   private ready: Promise<void> | null = null;
   private activeExecContext: BrowserShellExecContext = {};
-  private activeCommandCompletion: Promise<void> | null = null;
+  private readonly activeCommandCompletions = new Set<Promise<void>>();
   private execQueue: Promise<void> = Promise.resolve();
 
   constructor(
@@ -52,10 +57,9 @@ export class BrowserTargetShell {
       if (acquired) {
         // Cancellation can settle Bash before a custom command's owned work; do not let
         // the next command overlap that work while it reaches its terminal boundary.
-        const completion = this.activeCommandCompletion;
-        this.activeCommandCompletion = null;
-        if (completion) {
-          void completion.then(release);
+        const completions = [...this.activeCommandCompletions];
+        if (completions.length > 0) {
+          void Promise.all(completions).then(() => release());
         } else {
           release();
         }
@@ -70,12 +74,16 @@ export class BrowserTargetShell {
     const input = typeof record.input === "string" ? record.input : "";
     const cwd = typeof record.cwd === "string" && record.cwd.trim() ? this.fs.resolvePath("/", record.cwd) : "/";
     const sessionId = typeof record.sessionId === "string" ? record.sessionId.trim() : "";
+    const timeoutMs = resolveShellTimeout(record.timeout);
 
     if (sessionId) {
       return { status: "failed", output: "", error: "Browser shell sessions are not supported yet" };
     }
     if (!input.trim()) {
       return { status: "failed", output: "", error: "shell.exec requires input" };
+    }
+    if (timeoutMs === null) {
+      return { status: "failed", output: "", error: "shell.exec timeout must be a positive number" };
     }
     if (input.trim() === "help") {
       return { status: "completed", output: helpText(this.commands), exitCode: 0 };
@@ -87,10 +95,21 @@ export class BrowserTargetShell {
         await this.fs.mkdir(cwd);
       }
       throwIfAborted(context.abortSignal);
-      this.activeExecContext = context;
-      const result = await this.requireBash().exec(input, { cwd, signal: context.abortSignal });
-      throwIfAborted(context.abortSignal);
-      return toShellResult(result);
+      const deadline = new AbortController();
+      const timer = setTimeout(() => {
+        deadline.abort(new Error(`Command timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      const signal = context.abortSignal
+        ? AbortSignal.any([context.abortSignal, deadline.signal])
+        : deadline.signal;
+      this.activeExecContext = { ...context, abortSignal: signal };
+      try {
+        const result = await this.requireBash().exec(input, { cwd, signal });
+        throwIfAborted(signal);
+        return toShellResult(result);
+      } finally {
+        clearTimeout(timer);
+      }
     } catch (error) {
       return failedResult(error);
     } finally {
@@ -132,19 +151,21 @@ export class BrowserTargetShell {
         defineCommand(command.name, async (args, ctx) => {
           const commandContext: CommandContext = {
             cwd: ctx.cwd,
-            stdin: ctx.stdin,
+            stdin: decodeJustBashStdin(ctx.stdin),
             fs: this.fs,
             now: () => Date.now(),
             currentTargetId: this.activeExecContext.currentTargetId,
-            abortSignal: this.activeExecContext.abortSignal,
+            abortSignal: ctx.signal ?? this.activeExecContext.abortSignal,
             copyTargetFile: this.activeExecContext.copyTargetFile,
           };
           try {
             const execution = Promise.resolve(command.run(args, commandContext));
-            this.activeCommandCompletion = execution.then(
+            const completion = execution.then(
               () => undefined,
               () => undefined,
             );
+            this.activeCommandCompletions.add(completion);
+            void completion.then(() => this.activeCommandCompletions.delete(completion));
             return await abortable(
               execution,
               commandContext.abortSignal,
@@ -186,6 +207,7 @@ export class BrowserTargetShell {
         maxCommandCount: 10_000,
         maxLoopIterations: 10_000,
         maxCallDepth: 50,
+        maxExtensionCleanupTimeMs: JUST_BASH_EXTENSION_CLEANUP_TIME_MS,
       },
     });
   }
@@ -221,4 +243,11 @@ function failedResult(error: unknown): ShellResult {
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function resolveShellTimeout(value: unknown): number | null {
+  if (value === undefined) return DEFAULT_BROWSER_SHELL_TIMEOUT_MS;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
 }

--- a/extension/src/target/types.ts
+++ b/extension/src/target/types.ts
@@ -28,7 +28,11 @@ export type CommandContext = {
   now: () => number;
   currentTargetId?: string;
   abortSignal?: AbortSignal;
-  copyTargetFile?: (source: TargetCopyEndpoint, destination: TargetCopyEndpoint) => Promise<unknown>;
+  copyTargetFile?: (
+    source: TargetCopyEndpoint,
+    destination: TargetCopyEndpoint,
+    signal: AbortSignal | undefined,
+  ) => Promise<unknown>;
 };
 
 export type DriverHandler = GsvEndpointHandler;

--- a/gateway/package-lock.json
+++ b/gateway/package-lock.json
@@ -8,12 +8,14 @@
       "name": "gateway",
       "version": "0.4.1",
       "dependencies": {
+        "@cfworker/json-schema": "4.1.1",
         "@cloudflare/codemode": "^0.3.4",
         "@earendil-works/pi-ai": "^0.83.0",
         "@humansandmachines/gsv": "file:../packages/gsv",
         "agents": "^0.16.0",
-        "just-bash": "^2.12.6",
-        "marked": "^16.4.2"
+        "just-bash": "^3.4.2",
+        "marked": "^16.4.2",
+        "zod": "4.3.6"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.18.0",
@@ -29,7 +31,8 @@
       "name": "@humansandmachines/gsv",
       "version": "0.0.6",
       "dependencies": {
-        "marked": "^16.4.2"
+        "marked": "^16.4.2",
+        "zod": "4.3.6"
       },
       "devDependencies": {
         "esbuild": "^0.27.7",
@@ -4413,18 +4416,6 @@
         }
       }
     },
-    "node_modules/agents/node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/agents/node_modules/@rolldown/plugin-babel": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
@@ -4453,96 +4444,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/agents/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/agents/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/agents/node_modules/fast-xml-parser": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.0.tgz",
-      "integrity": "sha512-duBuXbyIhEeNO4GjFuVqr0nF047oNwr18aum+zJyqo0MUG/n7Afgs3Qv3D6VN3ONedUKxiuFlPiMGIa0Z11chA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.2.0",
-        "fast-xml-builder": "^1.2.0",
-        "is-unsafe": "^1.0.1",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.4.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/agents/node_modules/just-bash": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/just-bash/-/just-bash-3.0.1.tgz",
-      "integrity": "sha512-YVyzCN08fKarUnwqy7rKOAcX+2MLYLnYInuowmUXn3mqhrtd4ieZNBuzdQG+qYV9DqnIWuv9Whiph0WRIWsBtw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "diff": "^8.0.2",
-        "fast-xml-parser": "^5.7.3",
-        "file-type": "^21.2.0",
-        "ini": "^6.0.0",
-        "minimatch": "^10.1.1",
-        "modern-tar": "^0.7.3",
-        "papaparse": "^5.5.3",
-        "quickjs-emscripten": "^0.32.0",
-        "re2js": "^1.2.1",
-        "seek-bzip": "^2.0.0",
-        "smol-toml": "^1.6.0",
-        "sprintf-js": "^1.1.3",
-        "sql.js": "^1.13.0",
-        "turndown": "^7.2.2",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "just-bash": "dist/bin/just-bash.js",
-        "just-bash-shell": "dist/bin/shell/shell.js"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/zstd": "^7.0.0",
-        "node-liblzma": "^2.0.3"
-      }
-    },
-    "node_modules/agents/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ai": {
@@ -5202,15 +5103,6 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "license": "BSD-3-Clause OR MIT",
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -5236,9 +5128,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -5640,31 +5532,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/compressjs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/compressjs/-/compressjs-1.0.3.tgz",
-      "integrity": "sha512-jpKJjBTretQACTGLNuvnozP1JdP2ZLrjdGdBgk/tz1VfXlUcBhhSZW6vEsuThmeot/yjvSrPQKEgfF3X2Lpi8Q==",
-      "license": "GPL",
-      "dependencies": {
-        "amdefine": "~1.0.0",
-        "commander": "~2.8.1"
-      },
-      "bin": {
-        "compressjs": "bin/compressjs"
-      }
-    },
-    "node_modules/compressjs/node_modules/commander": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-      "integrity": "sha512-+pJLBFVk+9ZZdlAOB5WuIElVPPth47hILFkmGym57aq8kwxsowvByvB0DHs1vQAhyMZzdcpTtF0VDKGkSDR4ZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-readlink": ">= 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
       }
     },
     "node_modules/content-disposition": {
@@ -6896,12 +6763,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-      "license": "MIT"
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7168,9 +7029,9 @@
       }
     },
     "node_modules/is-unsafe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
-      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
       "funding": [
         {
           "type": "github",
@@ -7319,35 +7180,51 @@
       }
     },
     "node_modules/just-bash": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/just-bash/-/just-bash-2.14.0.tgz",
-      "integrity": "sha512-hiwsAa7OugRX5/fHhRijpyASioZ/UGjt/fjS15DQmrcFJmsBFabefZogdBJifw0WJUVqUiqATVRbhcwKScrD3w==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/just-bash/-/just-bash-3.4.2.tgz",
+      "integrity": "sha512-T0Vpy7YRgCjxJdqG3tkxn0ZnIDLJvVwb8hH4L+6NVdp+Te27jQxjxnszW9ODjEKbWxWujj83rP5S0GQxCSufgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "compressjs": "^1.0.3",
-        "diff": "^8.0.2",
-        "fast-xml-parser": "^5.3.3",
-        "file-type": "^21.2.0",
+        "diff": "^8.0.4",
+        "fast-xml-parser": "^5.10.1",
+        "file-type": "^21.3.4",
         "ini": "^6.0.0",
-        "minimatch": "^10.1.1",
-        "modern-tar": "^0.7.3",
-        "papaparse": "^5.5.3",
+        "minimatch": "^10.2.6",
+        "modern-tar": "^0.7.7",
+        "papaparse": "^5.6.0",
         "quickjs-emscripten": "^0.32.0",
-        "re2js": "^1.2.1",
-        "smol-toml": "^1.6.0",
+        "re2js": "^1.3.3",
+        "seek-bzip": "^2.0.0",
+        "smol-toml": "^1.8.0",
         "sprintf-js": "^1.1.3",
-        "sql.js": "^1.13.0",
-        "turndown": "^7.2.2",
-        "yaml": "^2.8.2"
+        "sql.js": "^1.14.1",
+        "turndown": "^7.2.4",
+        "undici": "^7.29.0",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "just-bash": "dist/bin/just-bash.js",
         "just-bash-shell": "dist/bin/shell/shell.js"
       },
+      "engines": {
+        "node": ">=20.18.1"
+      },
       "optionalDependencies": {
         "@mongodb-js/zstd": "^7.0.0",
-        "node-liblzma": "^2.0.3"
+        "node-liblzma": "^2.2.0"
       }
+    },
+    "node_modules/just-bash/node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/just-bash/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -7359,30 +7236,77 @@
       }
     },
     "node_modules/just-bash/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/just-bash/node_modules/fast-xml-parser": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+      "integrity": "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/just-bash/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/just-bash/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/just-bash/node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/jwa": {
@@ -7912,9 +7836,9 @@
       "optional": true
     },
     "node_modules/modern-tar": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
-      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -8243,9 +8167,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/papaparse": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.7.0.tgz",
+      "integrity": "sha512-qBGxg/7Q3Kl9Wfhrz2Z74UnvnHTXLNG6jmKJFeBvP2+y4lV7So+7SR62+Zd47JvdrCkX+nDcnr0ObPzek/+6RA==",
       "license": "MIT"
     },
     "node_modules/parse-ms": {
@@ -8306,9 +8230,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -8653,9 +8577,9 @@
       "optional": true
     },
     "node_modules/re2js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/re2js/-/re2js-1.2.3.tgz",
-      "integrity": "sha512-M2/7k8LkP+LmB/muGZXvAHiwhgwqq0Ign2UHCZkea39nHOakeixyMSfb7rql7N/6u5PTS+IpP2MKfRLJ4fed0g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-1.3.3.tgz",
+      "integrity": "sha512-s/I5zEAo79SUK0Qw4dpZKpiMwbQ6Gz0KU2NRr7eaO4x/p2g7Vvmn3hdeXDg8VsaUjfj/ora+e9oi27LX/C9+mw==",
       "license": "MIT"
     },
     "node_modules/react": {
@@ -9106,9 +9030,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -9306,9 +9230,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
       "funding": [
         {
           "type": "github",
@@ -9317,7 +9241,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/strtok3": {
@@ -9969,12 +9893,16 @@
       }
     },
     "node_modules/turndown": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
-      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
       "license": "MIT",
       "dependencies": {
         "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
       }
     },
     "node_modules/type-is": {

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -29,7 +29,7 @@
     "@earendil-works/pi-ai": "^0.83.0",
     "@humansandmachines/gsv": "file:../packages/gsv",
     "agents": "^0.16.0",
-    "just-bash": "^2.12.6",
+    "just-bash": "^3.4.2",
     "marked": "^16.4.2",
     "zod": "4.3.6"
   }

--- a/gateway/src/drivers/native/shell.test.ts
+++ b/gateway/src/drivers/native/shell.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
 import { Bash } from "just-bash";
-import { handleShellExec, NATIVE_SHELL_NETWORK_CONFIG } from "./shell";
+import {
+  DEFAULT_NATIVE_SHELL_TIMEOUT_MS,
+  handleShellExec,
+  NATIVE_SHELL_NETWORK_CONFIG,
+} from "./shell";
 import {
   handleFsCopy,
   handleFsRead,
@@ -206,6 +210,7 @@ function makeContext(options?: {
   identity?: ProcessIdentity;
   aiRun?: (model: string, input: ShellAiInput) => Promise<ShellAiResult>;
   ripgit?: Fetcher;
+  requestSignal?: AbortSignal;
 }): KernelContext {
   const identity = options?.identity ?? IDENTITY;
   const installationIdentity: InstallationIdentity = {
@@ -339,6 +344,7 @@ function makeContext(options?: {
     },
     processId: options?.processId === null ? undefined : options?.processId ?? "task:shell",
     processRunId: options?.processRunId,
+    requestSignal: options?.requestSignal,
     serverVersion: "0.4.1",
     scheduleIpcCallTimeout: options?.scheduleIpcCallTimeout,
     scheduleScheduleWake: options?.scheduleScheduleWake,
@@ -533,6 +539,48 @@ function enablePrivateDmHandoff(
 }
 
 describe("native shell execution", () => {
+  it("uses a two-minute default runtime", () => {
+    expect(DEFAULT_NATIVE_SHELL_TIMEOUT_MS).toBe(120_000);
+  });
+
+  it("reports the configured command timeout under just-bash cancellation", async () => {
+    const result = await handleShellExec(
+      { input: "sleep 1", timeout: 10 },
+      makeContext(),
+    );
+
+    expect(result).toMatchObject({
+      status: "failed",
+      error: "Command timed out after 10ms",
+    });
+  });
+
+  it("preserves the request cancellation reason under just-bash cancellation", async () => {
+    const controller = new AbortController();
+    const resultPromise = handleShellExec(
+      { input: "sleep 1" },
+      makeContext({ requestSignal: controller.signal }),
+    );
+    controller.abort(new Error("User interrupted"));
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: "failed",
+      error: "User interrupted",
+    });
+  });
+
+  it("supports process substitution through the native filesystem", async () => {
+    const result = await handleShellExec(
+      { input: "cat <(printf 'substitution works')" },
+      makeContext(),
+    );
+
+    expect(result).toMatchObject({
+      status: "completed",
+      stdout: "substitution works",
+    });
+  });
+
   it("keeps command stderr visible on non-zero exits", async () => {
     const result = await handleShellExec(
       { input: "printf 'real failure\\n' >&2; exit 7" },
@@ -1056,6 +1104,37 @@ describe("media native commands", () => {
     );
     expect(denied.exitCode).toBe(1);
     expect(denied.stderr).toContain("Permission denied: ai.text.generate");
+  });
+
+  it("decodes UTF-8 stdin before invoking llm", async () => {
+    generateMock.mockImplementationOnce(async (request: any) => {
+      expect(request.context.messages[0].content).toBe("café ☕");
+      return {
+        role: "assistant",
+        content: [{ type: "text", text: "received" }],
+        api: "test",
+        provider: "workers-ai",
+        model: "@cf/test/model",
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      };
+    });
+
+    const result = await handleShellExec(
+      { input: "printf 'café ☕' | llm" },
+      makeContext({ capabilities: ["ai.text.generate"] }),
+    );
+
+    expect(result.status, result.stderr).toBe("completed");
+    expect(result.stdout).toBe("received\n");
   });
 
   it("fails llm when text generation returns an error message", async () => {

--- a/gateway/src/drivers/native/shell.test.ts
+++ b/gateway/src/drivers/native/shell.test.ts
@@ -569,6 +569,50 @@ describe("native shell execution", () => {
     });
   });
 
+  it("fences native custom command completion after timeout", async () => {
+    let generationSignal: AbortSignal | undefined;
+    let finishGeneration: () => void = () => {};
+    generateMock.mockImplementationOnce(async (request: { signal?: AbortSignal }) => await new Promise((resolve) => {
+      generationSignal = request.signal;
+      finishGeneration = () => resolve({
+        role: "assistant",
+        content: [{ type: "text", text: "late response" }],
+        api: "test",
+        provider: "workers-ai",
+        model: "@cf/test/model",
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      });
+    }));
+
+    const resultPromise = handleShellExec(
+      { input: "llm wait", timeout: 10 },
+      makeContext({ capabilities: ["ai.text.generate"] }),
+    );
+    await vi.waitFor(() => expect(generateMock).toHaveBeenCalledOnce());
+
+    const earlyOutcome = await Promise.race([
+      resultPromise.then(() => "settled"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("pending"), 150)),
+    ]);
+    expect(earlyOutcome).toBe("pending");
+    expect(generationSignal?.aborted).toBe(true);
+
+    finishGeneration();
+    await expect(resultPromise).resolves.toMatchObject({
+      status: "failed",
+      error: "Command timed out after 10ms",
+    });
+  });
+
   it("supports process substitution through the native filesystem", async () => {
     const result = await handleShellExec(
       { input: "cat <(printf 'substitution works')" },
@@ -2472,7 +2516,7 @@ describe("fs copy", () => {
     expect(openContactSource).toHaveBeenCalledWith({
       target: contact.id,
       path: "/resources/resource:shared",
-    }, undefined);
+    }, expect.any(AbortSignal));
     expect(await (await env.STORAGE.get(destinationKey))?.text()).toBe("from contact");
   });
 

--- a/gateway/src/drivers/native/shell.ts
+++ b/gateway/src/drivers/native/shell.ts
@@ -13,7 +13,10 @@ import type { BashExecResult, NetworkConfig } from "just-bash";
 import { resolveUserPath } from "../../fs";
 import type { KernelContext } from "../../kernel/context";
 import type { ShellExecArgs, ShellExecResult } from "../../syscalls/shell";
-import type { ProcessIdentity } from "@humansandmachines/gsv/protocol";
+import {
+  DEFAULT_SHELL_EXEC_TIMEOUT_MS,
+  type ProcessIdentity,
+} from "@humansandmachines/gsv/protocol";
 import { createNativeFileSystem } from "./filesystem";
 import {
   buildCustomCommands,
@@ -28,6 +31,10 @@ export const NATIVE_SHELL_NETWORK_CONFIG = {
   // public hostnames instead of failing before fetch.
   denyPrivateRanges: false,
 } satisfies NetworkConfig;
+
+export const DEFAULT_NATIVE_SHELL_TIMEOUT_MS = DEFAULT_SHELL_EXEC_TIMEOUT_MS;
+const JUST_BASH_EXTENSION_CLEANUP_TIME_MS = 100;
+const JUST_BASH_EXECUTION_BACKSTOP_GRACE_MS = 1_000;
 
 export async function handleShellExec(
   args: ShellExecArgs,
@@ -52,10 +59,8 @@ export async function handleShellExec(
   const cwd = args.cwd
     ? resolveUserPath(args.cwd, identity.home, identity.cwd)
     : identity.cwd;
-  const bash = createBash(ctx, identity, cwd, options);
-
   const timeoutMs = parseInt(
-    ctx.config.get("config/shell/timeout_ms") ?? "30000",
+    ctx.config.get("config/shell/timeout_ms") ?? String(DEFAULT_NATIVE_SHELL_TIMEOUT_MS),
     10,
   );
   const maxOutput = parseInt(
@@ -63,10 +68,16 @@ export async function handleShellExec(
     10,
   );
   const timeout = args.timeout ?? timeoutMs;
+  if (!Number.isFinite(timeout) || timeout <= 0) {
+    return { status: "failed", output: "", error: "timeout must be a positive number" };
+  }
+  const bash = createBash(ctx, identity, cwd, timeout, options);
+  const controller = new AbortController();
 
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeout);
+    const timer = setTimeout(() => {
+      controller.abort(new Error(`Command timed out after ${timeout}ms`));
+    }, timeout);
     const signal = ctx.requestSignal
       ? AbortSignal.any([controller.signal, ctx.requestSignal])
       : controller.signal;
@@ -79,6 +90,13 @@ export async function handleShellExec(
       });
     } finally {
       clearTimeout(timer);
+    }
+
+    if (ctx.requestSignal?.aborted) {
+      return requestCancelledResult(ctx.requestSignal);
+    }
+    if (controller.signal.aborted) {
+      return commandTimedOutResult(timeout);
     }
 
     const stdout = truncate(result.stdout, maxOutput);
@@ -114,16 +132,13 @@ export async function handleShellExec(
     };
   } catch (err) {
     if (ctx.requestSignal?.aborted) {
-      return {
-        status: "failed",
-        output: "",
-        error: ctx.requestSignal.reason instanceof Error
-          ? ctx.requestSignal.reason.message
-          : "Request cancelled",
-      };
+      return requestCancelledResult(ctx.requestSignal);
+    }
+    if (controller.signal.aborted) {
+      return commandTimedOutResult(timeout);
     }
     if (err instanceof Error && err.name === "AbortError") {
-      return { status: "failed", output: "", error: `Command timed out after ${timeout}ms` };
+      return commandTimedOutResult(timeout);
     }
     return { status: "failed", output: "", error: err instanceof Error ? err.message : String(err) };
   }
@@ -133,6 +148,7 @@ function createBash(
   ctx: KernelContext,
   identity: ProcessIdentity,
   cwd: string,
+  timeoutMs: number,
   options?: NativeShellCommandOptions,
 ): Bash {
   const fs = createNativeFileSystem(ctx);
@@ -178,11 +194,30 @@ function createBash(
       maxCallDepth: 64,
       maxLoopIterations: 10_000,
       maxOutputSize: maxOutput,
+      maxExecutionTimeMs: timeoutMs + JUST_BASH_EXECUTION_BACKSTOP_GRACE_MS,
+      maxExtensionCleanupTimeMs: JUST_BASH_EXTENSION_CLEANUP_TIME_MS,
     },
     customCommands: buildCustomCommands(fs, identity, ctx, options),
   });
 }
 
+function requestCancelledResult(signal: AbortSignal): ShellExecResult {
+  return {
+    status: "failed",
+    output: "",
+    error: signal.reason instanceof Error
+      ? signal.reason.message
+      : "Request cancelled",
+  };
+}
+
+function commandTimedOutResult(timeoutMs: number): ShellExecResult {
+  return {
+    status: "failed",
+    output: "",
+    error: `Command timed out after ${timeoutMs}ms`,
+  };
+}
 
 function truncate(str: string, maxBytes: number): string {
   if (new TextEncoder().encode(str).length <= maxBytes) return str;

--- a/gateway/src/drivers/native/shell.ts
+++ b/gateway/src/drivers/native/shell.ts
@@ -9,7 +9,11 @@
  */
 
 import { Bash } from "just-bash";
-import type { BashExecResult, NetworkConfig } from "just-bash";
+import type {
+  BashExecResult,
+  Command,
+  NetworkConfig,
+} from "just-bash";
 import { resolveUserPath } from "../../fs";
 import type { KernelContext } from "../../kernel/context";
 import type { ShellExecArgs, ShellExecResult } from "../../syscalls/shell";
@@ -71,16 +75,24 @@ export async function handleShellExec(
   if (!Number.isFinite(timeout) || timeout <= 0) {
     return { status: "failed", output: "", error: "timeout must be a positive number" };
   }
-  const bash = createBash(ctx, identity, cwd, timeout, options);
   const controller = new AbortController();
+  const signal = ctx.requestSignal
+    ? AbortSignal.any([controller.signal, ctx.requestSignal])
+    : controller.signal;
+  const commandFence = new NativeCommandFence();
+  const bash = createBash(
+    { ...ctx, requestSignal: signal },
+    identity,
+    cwd,
+    timeout,
+    commandFence,
+    options,
+  );
 
   try {
     const timer = setTimeout(() => {
       controller.abort(new Error(`Command timed out after ${timeout}ms`));
     }, timeout);
-    const signal = ctx.requestSignal
-      ? AbortSignal.any([controller.signal, ctx.requestSignal])
-      : controller.signal;
 
     let result: BashExecResult;
     try {
@@ -90,6 +102,7 @@ export async function handleShellExec(
       });
     } finally {
       clearTimeout(timer);
+      await commandFence.waitForCompletion();
     }
 
     if (ctx.requestSignal?.aborted) {
@@ -149,6 +162,7 @@ function createBash(
   identity: ProcessIdentity,
   cwd: string,
   timeoutMs: number,
+  commandFence: NativeCommandFence,
   options?: NativeShellCommandOptions,
 ): Bash {
   const fs = createNativeFileSystem(ctx);
@@ -197,8 +211,32 @@ function createBash(
       maxExecutionTimeMs: timeoutMs + JUST_BASH_EXECUTION_BACKSTOP_GRACE_MS,
       maxExtensionCleanupTimeMs: JUST_BASH_EXTENSION_CLEANUP_TIME_MS,
     },
-    customCommands: buildCustomCommands(fs, identity, ctx, options),
+    customCommands: commandFence.wrap(buildCustomCommands(fs, identity, ctx, options)),
   });
+}
+
+class NativeCommandFence {
+  private readonly activeCompletions = new Set<Promise<void>>();
+
+  wrap(commands: Command[]): Command[] {
+    return commands.map((command) => ({
+      ...command,
+      execute: (args, ctx) => {
+        const execution = command.execute(args, ctx);
+        const completion = execution.then(
+          () => undefined,
+          () => undefined,
+        );
+        this.activeCompletions.add(completion);
+        void completion.then(() => this.activeCompletions.delete(completion));
+        return execution;
+      },
+    }));
+  }
+
+  async waitForCompletion(): Promise<void> {
+    await Promise.all(this.activeCompletions);
+  }
 }
 
 function requestCancelledResult(signal: AbortSignal): ShellExecResult {

--- a/gateway/src/drivers/native/shell/llm.ts
+++ b/gateway/src/drivers/native/shell/llm.ts
@@ -1,4 +1,9 @@
-import { defineCommand, type Command, type CommandContext, type ExecResult } from "just-bash";
+import {
+  defineCommand,
+  type Command,
+  type CommandContext,
+  type ExecResult,
+} from "just-bash";
 import type {
   AiTextGenerateConfig,
   AiTextGenerateResult,
@@ -8,6 +13,7 @@ import { handleAiTextGenerate } from "../../../kernel/ai";
 import type { KernelContext } from "../../../kernel/context";
 import type { NetFetchDeviceTransport } from "../../../kernel/net";
 import { requireCommandCapability, requireShellOptionValue } from "./common";
+import { decodeShellStdin } from "./stdin";
 
 type ParsedArgs = {
   options: Map<string, string | true>;
@@ -212,7 +218,7 @@ function normalizeReasoning(value: string): NonNullable<AiTextGenerateOptions["r
 }
 
 function readTextArgument(positionals: string[], ctx: CommandContext): string {
-  const text = positionals.join(" ").trim() || ctx.stdin.trim();
+  const text = positionals.join(" ").trim() || decodeShellStdin(ctx.stdin).trim();
   if (!text) {
     throw new Error("prompt is required");
   }

--- a/gateway/src/drivers/native/shell/mail.test.ts
+++ b/gateway/src/drivers/native/shell/mail.test.ts
@@ -5,7 +5,7 @@ import type {
   ProcessIdentity,
 } from "@humansandmachines/gsv/protocol";
 import { env } from "cloudflare:test";
-import type { CommandContext } from "just-bash";
+import { createCommandContext, InMemoryFs, type CommandContext } from "just-bash";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createAccountHomeBackend } from "../../../fs/backends/account-home";
 import { GsvFs } from "../../../fs/gsv-fs";
@@ -483,16 +483,11 @@ function commandContext(
 }
 
 function shellCommandContext(signal?: AbortSignal): CommandContext {
-  // SAFETY: this fixture supplies the CommandContext fields used by mail commands.
-  return {
+  return createCommandContext({
+    fs: new InMemoryFs(),
     cwd: "/",
-    env: new Map(),
-    stdin: "",
-    fs: {
-      resolvePath: (_cwd: string, path: string) => path,
-    },
     signal,
-  } as CommandContext;
+  });
 }
 
 function messageInput(

--- a/gateway/src/drivers/native/shell/media.ts
+++ b/gateway/src/drivers/native/shell/media.ts
@@ -1,4 +1,9 @@
-import { defineCommand, type Command, type CommandContext, type ExecResult } from "just-bash";
+import {
+  defineCommand,
+  type Command,
+  type CommandContext,
+  type ExecResult,
+} from "just-bash";
 import {
   bodyToText,
   jsonObjectSchema,
@@ -21,6 +26,7 @@ import type { KernelContext } from "../../../kernel/context";
 import { openFsSource, type FsDeviceTransport } from "../fs";
 import { requireCommandCapability, requireShellOptionValue } from "./common";
 import { parseShellFsEndpoint } from "./fs-path";
+import { decodeShellStdin } from "./stdin";
 
 export type MediaHandlers = {
   imageGenerate: typeof handleAiImageGenerate;
@@ -642,7 +648,7 @@ function parseSchemaOption(value: string | undefined): JsonObject | undefined {
 }
 
 function readTextArgument(positionals: string[], ctx: CommandContext, label: string): string {
-  const text = positionals.join(" ").trim() || ctx.stdin.trim();
+  const text = positionals.join(" ").trim() || decodeShellStdin(ctx.stdin).trim();
   if (!text) {
     throw new Error(`${label} is required`);
   }

--- a/gateway/src/drivers/native/shell/skills.ts
+++ b/gateway/src/drivers/native/shell/skills.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../kernel/skills";
 import type { ProcessIdentity } from "@humansandmachines/gsv/protocol";
 import { nativeCommandSynopsis } from "./discovery";
+import { decodeShellStdin } from "./stdin";
 
 export type SkillFs = Pick<GsvFs, "resolvePath" | "exists" | "mkdir" | "writeFile" | "readdir" | "stat" | "readFile">;
 
@@ -241,7 +242,7 @@ async function readSkillBody(
   fs: SkillFs,
   identity: ProcessIdentity,
 ): Promise<string> {
-  const stdin = commandCtx.stdin.trim();
+  const stdin = decodeShellStdin(commandCtx.stdin).trim();
   if (from && stdin) {
     throw new Error("provide workflow instructions with either --from or stdin, not both");
   }

--- a/gateway/src/drivers/native/shell/stdin.ts
+++ b/gateway/src/drivers/native/shell/stdin.ts
@@ -1,0 +1,21 @@
+import type { CommandContext } from "just-bash";
+
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
+
+export function decodeShellStdin(stdin: CommandContext["stdin"]): string {
+  const value = stdin as unknown as string;
+  let hasHighByte = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code > 0xff) return value;
+    if (code > 0x7f) hasHighByte = true;
+  }
+  if (!hasHighByte) return value;
+
+  const bytes = Uint8Array.from(value, (character) => character.charCodeAt(0));
+  try {
+    return utf8Decoder.decode(bytes);
+  } catch {
+    return value;
+  }
+}

--- a/gateway/src/drivers/native/shell/stdin.ts
+++ b/gateway/src/drivers/native/shell/stdin.ts
@@ -3,7 +3,7 @@ import type { CommandContext } from "just-bash";
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
 
 export function decodeShellStdin(stdin: CommandContext["stdin"]): string {
-  const value = stdin as unknown as string;
+  const value = String(stdin);
   let hasHighByte = false;
   for (let index = 0; index < value.length; index += 1) {
     const code = value.charCodeAt(index);

--- a/gateway/src/kernel/config.test.ts
+++ b/gateway/src/kernel/config.test.ts
@@ -9,6 +9,10 @@ import { runWithRealKernelSql } from "../test-support/real-kernel-sql";
 import { MAIL_STATUS } from "../syscalls/constants";
 
 describe("ConfigStore", () => {
+  it("defaults native shell execution to two minutes", () => {
+    expect(SYSTEM_CONFIG_DEFAULTS["config/shell/timeout_ms"]).toBe("120000");
+  });
+
   const configuredStoreTest = it.extend<{ store: ConfigStore }>({
     store: async ({ task: _task }, use) => {
       await runWithRealKernelSql(async (sql) => {

--- a/gateway/src/kernel/config.ts
+++ b/gateway/src/kernel/config.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_WORKERS_AI_MODEL,
 } from "../inference/default-models";
 import { MAIL_SEND } from "../syscalls/constants";
+import { DEFAULT_SHELL_EXEC_TIMEOUT_MS } from "@humansandmachines/gsv/protocol";
 
 // =============================================================================
 // System config defaults — every field documented.
@@ -146,7 +147,7 @@ export const SYSTEM_CONFIG_DEFAULTS = defineSystemConfigDefaults({
 
   // -- Shell ------------------------------------------------------------------
   // Default shell timeout in ms for native shell.exec.
-  "config/shell/timeout_ms": "30000",
+  "config/shell/timeout_ms": String(DEFAULT_SHELL_EXEC_TIMEOUT_MS),
   // Whether curl/wget are enabled in the native bash shell (true/false).
   "config/shell/network_enabled": "true",
   // Max output size in bytes for shell command results.

--- a/gateway/src/protocol/decode-wire-frame.test.ts
+++ b/gateway/src/protocol/decode-wire-frame.test.ts
@@ -95,6 +95,29 @@ describe("decodeWireFrameJson", () => {
       .toThrowError(new InvalidWireFrameError("Invalid fs.write response"));
   });
 
+  it("accepts the public shell result and rejects host-only response fields", () => {
+    const response = {
+      type: "res" as const,
+      id: "shell-1",
+      ok: true as const,
+      data: {
+        status: "completed",
+        output: "done\n",
+        exitCode: 0,
+        sessionId: "session-1",
+        truncated: false,
+        stdout: "done\n",
+        stderr: "",
+      },
+    };
+
+    expect(decodeWireResponse("shell.exec", response)).toEqual(response);
+    expect(() => decodeWireResponse("shell.exec", {
+      ...response,
+      data: { ...response.data, cwd: "/workspace" },
+    })).toThrowError(new InvalidWireFrameError("Invalid shell.exec response"));
+  });
+
   it("retains a request id when call-specific arguments are invalid", () => {
     try {
       decodeWireFrameJson(JSON.stringify({

--- a/host/apps/machine/src/tools/search.rs
+++ b/host/apps/machine/src/tools/search.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
-use walkdir::WalkDir;
+use walkdir::{DirEntry, WalkDir};
 
 const MAX_MATCHES: usize = 100;
 const MAX_SEARCH_FILES: usize = 25_000;
@@ -76,20 +76,16 @@ impl SearchTool {
         let mut scanned_bytes = 0_u64;
         let mut truncated = false;
 
-        for (scanned_files, entry) in WalkDir::new(&base_path)
-            .follow_links(false)
-            .into_iter()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().is_file())
-            .enumerate()
-        {
-            if cancellation.is_cancelled() {
-                return Err("Search cancelled".to_string());
-            }
+        let mut scanned_files = 0_usize;
+        for entry in WalkDir::new(&base_path).follow_links(false) {
+            let Some(entry) = cancellable_file_entry(entry, cancellation)? else {
+                continue;
+            };
             if scanned_files >= MAX_SEARCH_FILES {
                 truncated = true;
                 break;
             }
+            scanned_files += 1;
             let path = entry.path();
             if let Some(pattern) = &include_glob {
                 let file_name = path
@@ -124,6 +120,22 @@ impl SearchTool {
 
         Ok(search_output(matches, truncated))
     }
+}
+
+fn cancellable_file_entry(
+    entry: Result<DirEntry, walkdir::Error>,
+    cancellation: &CancellationToken,
+) -> Result<Option<DirEntry>, String> {
+    if cancellation.is_cancelled() {
+        return Err("Search cancelled".to_string());
+    }
+    let Ok(entry) = entry else {
+        return Ok(None);
+    };
+    if !entry.file_type().is_file() {
+        return Ok(None);
+    }
+    Ok(Some(entry))
 }
 
 struct FileSearchResult {
@@ -317,6 +329,21 @@ mod tests {
 
         assert_eq!(error, "Search cancelled");
         tokio::fs::remove_dir_all(workspace).await.unwrap();
+    }
+
+    #[test]
+    fn search_checks_cancellation_before_filtering_directories() {
+        let workspace = std::env::temp_dir().join(format!("gsv-search-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&workspace).unwrap();
+        let directory = WalkDir::new(&workspace).into_iter().next().unwrap();
+        assert!(directory.as_ref().unwrap().file_type().is_dir());
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+
+        let error = cancellable_file_entry(directory, &cancellation).unwrap_err();
+
+        assert_eq!(error, "Search cancelled");
+        fs::remove_dir_all(workspace).unwrap();
     }
 
     #[tokio::test]

--- a/host/apps/machine/src/tools/search.rs
+++ b/host/apps/machine/src/tools/search.rs
@@ -81,17 +81,6 @@ impl SearchTool {
             .into_iter()
             .filter_map(|e| e.ok())
             .filter(|e| e.file_type().is_file())
-            .filter(|entry| {
-                let Some(pattern) = &include_glob else {
-                    return true;
-                };
-                let file_name = entry
-                    .path()
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or("");
-                pattern.matches(file_name)
-            })
             .enumerate()
         {
             if cancellation.is_cancelled() {
@@ -102,6 +91,15 @@ impl SearchTool {
                 break;
             }
             let path = entry.path();
+            if let Some(pattern) = &include_glob {
+                let file_name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("");
+                if !pattern.matches(file_name) {
+                    continue;
+                }
+            }
 
             let remaining_bytes = MAX_SEARCH_TOTAL_BYTES.saturating_sub(scanned_bytes);
             if remaining_bytes == 0 {
@@ -309,7 +307,11 @@ mod tests {
         cancellation.cancel();
 
         let error = SearchTool::new(workspace.clone())
-            .execute_with_body_cancellable(json!({ "query": "needle" }), None, &cancellation)
+            .execute_with_body_cancellable(
+                json!({ "query": "needle", "include": "*.md" }),
+                None,
+                &cancellation,
+            )
             .await
             .unwrap_err();
 

--- a/host/apps/machine/src/tools/search.rs
+++ b/host/apps/machine/src/tools/search.rs
@@ -170,7 +170,7 @@ fn search_text_file(
     }
 
     let mut reader = BufReader::new(file.take(max_bytes.saturating_add(1)));
-    let mut line = String::new();
+    let mut line = Vec::new();
     let mut line_number = 0_usize;
     let mut bytes_read = 0_u64;
     let mut matches = Vec::new();
@@ -180,11 +180,8 @@ fn search_text_file(
         }
 
         line.clear();
-        let read = match reader.read_line(&mut line) {
+        let read = match reader.read_until(b'\n', &mut line) {
             Ok(read) => read,
-            Err(error) if error.kind() == std::io::ErrorKind::InvalidData => {
-                return Ok(empty(bytes_read, false));
-            }
             Err(_) => return Ok(empty(bytes_read, false)),
         };
         if read == 0 {
@@ -202,9 +199,12 @@ fn search_text_file(
                 truncated: true,
             });
         }
-        if line.as_bytes().contains(&0) {
+        if line.contains(&0) {
             return Ok(empty(bytes_read, false));
         }
+        let Ok(line) = std::str::from_utf8(&line) else {
+            return Ok(empty(bytes_read, false));
+        };
 
         line_number += 1;
         if line.contains(query) {
@@ -371,5 +371,27 @@ mod tests {
         );
         assert_eq!(output.data["truncated"], true);
         tokio::fs::remove_dir_all(workspace).await.unwrap();
+    }
+
+    #[test]
+    fn search_counts_bytes_consumed_before_invalid_utf8() {
+        let workspace = std::env::temp_dir().join(format!("gsv-search-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&workspace).unwrap();
+        let path = workspace.join("invalid.txt");
+        let contents = b"valid line\ninvalid \xff line\n";
+        fs::write(&path, contents).unwrap();
+
+        let result = search_text_file(
+            &path,
+            "valid",
+            &CancellationToken::new(),
+            MAX_SEARCH_FILE_BYTES,
+            MAX_MATCHES,
+        )
+        .unwrap();
+
+        assert!(result.matches.is_empty());
+        assert_eq!(result.bytes_read, contents.len() as u64);
+        fs::remove_dir_all(workspace).unwrap();
     }
 }

--- a/host/apps/machine/src/tools/search.rs
+++ b/host/apps/machine/src/tools/search.rs
@@ -4,10 +4,15 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::fs;
-use std::io::Read;
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
+
+const MAX_MATCHES: usize = 100;
+const MAX_SEARCH_FILES: usize = 25_000;
+const MAX_SEARCH_FILE_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_SEARCH_TOTAL_BYTES: u64 = 128 * 1024 * 1024;
 
 pub struct SearchTool {
     workspace: PathBuf,
@@ -68,75 +73,162 @@ impl SearchTool {
             .and_then(|inc| glob::Pattern::new(inc).ok());
 
         let mut matches: Vec<SearchMatch> = Vec::new();
+        let mut scanned_bytes = 0_u64;
+        let mut truncated = false;
 
-        for entry in WalkDir::new(&base_path)
-            .follow_links(true)
+        for (scanned_files, entry) in WalkDir::new(&base_path)
+            .follow_links(false)
             .into_iter()
             .filter_map(|e| e.ok())
             .filter(|e| e.file_type().is_file())
+            .filter(|entry| {
+                let Some(pattern) = &include_glob else {
+                    return true;
+                };
+                let file_name = entry
+                    .path()
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("");
+                pattern.matches(file_name)
+            })
+            .enumerate()
         {
             if cancellation.is_cancelled() {
                 return Err("Search cancelled".to_string());
             }
+            if scanned_files >= MAX_SEARCH_FILES {
+                truncated = true;
+                break;
+            }
             let path = entry.path();
 
-            if let Some(ref glob_pattern) = include_glob {
-                let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                if !glob_pattern.matches(file_name) {
-                    continue;
-                }
+            let remaining_bytes = MAX_SEARCH_TOTAL_BYTES.saturating_sub(scanned_bytes);
+            if remaining_bytes == 0 {
+                truncated = true;
+                break;
             }
-
-            if let Some(content) = read_text(path, cancellation)? {
-                for (line_num, line) in content.lines().enumerate() {
-                    if cancellation.is_cancelled() {
-                        return Err("Search cancelled".to_string());
-                    }
-                    if line.contains(&query) {
-                        matches.push(SearchMatch {
-                            path: path.display().to_string(),
-                            line: line_num + 1,
-                            content: line.chars().take(200).collect(),
-                        });
-
-                        if matches.len() >= 100 {
-                            return Ok(ToolOutput::json(json!({
-                                "ok": true,
-                                "matches": matches,
-                                "count": matches.len(),
-                                "truncated": true
-                            })));
-                        }
-                    }
-                }
+            let result = search_text_file(
+                path,
+                &query,
+                cancellation,
+                remaining_bytes.min(MAX_SEARCH_FILE_BYTES),
+                MAX_MATCHES - matches.len(),
+            )?;
+            scanned_bytes = scanned_bytes.saturating_add(result.bytes_read);
+            truncated |= result.truncated;
+            matches.extend(result.matches);
+            if matches.len() >= MAX_MATCHES {
+                truncated = true;
+                break;
             }
         }
 
-        Ok(ToolOutput::json(json!({
-            "ok": true,
-            "matches": matches,
-            "count": matches.len()
-        })))
+        Ok(search_output(matches, truncated))
     }
 }
 
-fn read_text(path: &Path, cancellation: &CancellationToken) -> Result<Option<String>, String> {
-    let mut file = match fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => return Ok(None),
+struct FileSearchResult {
+    matches: Vec<SearchMatch>,
+    bytes_read: u64,
+    truncated: bool,
+}
+
+fn search_text_file(
+    path: &Path,
+    query: &str,
+    cancellation: &CancellationToken,
+    max_bytes: u64,
+    max_matches: usize,
+) -> Result<FileSearchResult, String> {
+    let empty = |bytes_read, truncated| FileSearchResult {
+        matches: Vec::new(),
+        bytes_read,
+        truncated,
     };
-    let mut bytes = Vec::new();
-    let mut chunk = [0; 64 * 1024];
+
+    let file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Ok(empty(0, false)),
+    };
+    if file
+        .metadata()
+        .map(|metadata| metadata.len() > max_bytes)
+        .unwrap_or(false)
+    {
+        return Ok(empty(0, true));
+    }
+
+    let mut reader = BufReader::new(file.take(max_bytes.saturating_add(1)));
+    let mut line = String::new();
+    let mut line_number = 0_usize;
+    let mut bytes_read = 0_u64;
+    let mut matches = Vec::new();
     loop {
         if cancellation.is_cancelled() {
             return Err("Search cancelled".to_string());
         }
-        match file.read(&mut chunk) {
-            Ok(0) => return Ok(String::from_utf8(bytes).ok()),
-            Ok(read) => bytes.extend_from_slice(&chunk[..read]),
-            Err(_) => return Ok(None),
+
+        line.clear();
+        let read = match reader.read_line(&mut line) {
+            Ok(read) => read,
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidData => {
+                return Ok(empty(bytes_read, false));
+            }
+            Err(_) => return Ok(empty(bytes_read, false)),
+        };
+        if read == 0 {
+            return Ok(FileSearchResult {
+                matches,
+                bytes_read,
+                truncated: false,
+            });
+        }
+        bytes_read = bytes_read.saturating_add(read as u64);
+        if bytes_read > max_bytes {
+            return Ok(FileSearchResult {
+                matches,
+                bytes_read: max_bytes,
+                truncated: true,
+            });
+        }
+        if line.as_bytes().contains(&0) {
+            return Ok(empty(bytes_read, false));
+        }
+
+        line_number += 1;
+        if line.contains(query) {
+            matches.push(SearchMatch {
+                path: path.display().to_string(),
+                line: line_number,
+                content: line
+                    .trim_end_matches(['\r', '\n'])
+                    .chars()
+                    .take(200)
+                    .collect(),
+            });
+            if matches.len() >= max_matches {
+                return Ok(FileSearchResult {
+                    matches,
+                    bytes_read,
+                    truncated: true,
+                });
+            }
         }
     }
+}
+
+fn search_output(matches: Vec<SearchMatch>, truncated: bool) -> ToolOutput {
+    let count = matches.len();
+    let mut output = json!({
+        "ok": true,
+        "matches": matches,
+        "count": count,
+    });
+    if truncated {
+        output["truncated"] = json!(true);
+    }
+    ToolOutput::json(output)
 }
 
 #[derive(Deserialize)]
@@ -222,6 +314,33 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(error, "Search cancelled");
+        tokio::fs::remove_dir_all(workspace).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn search_skips_binary_and_oversized_files() {
+        let workspace = std::env::temp_dir().join(format!("gsv-search-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::write(workspace.join("text.txt"), "needle\n")
+            .await
+            .unwrap();
+        tokio::fs::write(workspace.join("binary.bin"), b"needle\0binary")
+            .await
+            .unwrap();
+        let oversized = fs::File::create(workspace.join("oversized.txt")).unwrap();
+        oversized.set_len(MAX_SEARCH_FILE_BYTES + 1).unwrap();
+
+        let output = SearchTool::new(workspace.clone())
+            .execute(json!({ "query": "needle" }))
+            .await
+            .unwrap();
+
+        assert_eq!(output.data["count"], 1);
+        assert_eq!(
+            output.data["matches"][0]["path"],
+            workspace.join("text.txt").display().to_string()
+        );
+        assert_eq!(output.data["truncated"], true);
         tokio::fs::remove_dir_all(workspace).await.unwrap();
     }
 }

--- a/host/apps/machine/src/tools/shell.rs
+++ b/host/apps/machine/src/tools/shell.rs
@@ -15,7 +15,7 @@ use tokio::process::{ChildStdin, Command};
 use tokio::sync::{broadcast, Mutex as AsyncMutex};
 use uuid::Uuid;
 
-const DEFAULT_TIMEOUT_MS: u64 = 5 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS: u64 = 2 * 60 * 1000;
 const DEFAULT_YIELD_MS: u64 = 5_000;
 const MIN_YIELD_MS: u64 = 250;
 const MAX_YIELD_MS: u64 = 30_000;
@@ -770,6 +770,11 @@ impl Tool for ShellTool {
 #[cfg(test)]
 mod result_tests {
     use super::*;
+
+    #[test]
+    fn default_runtime_matches_shell_contract() {
+        assert_eq!(DEFAULT_TIMEOUT_MS, 120_000);
+    }
 
     fn snapshot(status: &str) -> ProcessSnapshot {
         ProcessSnapshot {

--- a/host/apps/machine/src/tools/shell.rs
+++ b/host/apps/machine/src/tools/shell.rs
@@ -32,8 +32,6 @@ struct ProcessHandle {
 #[derive(Clone)]
 struct ProcessSnapshot {
     session_id: String,
-    cwd: String,
-    pid: Option<u32>,
     started_at: i64,
     ended_at: Option<i64>,
     status: String,
@@ -49,7 +47,6 @@ struct ProcessSnapshot {
 
 struct ProcessState {
     session_id: String,
-    cwd: String,
     pid: Option<u32>,
     started_at: i64,
     ended_at: Option<i64>,
@@ -171,8 +168,6 @@ fn append_output(state: &mut ProcessState, chunk: &str, stream: OutputStream) {
 fn snapshot_from_state(state: &ProcessState) -> ProcessSnapshot {
     ProcessSnapshot {
         session_id: state.session_id.clone(),
-        cwd: state.cwd.clone(),
-        pid: state.pid,
         started_at: state.started_at,
         ended_at: state.ended_at,
         status: state.status.clone(),
@@ -191,8 +186,6 @@ fn snapshot_and_drain_from_state(state: &mut ProcessState) -> ProcessSnapshot {
     let output = std::mem::take(&mut state.pending_output);
     ProcessSnapshot {
         session_id: state.session_id.clone(),
-        cwd: state.cwd.clone(),
-        pid: state.pid,
         started_at: state.started_at,
         ended_at: state.ended_at,
         status: state.status.clone(),
@@ -217,42 +210,46 @@ fn running_result(snapshot: &ProcessSnapshot) -> Value {
         "status": "running",
         "sessionId": snapshot.session_id,
         "output": snapshot.output,
-        "pid": snapshot.pid,
-        "startedAt": snapshot.started_at,
-        "tail": snapshot.tail,
-        "cwd": snapshot.cwd,
         "truncated": snapshot.truncated,
     })
 }
 
 fn completed_result(snapshot: &ProcessSnapshot) -> Value {
-    json!({
-        "ok": true,
-      "pid": snapshot.pid.unwrap_or_default(),
+    if snapshot.status == "completed" {
+        return json!({
+            "status": "completed",
+            "output": snapshot.output,
+            "exitCode": snapshot.exit_code.unwrap_or_default(),
+            "sessionId": snapshot.session_id,
+            "truncated": snapshot.truncated,
+            "stdout": snapshot.stdout,
+            "stderr": snapshot.stderr,
+        });
+    }
+
+    let error = if snapshot.timed_out {
+        "Command timed out".to_string()
+    } else if let Some(signal) = &snapshot.signal {
+        format!("Command failed: {}", signal)
+    } else {
+        format!(
+            "Command exited with code {}",
+            snapshot.exit_code.unwrap_or(-1)
+        )
+    };
+    let mut result = json!({
+        "status": "failed",
+        "output": snapshot.output,
+        "error": error,
+        "sessionId": snapshot.session_id,
+        "truncated": snapshot.truncated,
         "stdout": snapshot.stdout,
         "stderr": snapshot.stderr,
-        "status": if snapshot.status == "completed" { "completed" } else { "failed" },
-        "sessionId": snapshot.session_id,
-        "exitCode": snapshot.exit_code,
-        "error": if snapshot.status == "completed" {
-            Value::Null
-        } else if snapshot.timed_out {
-            json!("Command timed out")
-        } else if let Some(signal) = &snapshot.signal {
-            json!(format!("Command failed: {}", signal))
-        } else {
-            json!(format!("Command exited with code {}", snapshot.exit_code.unwrap_or(-1)))
-        },
-        "signal": snapshot.signal,
-        "timedOut": snapshot.timed_out,
-      "startedAt": snapshot.started_at,
-      "endedAt": snapshot.ended_at,
-      "durationMs": snapshot.ended_at.map(|ended| ended.saturating_sub(snapshot.started_at)),
-      "output": snapshot.output,
-      "tail": snapshot.tail,
-      "truncated": snapshot.truncated,
-      "cwd": snapshot.cwd,
-    })
+    });
+    if let Some(exit_code) = snapshot.exit_code {
+        result["exitCode"] = json!(exit_code);
+    }
+    result
 }
 
 fn normalize_signal_name(_status: &std::process::ExitStatus) -> Option<String> {
@@ -499,7 +496,6 @@ async fn launch_managed_process(
 
     let state = Arc::new(AsyncMutex::new(ProcessState {
         session_id: session_id.clone(),
-        cwd: cwd.display().to_string(),
         pid,
         started_at,
         ended_at: None,
@@ -771,6 +767,71 @@ impl Tool for ShellTool {
     }
 }
 
+#[cfg(test)]
+mod result_tests {
+    use super::*;
+
+    fn snapshot(status: &str) -> ProcessSnapshot {
+        ProcessSnapshot {
+            session_id: "session-1".to_string(),
+            started_at: 100,
+            ended_at: Some(125),
+            status: status.to_string(),
+            exit_code: Some(if status == "completed" { 0 } else { 7 }),
+            signal: None,
+            timed_out: false,
+            stdout: "stdout".to_string(),
+            stderr: "stderr".to_string(),
+            output: "stdoutstderr".to_string(),
+            tail: "tail".to_string(),
+            truncated: false,
+        }
+    }
+
+    #[test]
+    fn shell_results_use_only_public_protocol_fields() {
+        let mut running = snapshot("running");
+        running.ended_at = None;
+        running.exit_code = None;
+        assert_eq!(
+            running_result(&running),
+            json!({
+                "status": "running",
+                "sessionId": "session-1",
+                "output": "stdoutstderr",
+                "truncated": false,
+            })
+        );
+
+        assert_eq!(
+            completed_result(&snapshot("completed")),
+            json!({
+                "status": "completed",
+                "output": "stdoutstderr",
+                "exitCode": 0,
+                "sessionId": "session-1",
+                "truncated": false,
+                "stdout": "stdout",
+                "stderr": "stderr",
+            })
+        );
+
+        assert_eq!(
+            completed_result(&snapshot("failed")),
+            json!({
+                "status": "failed",
+                "output": "stdoutstderr",
+                "error": "Command exited with code 7",
+                "exitCode": 7,
+                "sessionId": "session-1",
+                "truncated": false,
+                "stdout": "stdout",
+                "stderr": "stderr",
+            })
+        );
+    }
+}
+
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
@@ -907,7 +968,7 @@ mod tests {
             .unwrap();
         let session_id = started.data["sessionId"].as_str().unwrap().to_string();
         let handle = get_process(&session_id).await.unwrap();
-        let pid = started.data["pid"].as_u64().unwrap() as u32;
+        let pid = handle.state.lock().await.pid.unwrap();
 
         let poll = tokio::spawn(async move {
             ShellTool::new(std::env::temp_dir())

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
       "version": "0.4.1",
       "dependencies": {
         "@humansandmachines/gsv": "file:../packages/gsv",
-        "just-bash": "^2.12.6"
+        "just-bash": "^3.4.2"
       },
       "devDependencies": {
         "@types/chrome": "^0.1.34",
@@ -112,7 +112,7 @@
         "@earendil-works/pi-ai": "^0.83.0",
         "@humansandmachines/gsv": "file:../packages/gsv",
         "agents": "^0.16.0",
-        "just-bash": "^2.12.6",
+        "just-bash": "^3.4.2",
         "marked": "^16.4.2",
         "zod": "4.3.6"
       },
@@ -5526,7 +5526,9 @@
       "license": "MIT"
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
       "funding": [
         {
           "type": "github",
@@ -7629,66 +7631,6 @@
         }
       }
     },
-    "node_modules/agents/node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/agents/node_modules/fast-xml-parser": {
-      "version": "5.9.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.2.0",
-        "fast-xml-builder": "^1.2.0",
-        "is-unsafe": "^1.0.1",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.4.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/agents/node_modules/just-bash": {
-      "version": "3.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "diff": "^8.0.2",
-        "fast-xml-parser": "^5.7.3",
-        "file-type": "^21.2.0",
-        "ini": "^6.0.0",
-        "minimatch": "^10.1.1",
-        "modern-tar": "^0.7.3",
-        "papaparse": "^5.5.3",
-        "quickjs-emscripten": "^0.32.0",
-        "re2js": "^1.2.1",
-        "seek-bzip": "^2.0.0",
-        "smol-toml": "^1.6.0",
-        "sprintf-js": "^1.1.3",
-        "sql.js": "^1.13.0",
-        "turndown": "^7.2.2",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "just-bash": "dist/bin/just-bash.js",
-        "just-bash-shell": "dist/bin/shell/shell.js"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/zstd": "^7.0.0",
-        "node-liblzma": "^2.0.3"
-      }
-    },
     "node_modules/ai": {
       "version": "6.0.168",
       "license": "Apache-2.0",
@@ -8265,7 +8207,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -8327,6 +8271,8 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8505,13 +8451,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -9523,7 +9471,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+      "integrity": "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==",
       "funding": [
         {
           "type": "github",
@@ -9532,13 +9482,30 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fast-xml-parser/node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fastq": {
@@ -10240,7 +10207,9 @@
       "license": "MIT"
     },
     "node_modules/is-unsafe": {
-      "version": "1.0.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
       "funding": [
         {
           "type": "github",
@@ -10374,52 +10343,47 @@
       }
     },
     "node_modules/just-bash": {
-      "version": "2.14.5",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/just-bash/-/just-bash-3.4.2.tgz",
+      "integrity": "sha512-T0Vpy7YRgCjxJdqG3tkxn0ZnIDLJvVwb8hH4L+6NVdp+Te27jQxjxnszW9ODjEKbWxWujj83rP5S0GQxCSufgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "diff": "^8.0.2",
-        "fast-xml-parser": "^5.7.3",
-        "file-type": "^21.2.0",
+        "diff": "^8.0.4",
+        "fast-xml-parser": "^5.10.1",
+        "file-type": "^21.3.4",
         "ini": "^6.0.0",
-        "minimatch": "^10.1.1",
-        "modern-tar": "^0.7.3",
-        "papaparse": "^5.5.3",
+        "minimatch": "^10.2.6",
+        "modern-tar": "^0.7.7",
+        "papaparse": "^5.6.0",
         "quickjs-emscripten": "^0.32.0",
-        "re2js": "^1.2.1",
+        "re2js": "^1.3.3",
         "seek-bzip": "^2.0.0",
-        "smol-toml": "^1.6.0",
+        "smol-toml": "^1.8.0",
         "sprintf-js": "^1.1.3",
-        "sql.js": "^1.13.0",
-        "turndown": "^7.2.2",
-        "yaml": "^2.8.2"
+        "sql.js": "^1.14.1",
+        "turndown": "^7.2.4",
+        "undici": "^7.29.0",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "just-bash": "dist/bin/just-bash.js",
         "just-bash-shell": "dist/bin/shell/shell.js"
       },
+      "engines": {
+        "node": ">=20.18.1"
+      },
       "optionalDependencies": {
         "@mongodb-js/zstd": "^7.0.0",
-        "node-liblzma": "^2.0.3"
+        "node-liblzma": "^2.2.0"
       }
     },
-    "node_modules/just-bash/node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
+    "node_modules/just-bash/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/jwa": {
@@ -10995,10 +10959,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -11029,7 +10995,9 @@
       "optional": true
     },
     "node_modules/modern-tar": {
-      "version": "0.7.6",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -11423,7 +11391,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/papaparse": {
-      "version": "5.5.3",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.7.0.tgz",
+      "integrity": "sha512-qBGxg/7Q3Kl9Wfhrz2Z74UnvnHTXLNG6jmKJFeBvP2+y4lV7So+7SR62+Zd47JvdrCkX+nDcnr0ObPzek/+6RA==",
       "license": "MIT"
     },
     "node_modules/parseurl": {
@@ -11479,7 +11449,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -13208,7 +13180,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -13370,7 +13344,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
       "funding": [
         {
           "type": "github",
@@ -13379,7 +13355,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/strtok3": {

--- a/packages/gsv/src/client.ts
+++ b/packages/gsv/src/client.ts
@@ -7,7 +7,6 @@ import type {
   ResultOf,
   SyscallName,
 } from "./protocol";
-import { DEFAULT_SHELL_EXEC_TIMEOUT_MS } from "./protocol/syscalls/shell";
 import type { JsonValue } from "./protocol/json";
 import { jsonValueSchema } from "./protocol/json";
 import {
@@ -73,7 +72,7 @@ export type GsvFrame = GsvRequestFrame | GsvResponseFrame | GsvSignalFrame;
 type PendingRequest = {
   resolve: (value: GsvResponse<JsonValue>) => void;
   reject: (error: Error) => void;
-  timeoutId: TimerHandle;
+  timeoutId: TimerHandle | null;
   call: string;
   bodyAbort?: AbortController;
   abortSignal?: AbortSignal;
@@ -973,10 +972,12 @@ export class GSVClient {
         void outgoing?.cancel(error);
         pending.reject(error);
       };
-      const timeoutId = globalThis.setTimeout(() => {
-        const error = new Error(`Request timed out after ${timeoutMs}ms: ${call}`);
-        cancelPending(error);
-      }, timeoutMs);
+      const timeoutId = timeoutMs === null
+        ? null
+        : globalThis.setTimeout(() => {
+          const error = new Error(`Request timed out after ${timeoutMs}ms: ${call}`);
+          cancelPending(error);
+        }, timeoutMs);
 
       const pending: PendingRequest = {
         resolve,
@@ -1038,17 +1039,21 @@ export class GSVClient {
 
     return new Promise<T>((resolve, reject) => {
       let settled = false;
-      const timeoutId = globalThis.setTimeout(() => {
-        cleanup();
-        reject(new Error(`Request timed out after ${timeoutMs}ms: ${call}`));
-      }, timeoutMs);
+      const timeoutId = timeoutMs === null
+        ? null
+        : globalThis.setTimeout(() => {
+          cleanup();
+          reject(new Error(`Request timed out after ${timeoutMs}ms: ${call}`));
+        }, timeoutMs);
 
       const cleanup = (): void => {
         if (settled) {
           return;
         }
         settled = true;
-        globalThis.clearTimeout(timeoutId);
+        if (timeoutId !== null) {
+          globalThis.clearTimeout(timeoutId);
+        }
         socket.removeEventListener("message", onMessage);
         socket.removeEventListener("close", onClose);
         socket.removeEventListener("error", onError);
@@ -1236,7 +1241,7 @@ export class GSVClient {
     socket.send(JSON.stringify(frame));
   }
 
-  private requestTimeoutMs(call: string, args: JsonValue): number {
+  private requestTimeoutMs(call: string, args: JsonValue): number | null {
     const configuredTimeout = this.requestTimeoutsMs[call];
     if (configuredTimeout !== undefined) {
       return configuredTimeout;
@@ -1251,10 +1256,9 @@ export class GSVClient {
         return pollingWait + SHELL_EXEC_RESPONSE_GRACE_MS;
       }
       const parsed = shellExecTimeoutArgumentsSchema.safeParse(args);
-      const executionTimeout = parsed.success
-        ? parsed.data.timeout ?? DEFAULT_SHELL_EXEC_TIMEOUT_MS
-        : DEFAULT_SHELL_EXEC_TIMEOUT_MS;
-      return executionTimeout + SHELL_EXEC_RESPONSE_GRACE_MS;
+      return parsed.success && parsed.data.timeout !== undefined
+        ? parsed.data.timeout + SHELL_EXEC_RESPONSE_GRACE_MS
+        : null;
     }
     return this.defaultRequestTimeoutMs;
   }
@@ -1265,7 +1269,9 @@ export class GSVClient {
       return null;
     }
     this.pending.delete(id);
-    globalThis.clearTimeout(pending.timeoutId);
+    if (pending.timeoutId !== null) {
+      globalThis.clearTimeout(pending.timeoutId);
+    }
     if (pending.abortSignal && pending.abortListener) {
       pending.abortSignal.removeEventListener("abort", pending.abortListener);
     }

--- a/packages/gsv/src/client.ts
+++ b/packages/gsv/src/client.ts
@@ -232,6 +232,12 @@ const binaryFrameDescriptorSchema = z.strictObject({
 const shellExecTimeoutArgumentsSchema = z.looseObject({
   timeout: z.optional(z.number().check(z.positive())),
 });
+const shellExecSessionArgumentsSchema = z.looseObject({
+  sessionId: z.string(),
+});
+const shellExecPollingArgumentsSchema = z.looseObject({
+  yieldMs: z.optional(z.number().check(z.positive())),
+});
 const gsvErrorSchema = z.strictObject({
   code: z.number(),
   message: z.string(),
@@ -1236,6 +1242,14 @@ export class GSVClient {
       return configuredTimeout;
     }
     if (call === "shell.exec") {
+      const session = shellExecSessionArgumentsSchema.safeParse(args);
+      if (session.success && session.data.sessionId.trim()) {
+        const polling = shellExecPollingArgumentsSchema.safeParse(args);
+        const pollingWait = polling.success
+          ? polling.data.yieldMs ?? this.defaultRequestTimeoutMs
+          : this.defaultRequestTimeoutMs;
+        return pollingWait + SHELL_EXEC_RESPONSE_GRACE_MS;
+      }
       const parsed = shellExecTimeoutArgumentsSchema.safeParse(args);
       const executionTimeout = parsed.success
         ? parsed.data.timeout ?? DEFAULT_SHELL_EXEC_TIMEOUT_MS

--- a/packages/gsv/src/client.ts
+++ b/packages/gsv/src/client.ts
@@ -229,6 +229,9 @@ const binaryFrameDescriptorSchema = z.strictObject({
   streamId: z.int().check(z.positive()),
   length: z.optional(z.int().check(z.nonnegative())),
 });
+const shellExecTimeoutArgumentsSchema = z.looseObject({
+  timeout: z.optional(z.number().check(z.positive())),
+});
 const gsvErrorSchema = z.strictObject({
   code: z.number(),
   message: z.string(),
@@ -944,7 +947,7 @@ export class GSVClient {
       args: wireArgs,
     };
     if (outgoing) frame.body = outgoing.descriptor;
-    const timeoutMs = this.requestTimeoutMs(call, args);
+    const timeoutMs = this.requestTimeoutMs(call, wireArgs);
     const bodyAbort = body ? new AbortController() : undefined;
 
     return new Promise((resolve, reject) => {
@@ -1018,13 +1021,14 @@ export class GSVClient {
     args: GsvOutgoingArguments,
   ): Promise<T> {
     const id = makeId();
+    const wireArgs = serializeOutgoingArguments(args);
     const frame: GsvRequestFrame = {
       type: "req",
       id,
       call,
-      args: serializeOutgoingArguments(args),
+      args: wireArgs,
     };
-    const timeoutMs = this.requestTimeoutMs(call, args);
+    const timeoutMs = this.requestTimeoutMs(call, wireArgs);
 
     return new Promise<T>((resolve, reject) => {
       let settled = false;
@@ -1226,17 +1230,15 @@ export class GSVClient {
     socket.send(JSON.stringify(frame));
   }
 
-  private requestTimeoutMs(call: string, args: GsvOutgoingArguments): number {
+  private requestTimeoutMs(call: string, args: JsonValue): number {
     const configuredTimeout = this.requestTimeoutsMs[call];
     if (configuredTimeout !== undefined) {
       return configuredTimeout;
     }
     if (call === "shell.exec") {
-      const requestedTimeout = (args as GsvRequestArguments).timeout;
-      const executionTimeout = typeof requestedTimeout === "number"
-        && Number.isFinite(requestedTimeout)
-        && requestedTimeout > 0
-        ? requestedTimeout
+      const parsed = shellExecTimeoutArgumentsSchema.safeParse(args);
+      const executionTimeout = parsed.success
+        ? parsed.data.timeout ?? DEFAULT_SHELL_EXEC_TIMEOUT_MS
         : DEFAULT_SHELL_EXEC_TIMEOUT_MS;
       return executionTimeout + SHELL_EXEC_RESPONSE_GRACE_MS;
     }

--- a/packages/gsv/src/client.ts
+++ b/packages/gsv/src/client.ts
@@ -7,6 +7,7 @@ import type {
   ResultOf,
   SyscallName,
 } from "./protocol";
+import { DEFAULT_SHELL_EXEC_TIMEOUT_MS } from "./protocol/syscalls/shell";
 import type { JsonValue } from "./protocol/json";
 import { jsonValueSchema } from "./protocol/json";
 import {
@@ -296,6 +297,7 @@ const PROTOCOL_VERSION = 3;
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
 const LONG_RUNNING_REQUEST_TIMEOUT_MS = 120_000;
 const AI_TEXT_GENERATION_REQUEST_TIMEOUT_MS = 180_000;
+const SHELL_EXEC_RESPONSE_GRACE_MS = 10_000;
 const DEFAULT_ENDPOINT_KEEPALIVE_MS = 240_000;
 const DEFAULT_ENDPOINT_ACKNOWLEDGEMENT_TIMEOUT_MS = 10_000;
 const WEBSOCKET_CONNECTING = 0;
@@ -942,7 +944,7 @@ export class GSVClient {
       args: wireArgs,
     };
     if (outgoing) frame.body = outgoing.descriptor;
-    const timeoutMs = this.requestTimeoutMs(call);
+    const timeoutMs = this.requestTimeoutMs(call, args);
     const bodyAbort = body ? new AbortController() : undefined;
 
     return new Promise((resolve, reject) => {
@@ -1022,7 +1024,7 @@ export class GSVClient {
       call,
       args: serializeOutgoingArguments(args),
     };
-    const timeoutMs = this.requestTimeoutMs(call);
+    const timeoutMs = this.requestTimeoutMs(call, args);
 
     return new Promise<T>((resolve, reject) => {
       let settled = false;
@@ -1224,8 +1226,21 @@ export class GSVClient {
     socket.send(JSON.stringify(frame));
   }
 
-  private requestTimeoutMs(call: string): number {
-    return this.requestTimeoutsMs[call] ?? this.defaultRequestTimeoutMs;
+  private requestTimeoutMs(call: string, args: GsvOutgoingArguments): number {
+    const configuredTimeout = this.requestTimeoutsMs[call];
+    if (configuredTimeout !== undefined) {
+      return configuredTimeout;
+    }
+    if (call === "shell.exec") {
+      const requestedTimeout = (args as GsvRequestArguments).timeout;
+      const executionTimeout = typeof requestedTimeout === "number"
+        && Number.isFinite(requestedTimeout)
+        && requestedTimeout > 0
+        ? requestedTimeout
+        : DEFAULT_SHELL_EXEC_TIMEOUT_MS;
+      return executionTimeout + SHELL_EXEC_RESPONSE_GRACE_MS;
+    }
+    return this.defaultRequestTimeoutMs;
   }
 
   private takePending(id: string): PendingRequest | null {

--- a/packages/gsv/src/protocol/index.ts
+++ b/packages/gsv/src/protocol/index.ts
@@ -1,6 +1,7 @@
 export type * from "./syscalls/system";
 export type * from "./syscalls/fs";
 export type * from "./syscalls/shell";
+export { DEFAULT_SHELL_EXEC_TIMEOUT_MS } from "./syscalls/shell";
 export type * from "./syscalls/net";
 export type * from "./syscalls/codemode";
 export type * from "./syscalls/repositories";

--- a/packages/gsv/src/protocol/syscalls/shell.ts
+++ b/packages/gsv/src/protocol/syscalls/shell.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_SHELL_EXEC_TIMEOUT_MS = 120_000;
+
 export type ShellExecArgs = {
   input: string;
   cwd?: string;

--- a/packages/gsv/test/client-body.test.mjs
+++ b/packages/gsv/test/client-body.test.mjs
@@ -788,6 +788,46 @@ test("cancels an outbound request before rejecting its timeout", async () => {
   client.close();
 });
 
+test("lets shell execution finish before its request transport times out", async () => {
+  const { client, socket } = await connectedClient();
+  const originalSetTimeout = globalThis.setTimeout;
+  const scheduledDelays = [];
+  globalThis.setTimeout = (callback, delay, ...args) => {
+    scheduledDelays.push(delay);
+    return originalSetTimeout(callback, delay, ...args);
+  };
+
+  try {
+    const defaultTimeout = client.request("shell.exec", { input: "sleep 1" });
+    const defaultRequest = JSON.parse(socket.sent.at(-1));
+    assert.equal(scheduledDelays.at(-1), 130_000);
+    socket.receive(JSON.stringify({
+      type: "res",
+      id: defaultRequest.id,
+      ok: true,
+      data: { status: "completed", output: "", exitCode: 0 },
+    }));
+    await defaultTimeout;
+
+    const explicitTimeout = client.request("shell.exec", {
+      input: "sleep 1",
+      timeout: 300_000,
+    });
+    const explicitRequest = JSON.parse(socket.sent.at(-1));
+    assert.equal(scheduledDelays.at(-1), 310_000);
+    socket.receive(JSON.stringify({
+      type: "res",
+      id: explicitRequest.id,
+      ok: true,
+      data: { status: "completed", output: "", exitCode: 0 },
+    }));
+    await explicitTimeout;
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    client.close();
+  }
+});
+
 test("keeps a caller-owned mail delivery id after a lost response", async () => {
   const client = new GSVClient({
     WebSocket: FakeWebSocket,

--- a/packages/gsv/test/client-body.test.mjs
+++ b/packages/gsv/test/client-body.test.mjs
@@ -788,7 +788,7 @@ test("cancels an outbound request before rejecting its timeout", async () => {
   client.close();
 });
 
-test("lets shell execution finish before its request transport times out", async () => {
+test("leaves omitted shell deadlines to the server and budgets explicit timeouts", async () => {
   const { client, socket } = await connectedClient();
   const originalSetTimeout = globalThis.setTimeout;
   const scheduledDelays = [];
@@ -798,23 +798,23 @@ test("lets shell execution finish before its request transport times out", async
   };
 
   try {
-    const defaultTimeout = client.request("shell.exec", { input: "sleep 1" });
-    const defaultRequest = JSON.parse(socket.sent.at(-1));
-    assert.equal(scheduledDelays.at(-1), 130_000);
+    const serverDeadline = client.request("shell.exec", { input: "sleep 1" });
+    const serverDeadlineRequest = JSON.parse(socket.sent.at(-1));
+    assert.deepEqual(scheduledDelays, []);
     socket.receive(JSON.stringify({
       type: "res",
-      id: defaultRequest.id,
+      id: serverDeadlineRequest.id,
       ok: true,
       data: { status: "completed", output: "", exitCode: 0 },
     }));
-    await defaultTimeout;
+    await serverDeadline;
 
     const explicitTimeout = client.request("shell.exec", {
       input: "sleep 1",
       timeout: 300_000,
     });
     const explicitRequest = JSON.parse(socket.sent.at(-1));
-    assert.equal(scheduledDelays.at(-1), 310_000);
+    assert.deepEqual(scheduledDelays, [310_000]);
     socket.receive(JSON.stringify({
       type: "res",
       id: explicitRequest.id,

--- a/packages/gsv/test/client-body.test.mjs
+++ b/packages/gsv/test/client-body.test.mjs
@@ -828,6 +828,37 @@ test("lets shell execution finish before its request transport times out", async
   }
 });
 
+test("uses the polling wait budget for shell continuation transport timeouts", async () => {
+  const { client, socket } = await connectedClient();
+  const originalSetTimeout = globalThis.setTimeout;
+  const scheduledDelays = [];
+  globalThis.setTimeout = (callback, delay, ...args) => {
+    scheduledDelays.push(delay);
+    return originalSetTimeout(callback, delay, ...args);
+  };
+
+  try {
+    const continuation = client.request("shell.exec", {
+      input: "",
+      sessionId: "session-1",
+      timeout: 1_000,
+      yieldMs: 30_000,
+    });
+    const request = JSON.parse(socket.sent.at(-1));
+    assert.equal(scheduledDelays.at(-1), 40_000);
+    socket.receive(JSON.stringify({
+      type: "res",
+      id: request.id,
+      ok: true,
+      data: { status: "running", output: "", sessionId: "session-1" },
+    }));
+    await continuation;
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    client.close();
+  }
+});
+
 test("keeps a caller-owned mail delivery id after a lost response", async () => {
   const client = new GSVClient({
     WebSocket: FakeWebSocket,


### PR DESCRIPTION
## Summary

- make machine shell responses conform exactly to the public shell.exec protocol
- release the browser command queue when an active command ignores cancellation
- bound machine file searches by file count, per-file bytes, total bytes, and result count
- skip symlinks, binary files, and oversized files during machine searches

## Validation

- machine: 56 tests passed; cargo fmt and Clippy passed
- extension: 35 tests passed; typecheck and production build passed
- gateway: TypeScript and focused wire-protocol tests passed
- SDK: typecheck/build and 68 tests passed
- rebuilt and restarted gsvd; daemon connected successfully
- browser extension was rebuilt and the fix was confirmed manually