### PR TITLE
publish vision helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,7 @@ jobs:
 
   # GPUI 0.2.2 supports Linux and macOS. Build Desktop and its isolated
   # transcription helper natively for both architectures on those systems.
+  # The gesture-vision helper uses the same native release matrix.
   build-desktop:
     needs: [resolve]
     env:
@@ -190,6 +191,7 @@ jobs:
             clang \
             cmake \
             libasound2-dev \
+            libclang-dev \
             libfontconfig1-dev \
             libssl-dev \
             libwayland-dev \
@@ -197,13 +199,14 @@ jobs:
             libx11-xcb-dev \
             libxkbcommon-dev \
             libxkbcommon-x11-dev \
+            linux-libc-dev \
             pkg-config
 
-      - name: Build Desktop and transcription helper
+      - name: Build Desktop and local helpers
         working-directory: host
         run: >-
           cargo build --locked --release --target ${{ matrix.target }}
-          --package desktop --package transcriber
+          --package desktop --package transcriber --package gestures
 
       - name: Stage Desktop
         shell: bash
@@ -212,8 +215,11 @@ jobs:
           mkdir -p release
           cp "host/target/${{ matrix.target }}/release/gsv-desktop" "release/gsv-desktop-${{ matrix.platform }}"
           cp "host/target/${{ matrix.target }}/release/gsv-transcribe" "release/gsv-transcribe-${{ matrix.platform }}"
+          cp "host/target/${{ matrix.target }}/release/gsv-vision" "release/gsv-vision-${{ matrix.platform }}"
           if [ "${{ matrix.platform }}" = "linux-x64" ]; then
             cp host/helpers/transcriber/THIRD_PARTY.md release/gsv-transcribe-THIRD_PARTY.md
+            cp host/helpers/gestures/models/LICENSE.apache-2.0 release/gsv-vision-LICENSE.apache-2.0
+            cp host/helpers/gestures/models/PROVENANCE.md release/gsv-vision-PROVENANCE.md
           fi
 
       - name: Upload Desktop
