### PR TITLE
Forward managed inference RPC targets

### DIFF
--- a/gateway/src/inference/gsv-provider.test.ts
+++ b/gateway/src/inference/gsv-provider.test.ts
@@ -152,6 +152,58 @@ describe("GSV inference provider", () => {
     expect(dispose).toHaveBeenCalledOnce();
   });
 
+  it("settles cancellation while acquiring the inference target", async () => {
+    const disposeAcquisition = vi.fn();
+    const acquisition = new Promise<ManagedInferenceTarget>(() => {});
+    Object.defineProperty(acquisition, Symbol.dispose, {
+      value: disposeAcquisition,
+    });
+    const service = {
+      getInstallation: vi.fn(() => acquisition),
+    } satisfies ManagedInferenceService;
+    const controller = new AbortController();
+    const stream = providerStream(service, controller.signal);
+
+    await vi.waitFor(() => {
+      expect(service.getInstallation).toHaveBeenCalledOnce();
+    });
+    controller.abort(new Error("test cancellation"));
+
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "aborted",
+      errorMessage: "GSV inference cancelled",
+    });
+    expect(disposeAcquisition).toHaveBeenCalledOnce();
+  });
+
+  it("disposes a target that arrives after acquisition was cancelled", async () => {
+    let resolveTarget: (target: ManagedInferenceTarget) => void = () => {};
+    const acquisition = new Promise<ManagedInferenceTarget>((resolve) => {
+      resolveTarget = resolve;
+    });
+    const { target, dispose } = managedService(
+      vi.fn<ManagedInferenceTarget["generateStream"]>(),
+    );
+    const service = {
+      getInstallation: vi.fn(() => acquisition),
+    } satisfies ManagedInferenceService;
+    const controller = new AbortController();
+    const stream = providerStream(service, controller.signal);
+
+    await vi.waitFor(() => {
+      expect(service.getInstallation).toHaveBeenCalledOnce();
+    });
+    controller.abort(new Error("test cancellation"));
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "aborted",
+    });
+    resolveTarget(target);
+
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+    expect(target.generateStream).not.toHaveBeenCalled();
+    expect(target.abort).not.toHaveBeenCalled();
+  });
+
   it("aborts when cancellation overtakes the stream RPC", async () => {
     let markStarted: () => void = () => {};
     const started = new Promise<void>((resolve) => {

--- a/gateway/src/inference/gsv-provider.test.ts
+++ b/gateway/src/inference/gsv-provider.test.ts
@@ -6,9 +6,12 @@ import {
   GSV_INFERENCE_PRODUCT_MODEL,
   GSV_INFERENCE_PROVIDER,
   type ManagedInferenceResult,
-  type ManagedInferenceService,
   type ManagedInferenceStreamEvent,
 } from "@humansandmachines/gsv/protocol";
+import type {
+  InferenceService as ManagedInferenceService,
+  InferenceTarget as ManagedInferenceTarget,
+} from "@humansandmachines/gsv/services/inference";
 import { describe, expect, it, vi } from "vitest";
 import {
   createGsvInferenceProviderFactory,
@@ -47,9 +50,7 @@ const RESULT: ManagedInferenceResult = {
 describe("GSV inference provider", () => {
   it("registers only when its service binding is present", () => {
     const service: ManagedInferenceService = {
-      generate: vi.fn(),
-      generateStream: vi.fn(),
-      abort: vi.fn(),
+      getInstallation: vi.fn<ManagedInferenceService["getInstallation"]>(),
     };
 
     // SAFETY: The fixture implements the Env binding consumed by provider registration.
@@ -73,7 +74,7 @@ describe("GSV inference provider", () => {
         bodyController = controller;
       },
     });
-    const service = managedService(vi.fn(async () => body));
+    const { service, target, dispose } = managedService(vi.fn(async () => body));
     const stream = providerStream(service, new AbortController().signal);
     const events = stream[Symbol.asyncIterator]();
 
@@ -113,8 +114,12 @@ describe("GSV inference provider", () => {
       content: [{ type: "text", text: "pong" }],
       stopReason: "stop",
     });
-    expect(service.generateStream).toHaveBeenCalledOnce();
-    expect(service.generate).not.toHaveBeenCalled();
+    expect(service.getInstallation).toHaveBeenCalledWith(
+      ATTRIBUTION.installationId,
+    );
+    expect(target.generateStream).toHaveBeenCalledOnce();
+    expect(target.generate).not.toHaveBeenCalled();
+    expect(dispose).toHaveBeenCalledOnce();
   });
 
   it("aborts an active byte stream on request cancellation", async () => {
@@ -122,7 +127,7 @@ describe("GSV inference provider", () => {
     const started = new Promise<void>((resolve) => {
       markStarted = resolve;
     });
-    const generateStream = vi.fn<ManagedInferenceService["generateStream"]>(
+    const generateStream = vi.fn<ManagedInferenceTarget["generateStream"]>(
       async () => new ReadableStream({
         start() {
           markStarted();
@@ -131,11 +136,8 @@ describe("GSV inference provider", () => {
     );
     const controller = new AbortController();
     const abort = vi.fn(async () => {});
-    const stream = providerStream({
-      generate: vi.fn(),
-      generateStream,
-      abort,
-    }, controller.signal);
+    const { service, dispose } = managedService(generateStream, abort);
+    const stream = providerStream(service, controller.signal);
     const completion = stream.result();
 
     await started;
@@ -146,11 +148,8 @@ describe("GSV inference provider", () => {
       errorMessage: "GSV inference cancelled",
     });
     expect(abort).toHaveBeenCalledTimes(1);
-    expect(abort).toHaveBeenCalledWith({
-      version: 1,
-      installationId: ATTRIBUTION.installationId,
-      logicalRequestId: ATTRIBUTION.logicalRequestId,
-    });
+    expect(abort).toHaveBeenCalledWith(ATTRIBUTION.logicalRequestId);
+    expect(dispose).toHaveBeenCalledOnce();
   });
 
   it("aborts when cancellation overtakes the stream RPC", async () => {
@@ -161,7 +160,7 @@ describe("GSV inference provider", () => {
     const controller = new AbortController();
     const reason = new Error("test cancellation");
     let releaseStream: (value: ReadableStream<Uint8Array>) => void = () => {};
-    const generateStream = vi.fn<ManagedInferenceService["generateStream"]>(
+    const generateStream = vi.fn<ManagedInferenceTarget["generateStream"]>(
       () => new Promise((resolve) => {
         releaseStream = resolve;
         markStarted();
@@ -169,11 +168,8 @@ describe("GSV inference provider", () => {
     );
     const abort = vi.fn(async () => {});
 
-    const stream = providerStream({
-      generate: vi.fn(),
-      generateStream,
-      abort,
-    }, controller.signal);
+    const { service, dispose } = managedService(generateStream, abort);
+    const stream = providerStream(service, controller.signal);
     await started;
     controller.abort(reason);
     releaseStream(eventStream({ type: "done", reason: "stop", message: RESULT }));
@@ -183,6 +179,7 @@ describe("GSV inference provider", () => {
       errorMessage: "GSV inference cancelled",
     });
     expect(abort).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledOnce();
   });
 });
 
@@ -202,9 +199,20 @@ function providerStream(
 }
 
 function managedService(
-  generateStream: ManagedInferenceService["generateStream"],
-): ManagedInferenceService {
-  return { generate: vi.fn(), generateStream, abort: vi.fn() };
+  generateStream: ManagedInferenceTarget["generateStream"],
+  abort: ManagedInferenceTarget["abort"] = vi.fn(async () => {}),
+) {
+  const dispose = vi.fn();
+  const target = {
+    generate: vi.fn(),
+    generateStream,
+    abort,
+    [Symbol.dispose]: dispose,
+  } satisfies ManagedInferenceTarget & { [Symbol.dispose](): void };
+  const service = {
+    getInstallation: vi.fn(async () => target),
+  } satisfies ManagedInferenceService;
+  return { service, target, dispose };
 }
 
 function encoded(event: ManagedInferenceStreamEvent): Uint8Array {

--- a/gateway/src/inference/gsv-provider.ts
+++ b/gateway/src/inference/gsv-provider.ts
@@ -28,6 +28,7 @@ import type {
   InferenceAttribution,
   InferenceProviderFactory,
 } from "./provider";
+import { raceWithAbort } from "../shared/abort";
 
 const GSV_INFERENCE_API = "gsv-inference";
 
@@ -54,6 +55,10 @@ type GsvInferenceBindings = {
 };
 
 type DisposableManagedInferenceTarget = ManagedInferenceTarget & {
+  [Symbol.dispose]?(): void;
+};
+
+type DisposableManagedInferenceAcquisition = Promise<ManagedInferenceTarget> & {
   [Symbol.dispose]?(): void;
 };
 
@@ -171,6 +176,7 @@ async function pumpGsvInference(
   signal?: AbortSignal,
 ): Promise<void> {
   let target: ManagedInferenceTarget | undefined;
+  let acquisitionDisposesLateTarget = false;
   let generationStarted = false;
   let generationAbort: Promise<void> | undefined;
   const abortGeneration = () => {
@@ -189,7 +195,19 @@ async function pumpGsvInference(
       stream.push(gsvInferenceErrorEvent(true));
       return;
     }
-    target = await service.getInstallation(request.installationId);
+    const acquisition = service.getInstallation(request.installationId);
+    target = await raceWithAbort(acquisition, signal, {
+      onAbort: () => {
+        acquisitionDisposesLateTarget = disposeManagedInferenceAcquisition(
+          acquisition,
+        );
+      },
+      onLateResolve: (lateTarget) => {
+        if (!acquisitionDisposesLateTarget) {
+          disposeManagedInferenceTarget(lateTarget);
+        }
+      },
+    });
     if (signal?.aborted) {
       stream.push(gsvInferenceErrorEvent(true));
       return;
@@ -221,6 +239,18 @@ async function pumpGsvInference(
     await generationAbort;
     disposeManagedInferenceTarget(target);
   }
+}
+
+function disposeManagedInferenceAcquisition(
+  acquisition: Promise<ManagedInferenceTarget>,
+): boolean {
+  // SAFETY: Workers RPC promises implement Symbol.dispose. Disposing a pending
+  // promise also disposes an RpcTarget result if it arrives later.
+  const disposable = acquisition as DisposableManagedInferenceAcquisition;
+  const dispose = disposable[Symbol.dispose];
+  if (!dispose) return false;
+  dispose.call(disposable);
+  return true;
 }
 
 function disposeManagedInferenceTarget(

--- a/gateway/src/inference/gsv-provider.ts
+++ b/gateway/src/inference/gsv-provider.ts
@@ -20,7 +20,10 @@ import {
   type ManagedInferenceResult,
   type ManagedInferenceStreamEvent,
 } from "@humansandmachines/gsv/protocol";
-import type { InferenceService as ManagedInferenceService } from "@humansandmachines/gsv/services/inference";
+import type {
+  InferenceService as ManagedInferenceService,
+  InferenceTarget as ManagedInferenceTarget,
+} from "@humansandmachines/gsv/services/inference";
 import type {
   InferenceAttribution,
   InferenceProviderFactory,
@@ -48,6 +51,10 @@ const GSV_INFERENCE_MODEL_METADATA: Model<typeof GSV_INFERENCE_API> = {
 
 type GsvInferenceBindings = {
   MANAGED_INFERENCE?: ManagedInferenceService;
+};
+
+type DisposableManagedInferenceTarget = ManagedInferenceTarget & {
+  [Symbol.dispose]?(): void;
 };
 
 type AppliedManagedInferenceEvent = {
@@ -163,17 +170,14 @@ async function pumpGsvInference(
   stream: AssistantMessageEventStream,
   signal?: AbortSignal,
 ): Promise<void> {
+  let target: ManagedInferenceTarget | undefined;
   let generationStarted = false;
   let generationAbort: Promise<void> | undefined;
   const abortGeneration = () => {
-    if (generationStarted && !generationAbort) {
+    if (target && generationStarted && !generationAbort) {
       generationAbort = (async () => {
         try {
-          await service.abort({
-            version: 1,
-            installationId: request.installationId,
-            logicalRequestId: request.logicalRequestId,
-          });
+          await target.abort(request.logicalRequestId);
         } catch {}
       })();
     }
@@ -185,7 +189,12 @@ async function pumpGsvInference(
       stream.push(gsvInferenceErrorEvent(true));
       return;
     }
-    const bodyPromise = service.generateStream(request);
+    target = await service.getInstallation(request.installationId);
+    if (signal?.aborted) {
+      stream.push(gsvInferenceErrorEvent(true));
+      return;
+    }
+    const bodyPromise = target.generateStream(request);
     generationStarted = true;
     if (signal?.aborted) abortGeneration();
     const body = await bodyPromise;
@@ -210,7 +219,16 @@ async function pumpGsvInference(
   } finally {
     signal?.removeEventListener("abort", abortGeneration);
     await generationAbort;
+    disposeManagedInferenceTarget(target);
   }
+}
+
+function disposeManagedInferenceTarget(
+  target: ManagedInferenceTarget | undefined,
+): void {
+  // SAFETY: Workers RPC stubs implement Symbol.dispose; local test targets may omit it.
+  const disposable = target as DisposableManagedInferenceTarget | undefined;
+  disposable?.[Symbol.dispose]?.();
 }
 
 function toAssistantMessage(

--- a/gateway/src/inference/service.test.ts
+++ b/gateway/src/inference/service.test.ts
@@ -38,8 +38,11 @@ import {
   GSV_INFERENCE_PROVIDER,
   type AiConfigResult,
   type ManagedInferenceResult,
-  type ManagedInferenceService,
 } from "@humansandmachines/gsv/protocol";
+import type {
+  InferenceService as ManagedInferenceService,
+  InferenceTarget as ManagedInferenceTarget,
+} from "@humansandmachines/gsv/services/inference";
 import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
 import { createGsvInferenceProviderFactory } from "./gsv-provider";
 
@@ -190,13 +193,17 @@ describe("createGenerationService", () => {
       stopReason: "stop",
       timestamp: 1,
     };
-    const generateStream = vi.fn<ManagedInferenceService["generateStream"]>(
+    const generateStream = vi.fn<ManagedInferenceTarget["generateStream"]>(
       async () => managedResultStream(managedResult),
     );
-    const managedInference: ManagedInferenceService = {
+    const target: ManagedInferenceTarget = {
       generate: vi.fn(),
       generateStream,
       abort: vi.fn(),
+    };
+    const getInstallation = vi.fn(async () => target);
+    const managedInference: ManagedInferenceService = {
+      getInstallation,
     };
     completePiAiSimpleMock.mockImplementationOnce((model, context, options, models) =>
       models.completeSimple(model, context, options)
@@ -226,6 +233,7 @@ describe("createGenerationService", () => {
     });
 
     expect(result.content).toEqual([{ type: "text", text: "managed pong" }]);
+    expect(getInstallation).toHaveBeenCalledWith("inst_test");
     expect(generateStream).toHaveBeenCalledWith(expect.objectContaining({
       installationId: "inst_test",
       logicalRequestId: "request_test",
@@ -262,10 +270,9 @@ describe("createGenerationService", () => {
   });
 
   it("requires trusted attribution for a registered provider", async () => {
+    const getInstallation = vi.fn<ManagedInferenceService["getInstallation"]>();
     const managedInference: ManagedInferenceService = {
-      generate: vi.fn(),
-      generateStream: vi.fn(),
-      abort: vi.fn(),
+      getInstallation,
     };
 
     await expect(createGenerationService({
@@ -279,7 +286,7 @@ describe("createGenerationService", () => {
       },
       context: CONTEXT,
     })).rejects.toThrow("Inference attribution is unavailable for provider: gsv");
-    expect(managedInference.generateStream).not.toHaveBeenCalled();
+    expect(getInstallation).not.toHaveBeenCalled();
   });
 
   it("passes a routed fetch to built-in provider completions", async () => {

--- a/gateway/test-integration/fixtures/dependencies.ts
+++ b/gateway/test-integration/fixtures/dependencies.ts
@@ -1,4 +1,4 @@
-import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
+import { DurableObject, RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
 import {
   encodeManagedInferenceStreamEvent,
   GSV_INFERENCE_PRODUCT_MODEL,
@@ -21,11 +21,13 @@ import type {
   InstallationDirectoryResult,
   InstallationOnboardingAuthorization,
   ManagedInstallationState,
-  ManagedInferenceAbortRequest,
   ManagedInferenceRequest,
   ManagedInferenceResult,
-  ManagedInferenceService,
 } from "@humansandmachines/gsv/protocol";
+import type {
+  InferenceService as ManagedInferenceService,
+  InferenceTarget as ManagedInferenceTargetContract,
+} from "@humansandmachines/gsv/services/inference";
 import { SINGLETON_INSTALLATION_ID } from "../../src/installation/identity";
 import {
   resolveAdapterActivityRpcArgs,
@@ -125,13 +127,42 @@ export class ManagedInferenceFixture
   extends WorkerEntrypoint<Env>
   implements ManagedInferenceService
 {
-  async generate(input: ManagedInferenceRequest): Promise<ManagedInferenceResult> {
+  async getInstallation(
+    installationId: string,
+  ): Promise<ManagedInferenceTargetContract> {
+    return new ManagedInferenceTarget(this.env, installationId);
+  }
+}
+
+class ManagedInferenceTarget
+  extends RpcTarget
+  implements ManagedInferenceTargetContract
+{
+  readonly #env: Env;
+  readonly #installationId: string;
+
+  constructor(env: Env, installationId: string) {
+    super();
+    this.#env = env;
+    this.#installationId = installationId;
+  }
+
+  async generate(
+    input: ManagedInferenceRequest,
+  ): Promise<ManagedInferenceResult> {
+    if (input.installationId !== this.#installationId) {
+      throw new Error(
+        "Managed inference installation does not match its target",
+      );
+    }
     const waitsForCancellation = input.messages.some((message) => (
       message.role === "user" && message.content === "wait for cancellation"
     ));
     if (waitsForCancellation) {
-      const id = this.env.INTEGRATION_STATE.idFromName(SINGLETON_INSTALLATION_ID);
-      const state = this.env.INTEGRATION_STATE.get(id);
+      const id = this.#env.INTEGRATION_STATE.idFromName(
+        SINGLETON_INSTALLATION_ID,
+      );
+      const state = this.#env.INTEGRATION_STATE.get(id);
       while (!await state.wasManagedInferenceCancelled(input.installationId)) {
         await scheduler.wait(10);
       }
@@ -229,10 +260,12 @@ export class ManagedInferenceFixture
     });
   }
 
-  async abort(input: ManagedInferenceAbortRequest): Promise<void> {
-    const id = this.env.INTEGRATION_STATE.idFromName(SINGLETON_INSTALLATION_ID);
-    await this.env.INTEGRATION_STATE.get(id).recordManagedInferenceCancellation(
-      input.installationId,
+  async abort(_logicalRequestId: string): Promise<void> {
+    const id = this.#env.INTEGRATION_STATE.idFromName(
+      SINGLETON_INSTALLATION_ID,
+    );
+    await this.#env.INTEGRATION_STATE.get(id).recordManagedInferenceCancellation(
+      this.#installationId,
     );
   }
 }

--- a/gateway/test-integration/fixtures/managed-inference-probe.ts
+++ b/gateway/test-integration/fixtures/managed-inference-probe.ts
@@ -1,8 +1,10 @@
 import {
   GSV_INFERENCE_PRODUCT_MODEL,
   type ManagedInferenceRequest,
-  type ManagedInferenceService,
 } from "@humansandmachines/gsv/protocol";
+import type {
+  InferenceService as ManagedInferenceService,
+} from "@humansandmachines/gsv/services/inference";
 
 interface Env {
   MANAGED_INFERENCE: ManagedInferenceService;
@@ -23,24 +25,27 @@ export default {
       maxOutputTokens: 128,
       timeoutMs: 5_000,
     };
-    if (url.pathname === "/abort-first") {
-      await env.MANAGED_INFERENCE.abort({
-        version: 1,
-        installationId: input.installationId,
-        logicalRequestId: input.logicalRequestId,
-      });
-      const result = await env.MANAGED_INFERENCE.generate(input);
-      return new Response(null, {
-        status: result.stopReason === "aborted" ? 204 : 500,
-      });
+    const target = await env.MANAGED_INFERENCE.getInstallation(
+      input.installationId,
+    );
+    try {
+      if (url.pathname === "/abort-first") {
+        await target.abort(input.logicalRequestId);
+        const result = await target.generate(input);
+        return new Response(null, {
+          status: result.stopReason === "aborted" ? 204 : 500,
+        });
+      }
+      const result = target.generate(input);
+      await target.abort(input.logicalRequestId);
+      await result;
+      return new Response(null, { status: 204 });
+    } finally {
+      // SAFETY: Workers RPC stubs implement Symbol.dispose.
+      const disposable = target as typeof target & {
+        [Symbol.dispose]?(): void;
+      };
+      disposable[Symbol.dispose]?.();
     }
-    const result = env.MANAGED_INFERENCE.generate(input);
-    await env.MANAGED_INFERENCE.abort({
-      version: 1,
-      installationId: input.installationId,
-      logicalRequestId: input.logicalRequestId,
-    });
-    await result;
-    return new Response(null, { status: 204 });
   },
 } satisfies ExportedHandler<Env>;

--- a/packages/gsv/src/services/inference.ts
+++ b/packages/gsv/src/services/inference.ts
@@ -90,13 +90,18 @@ export type ManagedInferenceAbortRequest = {
   logicalRequestId: string;
 };
 
-/** Platform inference contract consumed by a Gateway deployment. */
-export interface InferenceService {
+/** Installation-scoped inference capability returned to a Gateway deployment. */
+export interface InferenceTarget {
   generate(input: ManagedInferenceRequest): Promise<ManagedInferenceResult>;
   generateStream(
     input: ManagedInferenceRequest,
   ): Promise<ReadableStream<Uint8Array>>;
-  abort(input: ManagedInferenceAbortRequest): Promise<void>;
+  abort(logicalRequestId: string): Promise<void>;
+}
+
+/** Platform inference contract consumed by a Gateway deployment. */
+export interface InferenceService {
+  getInstallation(installationId: string): Promise<InferenceTarget>;
 }
 
 /** @deprecated Import `InferenceService` from `@humansandmachines/gsv/services/inference`. */


### PR DESCRIPTION
## Summary

- expose an installation-scoped managed inference RPC target
- stream and abort through the forwarded target while retaining it for the response lifetime
- update unit and integration fixtures for target acquisition and disposal

## Why

Returning the installation Durable Object target lets the provider response travel directly to the gateway instead of relaying its stream through a second Worker RPC return.

## Validation

- gateway TypeScript check
- 1,665 gateway unit tests
- 32 gateway integration tests
- repository lint