@@ -319,6 +325,7 @@ jobs:
           cp artifacts/gsv-host-tools-windows-x64/* release/
 
           # Desktop and isolated local transcription helper
+          # Gesture-vision helper and its model metadata
           cp artifacts/gsv-desktop-linux-x64/* release/
           cp artifacts/gsv-desktop-linux-arm64/* release/
           cp artifacts/gsv-desktop-darwin-x64/* release/
@@ -336,8 +343,11 @@ jobs:
           chmod +x release/gsv-linux-* release/gsvd-linux-* \
             release/gsv-darwin-* release/gsvd-darwin-* \
             release/gsv-desktop-* release/gsv-transcribe-linux-* \
-            release/gsv-transcribe-darwin-*
-          chmod -x release/gsv-transcribe-THIRD_PARTY.md
+            release/gsv-transcribe-darwin-* release/gsv-vision-linux-* \
+            release/gsv-vision-darwin-*
+          chmod -x release/gsv-transcribe-THIRD_PARTY.md \
+            release/gsv-vision-LICENSE.apache-2.0 \
+            release/gsv-vision-PROVENANCE.md
 
           # Include install script
           cp install.sh release/
@@ -412,17 +422,19 @@ jobs:
           ### Host applications
 
           The installer verifies every downloaded artifact, replaces \`gsv\`, \`gsvd\`,
-          Desktop, and the transcription helper as one versioned set, and migrates an
-          existing device service to execute \`gsvd --foreground\` directly. Linux and
-          macOS receive Desktop; Windows currently receives the CLI and daemon only.
+          Desktop, and both local helpers as one versioned set, and migrates an existing
+          device service to execute \`gsvd --foreground\` directly. Linux and macOS
+          receive Desktop, \`gsv-transcribe\`, and \`gsv-vision\`; the vision model
+          license and provenance are included as verified assets. Windows currently
+          receives the CLI and daemon only.
 
           ### Manual Installation
 
           Download the binary for your platform:
-          - **macOS (Apple Silicon)**: \`gsv-darwin-arm64\`, \`gsvd-darwin-arm64\`, \`gsv-desktop-darwin-arm64\`
-          - **macOS (Intel)**: \`gsv-darwin-x64\`, \`gsvd-darwin-x64\`, \`gsv-desktop-darwin-x64\`
-          - **Linux (x64)**: \`gsv-linux-x64\`, \`gsvd-linux-x64\`, \`gsv-desktop-linux-x64\`
-          - **Linux (ARM64)**: \`gsv-linux-arm64\`, \`gsvd-linux-arm64\`, \`gsv-desktop-linux-arm64\`
+          - **macOS (Apple Silicon)**: \`gsv-darwin-arm64\`, \`gsvd-darwin-arm64\`, \`gsv-desktop-darwin-arm64\`, \`gsv-transcribe-darwin-arm64\`, \`gsv-vision-darwin-arm64\`
+          - **macOS (Intel)**: \`gsv-darwin-x64\`, \`gsvd-darwin-x64\`, \`gsv-desktop-darwin-x64\`, \`gsv-transcribe-darwin-x64\`, \`gsv-vision-darwin-x64\`
+          - **Linux (x64)**: \`gsv-linux-x64\`, \`gsvd-linux-x64\`, \`gsv-desktop-linux-x64\`, \`gsv-transcribe-linux-x64\`, \`gsv-vision-linux-x64\`
+          - **Linux (ARM64)**: \`gsv-linux-arm64\`, \`gsvd-linux-arm64\`, \`gsv-desktop-linux-arm64\`, \`gsv-transcribe-linux-arm64\`, \`gsv-vision-linux-arm64\`
           - **Windows (x64)**: \`gsv-windows-x64.exe\`, \`gsvd-windows-x64.exe\`
 
           The macOS command-line Desktop builds are not yet code-signed or notarized.
@@ -487,6 +499,12 @@ jobs:
             release/gsv-transcribe-darwin-x64
             release/gsv-transcribe-darwin-arm64
             release/gsv-transcribe-THIRD_PARTY.md
+            release/gsv-vision-linux-x64
+            release/gsv-vision-linux-arm64
+            release/gsv-vision-darwin-x64
+            release/gsv-vision-darwin-arm64
+            release/gsv-vision-LICENSE.apache-2.0
+            release/gsv-vision-PROVENANCE.md
             release/gsv-cloudflare-*.tar.gz
             release/gsv-cloudflare-deployment-manifest.json
             release/cloudflare-checksums.txt

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ curl -fsSL https://install.gsv.space | bash
 
 The verified host installer ships matching versions of `gsv` and `gsvd` on
 Linux x64/ARM64, macOS Intel/Apple Silicon, and Windows x64. Linux and macOS
-also receive the native Desktop and its isolated local transcription helper;
-launch it with `gsv desktop`. See the
+also receive the native Desktop plus its isolated local transcription and
+gesture-vision helpers; launch it with `gsv desktop`. See the
 [host application install and upgrade guide](docs/how-to/install-host-apps.md)
 for platform details and service rollback behavior.
 

--- a/docs/architecture/rust-host-applications.md
+++ b/docs/architecture/rust-host-applications.md
@@ -131,13 +131,14 @@ masquerade as terminal transcription events. Its runtime is the Rust helper
 plus two checksum-pinned palm and hand-landmark TFLite models executed by tract;
 the command vocabulary is owned by Rust rather than the upstream canned gesture
 classifier. It has no Python, Java, Bazel, or native MediaPipe build/runtime
-dependency. The unsigned macOS development application includes `gsv-vision`,
-whose two checksum-verified TFLite models are embedded directly in the
-executable for offline, self-contained builds. It starts the helper in a
-disarmed state and provides visible Voice and Gestures affordances rather than
-depending on shell environment variables that Finder does not provide. Public
-distribution waits for Developer ID signing, notarization, and deliberate
-acceptance of the model redistribution policy.
+dependency. The raw Linux and macOS host distributions and the unsigned macOS
+development application include `gsv-vision`, whose two checksum-verified
+TFLite models are embedded directly in the executable for offline,
+self-contained builds. They carry the model license and exact provenance as
+verified release assets. The application starts the helper in a disarmed state
+and provides visible Voice and Gestures affordances rather than depending on
+shell environment variables that Finder does not provide. A signed macOS
+application distribution still requires Developer ID signing and notarization.
 
 The local protocol exposes `activate`, redacted `status`, `new`, `use`, and the
 narrow `microphone list/use/default` operations. Its endpoint must be accessible
@@ -223,9 +224,10 @@ binary transactionally and restart only after the replacement is complete; a
 failed health check restores the previous executable. Desktop updates do not
 silently alter a running agent Process.
 
-Published host artifacts currently cover Linux x64/ARM64 and macOS
-Intel/Apple Silicon for the existing host executables, plus Windows x64 for
-`gsv` and `gsvd`. Checksums cover every release asset. On macOS,
+Published host artifacts cover Linux x64/ARM64 and macOS Intel/Apple Silicon
+for Desktop, `gsv-transcribe`, `gsv-vision`, `gsv`, and `gsvd`, plus Windows x64
+for `gsv` and `gsvd`. Checksums cover every release asset, including the vision
+model license and provenance. On macOS,
 `host/scripts/package-macos.sh` assembles an architecture-native development
 `GSV.app` and ZIP containing Desktop, CLI, daemon, helpers, application
 metadata, and local gesture models. The result is intentionally unsigned and

--- a/docs/how-to/install-host-apps.md
+++ b/docs/how-to/install-host-apps.md
@@ -1,19 +1,19 @@
 # Install and upgrade GSV host applications
 
 The GSV release is one versioned host distribution. The operator CLI (`gsv`),
-machine daemon (`gsvd`), Desktop, and Desktop transcription helper share the
-version in the repository root `VERSION` file. The CLI refuses to manage a
-mismatched daemon.
+machine daemon (`gsvd`), Desktop, and Desktop's transcription and gesture-vision
+helpers share the version in the repository root `VERSION` file. The CLI
+refuses to manage a mismatched daemon.
 
 ## Supported release artifacts
 
-| Platform | `gsv` | `gsvd` | Desktop | Transcription |
-| --- | --- | --- | --- | --- |
-| Linux x64 | yes | yes | yes | yes |
-| Linux ARM64 | yes | yes | yes | yes |
-| macOS Intel | yes | yes | yes | yes |
-| macOS Apple Silicon | yes | yes | yes | yes |
-| Windows x64 | yes | yes | not yet | not yet |
+| Platform | `gsv` | `gsvd` | Desktop | Transcription | Gestures |
+| --- | --- | --- | --- | --- | --- |
+| Linux x64 | yes | yes | yes | yes | yes |
+| Linux ARM64 | yes | yes | yes | yes | yes |
+| macOS Intel | yes | yes | yes | yes | yes |
+| macOS Apple Silicon | yes | yes | yes | yes | yes |
+| Windows x64 | yes | yes | not yet | not yet | not yet |
 
 Windows ARM64 can run the Windows x64 CLI and daemon through emulation, but it
 is not a native release target. Other operating systems and architectures are
@@ -67,6 +67,10 @@ gsv desktop
 
 `gsv desktop status`, `new`, and `use PID` use same-user local IPC. Desktop
 connects to the gateway as a user; it does not route chat through `gsvd`.
+The installer places `gsv-transcribe` and `gsv-vision` beside Desktop so it can
+supervise the exact same-version helpers. The vision executable embeds its
+checksum-pinned models; their Apache 2.0 license and provenance are installed
+as verified sidecar assets.
 
 The current Desktop release is a command-line executable rather than a macOS
 `.app` bundle. It is not code-signed or notarized. A signed/notarized macOS

--- a/host/helpers/gestures/README.md
+++ b/host/helpers/gestures/README.md
@@ -153,5 +153,5 @@ Library/model/backend paths and native diagnostics are not printed.
 
 The artifact and parity contract lives in
 [`scripts/vision-native/README.md`](../../../scripts/vision-native/README.md).
-The macOS development bundle carries the model license and provenance beside
-the executable.
+The Linux/macOS host distribution and macOS development bundle carry the model
+license and provenance beside the executable.

--- a/install.sh
+++ b/install.sh
@@ -137,6 +137,39 @@ verify_asset() {
     fi
 }
 
+delegate_to_pinned_installer() {
+    if [ -z "$VERSION" ] || [ "${GSV_INSTALLER_RELEASE_BOUND:-0}" = "1" ]; then
+        return
+    fi
+
+    local bootstrap_dir
+    bootstrap_dir="$(mktemp -d)"
+    local checksum_file="${bootstrap_dir}/checksums.txt"
+    local installer_file="${bootstrap_dir}/install.sh"
+    local checksum_url
+    checksum_url="$(cache_bust_url_if_mutable "$VERSION" "$(release_asset_url "$VERSION" checksums.txt)")"
+    local installer_url
+    installer_url="$(cache_bust_url_if_mutable "$VERSION" "$(release_asset_url "$VERSION" install.sh)")"
+
+    info "Downloading installer for pinned release $VERSION"
+    if ! download_file "$checksum_url" "$checksum_file" || \
+        ! download_file "$installer_url" "$installer_file"; then
+        rm -rf "$bootstrap_dir"
+        error "Could not download the installer for $VERSION"
+        exit 1
+    fi
+    if ! verify_asset install.sh "$installer_file" "$checksum_file"; then
+        rm -rf "$bootstrap_dir"
+        exit 1
+    fi
+    success "Verified installer for $VERSION"
+
+    local status=0
+    GSV_INSTALLER_RELEASE_BOUND=1 bash "$installer_file" || status=$?
+    rm -rf "$bootstrap_dir"
+    exit "$status"
+}
+
 prepare_install_dir() {
     if mkdir -p "$INSTALL_DIR" 2>/dev/null && [ -w "$INSTALL_DIR" ]; then
         USE_SUDO=0
@@ -326,6 +359,7 @@ cleanup() {
 main() {
     detect_platform
     validate_channel
+    delegate_to_pinned_installer
     local release_ref
     release_ref="$(resolve_release_ref)"
     TMP_DIR="$(mktemp -d)"

--- a/install.sh
+++ b/install.sh
@@ -338,10 +338,22 @@ main() {
         "gsvd-${PLATFORM}"
         "gsv-desktop-${PLATFORM}"
         "gsv-transcribe-${PLATFORM}"
+        "gsv-vision-${PLATFORM}"
         "gsv-transcribe-THIRD_PARTY.md"
+        "gsv-vision-LICENSE.apache-2.0"
+        "gsv-vision-PROVENANCE.md"
     )
-    TARGETS=("gsv" "gsvd" "gsv-desktop" "gsv-transcribe" "gsv-transcribe-THIRD_PARTY.md")
-    EXECUTABLES=(1 1 1 1 0)
+    TARGETS=(
+        "gsv"
+        "gsvd"
+        "gsv-desktop"
+        "gsv-transcribe"
+        "gsv-vision"
+        "gsv-transcribe-THIRD_PARTY.md"
+        "gsv-vision-LICENSE.apache-2.0"
+        "gsv-vision-PROVENANCE.md"
+    )
+    EXECUTABLES=(1 1 1 1 1 0 0 0)
 
     echo ""
     echo -e "  ${BOLD}GSV host installer${NC} · ${PLATFORM} · ${release_ref}"
@@ -387,7 +399,7 @@ main() {
     remove_backups
     ensure_config_file
     persist_release_channel
-    success "Installed gsv, gsvd, Desktop, and local transcription to $INSTALL_DIR"
+    success "Installed gsv, gsvd, Desktop, and local helpers to $INSTALL_DIR"
     echo ""
     echo "  Next: gsv auth setup"
     echo "  Open: gsv desktop"

--- a/scripts/test-host-installer.sh
+++ b/scripts/test-host-installer.sh
@@ -6,10 +6,18 @@ TEST_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 FIXTURES="$TEST_ROOT/release"
+PINNED_FIXTURES="$TEST_ROOT/pinned-release"
 FAKE_BIN="$TEST_ROOT/bin"
 INSTALL_DIR="$TEST_ROOT/install"
+PINNED_INSTALL_DIR="$TEST_ROOT/pinned-install"
 TEST_HOME="$TEST_ROOT/home"
-mkdir -p "$FIXTURES" "$FAKE_BIN" "$INSTALL_DIR" "$TEST_HOME"
+mkdir -p \
+    "$FIXTURES" \
+    "$PINNED_FIXTURES" \
+    "$FAKE_BIN" \
+    "$INSTALL_DIR" \
+    "$PINNED_INSTALL_DIR" \
+    "$TEST_HOME"
 
 make_fixture() {
     local name="$1"
@@ -21,7 +29,7 @@ make_fixture() {
 write_checksums() {
     (
         cd "$FIXTURES"
-        sha256sum gsv-* gsvd-* > checksums.txt
+        sha256sum gsv-* gsvd-* install.sh > checksums.txt
     )
 }
 
@@ -33,6 +41,7 @@ make_fixture gsv-vision-linux-x64 vision-v1
 printf 'license-v1\n' > "$FIXTURES/gsv-transcribe-THIRD_PARTY.md"
 printf 'vision-license-v1\n' > "$FIXTURES/gsv-vision-LICENSE.apache-2.0"
 printf 'vision-provenance-v1\n' > "$FIXTURES/gsv-vision-PROVENANCE.md"
+cp "$REPOSITORY_ROOT/install.sh" "$FIXTURES/install.sh"
 write_checksums
 
 cat > "$FAKE_BIN/curl" <<'SH'
@@ -53,11 +62,46 @@ cp "$GSV_TEST_RELEASE_DIR/$asset" "$output"
 SH
 chmod 0755 "$FAKE_BIN/curl"
 
+cat > "$PINNED_FIXTURES/install.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+test "${GSV_INSTALLER_RELEASE_BOUND:-0}" = "1"
+printf '%s:%s\n' "$GSV_VERSION" "$GSV_INSTALLER_RELEASE_BOUND" \
+    > "$GSV_INSTALL_DIR/pinned-installer-ran"
+SH
+chmod 0755 "$PINNED_FIXTURES/install.sh"
+(
+    cd "$PINNED_FIXTURES"
+    sha256sum install.sh > checksums.txt
+)
+
+run_pinned_installer() {
+    env \
+        HOME="$TEST_HOME" \
+        PATH="$FAKE_BIN:$PATH" \
+        GSV_INSTALL_DIR="$PINNED_INSTALL_DIR" \
+        GSV_INSTALLER_RELEASE_BOUND=0 \
+        GSV_TEST_RELEASE_DIR="$PINNED_FIXTURES" \
+        GSV_VERSION="v-legacy" \
+        bash "$REPOSITORY_ROOT/install.sh" >/dev/null
+}
+
+run_pinned_installer
+test "$(cat "$PINNED_INSTALL_DIR/pinned-installer-ran")" = "v-legacy:1"
+rm "$PINNED_INSTALL_DIR/pinned-installer-ran"
+printf '\n# changed after checksums were written\n' >> "$PINNED_FIXTURES/install.sh"
+if run_pinned_installer 2>/dev/null; then
+    echo "installer accepted a pinned release installer that did not match checksums.txt" >&2
+    exit 1
+fi
+test ! -e "$PINNED_INSTALL_DIR/pinned-installer-ran"
+
 run_installer() {
     env \
         HOME="$TEST_HOME" \
         PATH="$FAKE_BIN:$PATH" \
         GSV_INSTALL_DIR="$INSTALL_DIR" \
+        GSV_INSTALLER_RELEASE_BOUND=0 \
         GSV_TEST_RELEASE_DIR="$FIXTURES" \
         GSV_VERSION="v-test" \
         bash "$REPOSITORY_ROOT/install.sh" >/dev/null

--- a/scripts/test-host-installer.sh
+++ b/scripts/test-host-installer.sh
@@ -29,7 +29,10 @@ make_fixture gsv-linux-x64 gsv-v1
 make_fixture gsvd-linux-x64 gsvd-v1
 make_fixture gsv-desktop-linux-x64 desktop-v1
 make_fixture gsv-transcribe-linux-x64 transcribe-v1
+make_fixture gsv-vision-linux-x64 vision-v1
 printf 'license-v1\n' > "$FIXTURES/gsv-transcribe-THIRD_PARTY.md"
+printf 'vision-license-v1\n' > "$FIXTURES/gsv-vision-LICENSE.apache-2.0"
+printf 'vision-provenance-v1\n' > "$FIXTURES/gsv-vision-PROVENANCE.md"
 write_checksums
 
 cat > "$FAKE_BIN/curl" <<'SH'
@@ -65,7 +68,10 @@ test "$("$INSTALL_DIR/gsv")" = "gsv-v1"
 test "$("$INSTALL_DIR/gsvd")" = "gsvd-v1"
 test "$("$INSTALL_DIR/gsv-desktop")" = "desktop-v1"
 test "$("$INSTALL_DIR/gsv-transcribe")" = "transcribe-v1"
+test "$("$INSTALL_DIR/gsv-vision")" = "vision-v1"
 test "$(cat "$INSTALL_DIR/gsv-transcribe-THIRD_PARTY.md")" = "license-v1"
+test "$(cat "$INSTALL_DIR/gsv-vision-LICENSE.apache-2.0")" = "vision-license-v1"
+test "$(cat "$INSTALL_DIR/gsv-vision-PROVENANCE.md")" = "vision-provenance-v1"
 
 make_fixture gsv-linux-x64 gsv-corrupt
 if run_installer 2>/dev/null; then
@@ -78,12 +84,15 @@ make_fixture gsv-linux-x64 gsv-v2
 make_fixture gsvd-linux-x64 gsvd-v2
 make_fixture gsv-desktop-linux-x64 desktop-v2
 make_fixture gsv-transcribe-linux-x64 transcribe-v2
+make_fixture gsv-vision-linux-x64 vision-v2
 printf 'license-v2\n' > "$FIXTURES/gsv-transcribe-THIRD_PARTY.md"
+printf 'vision-license-v2\n' > "$FIXTURES/gsv-vision-LICENSE.apache-2.0"
+printf 'vision-provenance-v2\n' > "$FIXTURES/gsv-vision-PROVENANCE.md"
 write_checksums
 cat > "$FAKE_BIN/chmod" <<'SH'
 #!/usr/bin/env sh
 case "$*" in
-    *gsvd.new.*) exit 1 ;;
+    *gsv-vision.new.*) exit 1 ;;
 esac
 exec /usr/bin/chmod "$@"
 SH
@@ -97,5 +106,9 @@ test "$("$INSTALL_DIR/gsv")" = "gsv-v1"
 test "$("$INSTALL_DIR/gsvd")" = "gsvd-v1"
 test "$("$INSTALL_DIR/gsv-desktop")" = "desktop-v1"
 test "$("$INSTALL_DIR/gsv-transcribe")" = "transcribe-v1"
+test "$("$INSTALL_DIR/gsv-vision")" = "vision-v1"
+test "$(cat "$INSTALL_DIR/gsv-transcribe-THIRD_PARTY.md")" = "license-v1"
+test "$(cat "$INSTALL_DIR/gsv-vision-LICENSE.apache-2.0")" = "vision-license-v1"
+test "$(cat "$INSTALL_DIR/gsv-vision-PROVENANCE.md")" = "vision-provenance-v1"
 
 echo "host installer checksum and replacement smoke passed"


### PR DESCRIPTION
## Summary

- build and publish gsv-vision for Linux x64/ARM64 and macOS Intel/Apple Silicon
- install Vision with the same versioned Desktop/helper transaction, including verified model license and provenance assets
- document the complete host distribution and extend the installer replacement smoke test

## Validation

- optimized release build for gestures
- cargo fmt for gestures and gesture-protocol
- cargo test for gestures and gesture-protocol (107 passed, 2 opt-in tests ignored)
- cargo clippy for both packages with warnings denied
- host installer checksum and replacement smoke
- shell syntax, workflow YAML parse, and diff checks