### PR TITLE
Bind gateway directly to inference installations

### DIFF
--- a/deployment/src/runtime.ts
+++ b/deployment/src/runtime.ts
@@ -33,6 +33,7 @@ export type GsvAdapterBinding = {
 export type GsvRuntimeServices = {
   installationDirectory?: Cloudflare.Workers.Worker;
   inference?: Cloudflare.Workers.WorkerEntrypointBinding;
+  inferenceInstallations?: Cloudflare.Workers.WorkerBindingProps[string];
   entitlements?: Cloudflare.Workers.WorkerEntrypointBinding;
   mailOutbound?: Cloudflare.Queues.Queue;
   adapters?: readonly GsvAdapterBinding[];
@@ -98,6 +99,10 @@ export const GsvRuntime = (props: GsvRuntimeProps) =>
     }
     if (props.services?.inference) {
       managedBindings.MANAGED_INFERENCE = props.services.inference;
+    }
+    if (props.services?.inferenceInstallations) {
+      managedBindings.MANAGED_INFERENCE_INSTALLATIONS =
+        props.services.inferenceInstallations;
     }
     if (props.services?.entitlements) {
       managedBindings.ENTITLEMENTS = props.services.entitlements;

--- a/gateway/src/inference/gsv-provider.test.ts
+++ b/gateway/src/inference/gsv-provider.test.ts
@@ -48,7 +48,7 @@ const RESULT: ManagedInferenceResult = {
 };
 
 describe("GSV inference provider", () => {
-  it("registers only when its service binding is present", () => {
+  it("registers when either managed inference binding is present", () => {
     const service: ManagedInferenceService = {
       getInstallation: vi.fn<ManagedInferenceService["getInstallation"]>(),
     };
@@ -61,10 +61,45 @@ describe("GSV inference provider", () => {
     expect(gsvInferenceFeaturesFromEnv({
       MANAGED_INFERENCE: service,
     } as Env)).toEqual([GSV_INFERENCE_FEATURE]);
+    // SAFETY: The fixture implements the direct namespace binding consumed by registration.
+    expect(gsvInferenceProviderFactoryFromEnv({
+      MANAGED_INFERENCE_INSTALLATIONS: { getByName: vi.fn() },
+    } as Env)).toMatchObject({ id: "gsv" });
+    // SAFETY: The fixture implements the direct namespace binding consumed by registration.
+    expect(gsvInferenceFeaturesFromEnv({
+      MANAGED_INFERENCE_INSTALLATIONS: { getByName: vi.fn() },
+    } as Env)).toEqual([GSV_INFERENCE_FEATURE]);
     // SAFETY: An empty Env fixture represents an absent optional binding.
     expect(gsvInferenceProviderFactoryFromEnv({} as Env)).toBeUndefined();
     // SAFETY: An empty Env fixture represents an absent optional binding.
     expect(gsvInferenceFeaturesFromEnv({} as Env)).toEqual([]);
+  });
+
+  it("prefers the direct installation namespace over the service fallback", async () => {
+    const { service, target, dispose } = managedService(
+      vi.fn(async () => eventStream({
+        type: "done",
+        reason: "stop",
+        message: RESULT,
+      })),
+    );
+    const getByName = vi.fn(() => target);
+    // SAFETY: The fixture implements both optional managed inference bindings.
+    const factory = gsvInferenceProviderFactoryFromEnv({
+      MANAGED_INFERENCE_INSTALLATIONS: { getByName },
+      MANAGED_INFERENCE: service,
+    } as Env);
+    if (!factory) throw new Error("managed inference provider was not registered");
+
+    await expect(providerStreamFromFactory(
+      factory,
+      new AbortController().signal,
+    ).result()).resolves.toMatchObject({ stopReason: "stop" });
+
+    expect(getByName).toHaveBeenCalledWith(ATTRIBUTION.installationId);
+    expect(service.getInstallation).not.toHaveBeenCalled();
+    expect(target.generateStream).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledOnce();
   });
 
   it("forwards deltas before the managed result completes", async () => {
@@ -239,7 +274,17 @@ function providerStream(
   service: ManagedInferenceService,
   signal: AbortSignal,
 ) {
-  const provider = createGsvInferenceProviderFactory(service).create(ATTRIBUTION);
+  return providerStreamFromFactory(
+    createGsvInferenceProviderFactory(service),
+    signal,
+  );
+}
+
+function providerStreamFromFactory(
+  factory: ReturnType<typeof createGsvInferenceProviderFactory>,
+  signal: AbortSignal,
+) {
+  const provider = factory.create(ATTRIBUTION);
   const models = createModels();
   models.setProvider(provider);
   const model = models.getModel("gsv", GSV_INFERENCE_MODEL)!;

--- a/gateway/src/inference/gsv-provider.ts
+++ b/gateway/src/inference/gsv-provider.ts
@@ -52,7 +52,18 @@ const GSV_INFERENCE_MODEL_METADATA: Model<typeof GSV_INFERENCE_API> = {
 
 type GsvInferenceBindings = {
   MANAGED_INFERENCE?: ManagedInferenceService;
+  MANAGED_INFERENCE_INSTALLATIONS?: DurableObjectNamespace;
 };
+
+type ManagedInferenceAccess =
+  | {
+    kind: "installations";
+    installations: DurableObjectNamespace;
+  }
+  | {
+    kind: "service";
+    service: ManagedInferenceService;
+  };
 
 type DisposableManagedInferenceTarget = ManagedInferenceTarget & {
   [Symbol.dispose]?(): void;
@@ -71,18 +82,24 @@ type AppliedManagedInferenceEvent = {
 export function gsvInferenceProviderFactoryFromEnv(
   env: Env,
 ): InferenceProviderFactory | undefined {
-  const service = managedInferenceServiceFromEnv(env);
-  return service ? createGsvInferenceProviderFactory(service) : undefined;
+  const access = managedInferenceAccessFromEnv(env);
+  return access ? createGsvInferenceProviderFactoryForAccess(access) : undefined;
 }
 
 export function gsvInferenceFeaturesFromEnv(env: Env): string[] {
-  return managedInferenceServiceFromEnv(env)
+  return managedInferenceAccessFromEnv(env)
     ? [GSV_INFERENCE_FEATURE]
     : [];
 }
 
 export function createGsvInferenceProviderFactory(
   service: ManagedInferenceService,
+): InferenceProviderFactory {
+  return createGsvInferenceProviderFactoryForAccess({ kind: "service", service });
+}
+
+function createGsvInferenceProviderFactoryForAccess(
+  access: ManagedInferenceAccess,
 ): InferenceProviderFactory {
   return {
     id: GSV_INFERENCE_PROVIDER,
@@ -92,28 +109,33 @@ export function createGsvInferenceProviderFactory(
       auth: {
         apiKey: {
           name: "GSV included inference",
-          resolve: async () => ({ auth: {}, source: "gateway service binding" }),
+          resolve: async () => ({
+            auth: {},
+            source: access.kind === "installations"
+              ? "gateway durable object binding"
+              : "gateway service binding",
+          }),
         },
       },
       models: [GSV_INFERENCE_MODEL_METADATA],
-      api: gsvInferenceStreams(service, attribution),
+      api: gsvInferenceStreams(access, attribution),
     }),
   };
 }
 
 function gsvInferenceStreams(
-  service: ManagedInferenceService,
+  access: ManagedInferenceAccess,
   attribution: InferenceAttribution,
 ): ProviderStreams {
   return {
     stream: (_model, context, options) => streamGsvInference(
-      service,
+      access,
       attribution,
       context,
       options,
     ),
     streamSimple: (_model, context, options) => streamGsvInference(
-      service,
+      access,
       attribution,
       context,
       options,
@@ -122,7 +144,7 @@ function gsvInferenceStreams(
 }
 
 function streamGsvInference(
-  service: ManagedInferenceService,
+  access: ManagedInferenceAccess,
   attribution: InferenceAttribution,
   context: Context,
   options?: StreamOptions | SimpleStreamOptions,
@@ -132,7 +154,7 @@ function streamGsvInference(
   }
   const stream = createAssistantMessageEventStream();
   void pumpGsvInference(
-    service,
+    access,
     buildManagedInferenceRequest(attribution, context, options),
     stream,
     options?.signal,
@@ -170,7 +192,7 @@ function buildManagedInferenceRequest(
 }
 
 async function pumpGsvInference(
-  service: ManagedInferenceService,
+  access: ManagedInferenceAccess,
   request: ManagedInferenceRequest,
   stream: AssistantMessageEventStream,
   signal?: AbortSignal,
@@ -195,19 +217,26 @@ async function pumpGsvInference(
       stream.push(gsvInferenceErrorEvent(true));
       return;
     }
-    const acquisition = service.getInstallation(request.installationId);
-    target = await raceWithAbort(acquisition, signal, {
-      onAbort: () => {
-        acquisitionDisposesLateTarget = disposeManagedInferenceAcquisition(
-          acquisition,
-        );
-      },
-      onLateResolve: (lateTarget) => {
-        if (!acquisitionDisposesLateTarget) {
-          disposeManagedInferenceTarget(lateTarget);
-        }
-      },
-    });
+    if (access.kind === "installations") {
+      target = managedInferenceTarget(
+        access.installations,
+        request.installationId,
+      );
+    } else {
+      const acquisition = access.service.getInstallation(request.installationId);
+      target = await raceWithAbort(acquisition, signal, {
+        onAbort: () => {
+          acquisitionDisposesLateTarget = disposeManagedInferenceAcquisition(
+            acquisition,
+          );
+        },
+        onLateResolve: (lateTarget) => {
+          if (!acquisitionDisposesLateTarget) {
+            disposeManagedInferenceTarget(lateTarget);
+          }
+        },
+      });
+    }
     if (signal?.aborted) {
       stream.push(gsvInferenceErrorEvent(true));
       return;
@@ -451,9 +480,29 @@ function requirePartial(
 }
 
 
-function managedInferenceServiceFromEnv(value: Env): ManagedInferenceService | undefined {
+function managedInferenceAccessFromEnv(value: Env): ManagedInferenceAccess | undefined {
+  // SAFETY: Managed-only bindings are optional extensions to the generated standalone Env.
+  const bindings = value as Env & GsvInferenceBindings;
+  if (bindings.MANAGED_INFERENCE_INSTALLATIONS) {
+    return {
+      kind: "installations",
+      installations: bindings.MANAGED_INFERENCE_INSTALLATIONS,
+    };
+  }
   // SAFETY: Managed deployments bind MANAGED_INFERENCE; standalone deployments omit it.
-  return (value as Env & GsvInferenceBindings).MANAGED_INFERENCE;
+  return bindings.MANAGED_INFERENCE
+    ? { kind: "service", service: bindings.MANAGED_INFERENCE }
+    : undefined;
+}
+
+function managedInferenceTarget(
+  installations: DurableObjectNamespace,
+  installationId: string,
+): ManagedInferenceTarget {
+  const target: unknown = installations.getByName(installationId);
+  // SAFETY: The external namespace is bound to the inference service's exported
+  // InferenceInstallation class, whose public RPC surface implements this contract.
+  return target as ManagedInferenceTarget;
 }
 
 function gsvInferenceErrorEvent(

--- a/gateway/test-integration/harness.ts
+++ b/gateway/test-integration/harness.ts
@@ -49,7 +49,21 @@ function integrationGatewayConfig(options: {
     define: config.define,
     rules: config.rules,
     migrations: lifecycleConfig.migrations,
-    durable_objects: lifecycleConfig.durable_objects,
+    durable_objects: {
+      bindings: [
+        ...(lifecycleConfig.durable_objects?.bindings ?? []).filter(
+          (binding: { name: string }) =>
+            binding.name !== "MANAGED_INFERENCE_INSTALLATIONS",
+        ),
+        ...(options.managedServices
+          ? [{
+              name: "MANAGED_INFERENCE_INSTALLATIONS",
+              class_name: "InferenceInstallation",
+              script_name: options.managedServices.inference,
+            }]
+          : []),
+      ],
+    },
     observability: config.observability,
     r2_buckets: config.r2_buckets,
     queues: options.managedMailQueue
@@ -77,13 +91,13 @@ function integrationGatewayConfig(options: {
               binding: "INSTALLATION_DIRECTORY",
               service: options.managedServices?.accounts ?? DEPENDENCY_WORKER,
             },
-            {
-              binding: "MANAGED_INFERENCE",
-              service: options.managedServices?.inference ?? DEPENDENCY_WORKER,
-              entrypoint: options.managedServices
-                ? "InferenceService"
-                : "ManagedInferenceFixture",
-            },
+            ...(options.managedServices
+              ? []
+              : [{
+                  binding: "MANAGED_INFERENCE",
+                  service: DEPENDENCY_WORKER,
+                  entrypoint: "ManagedInferenceFixture",
+                }]),
           ]
         : []),
     ],

--- a/gateway/wrangler.managed.dev.jsonc
+++ b/gateway/wrangler.managed.dev.jsonc
@@ -57,6 +57,11 @@
       {
         "class_name": "Conversation",
         "name": "CONVERSATION"
+      },
+      {
+        "class_name": "InferenceInstallation",
+        "name": "MANAGED_INFERENCE_INSTALLATIONS",
+        "script_name": "gsv-inference-dev"
       }
     ]
   },

--- a/gateway/wrangler.managed.jsonc
+++ b/gateway/wrangler.managed.jsonc
@@ -57,6 +57,11 @@
       {
         "class_name": "Conversation",
         "name": "CONVERSATION"
+      },
+      {
+        "class_name": "InferenceInstallation",
+        "name": "MANAGED_INFERENCE_INSTALLATIONS",
+        "script_name": "gsv-inference"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- prefer an external InferenceInstallation Durable Object namespace in managed gateways
- retain the WorkerEntrypoint service as a rolling-deployment fallback
- make managed integration coverage exercise the direct namespace only
- add managed Wrangler bindings for production and development

## Validation
- gateway unit suite: 110 files, 1686 tests passed
- lint and gateway/deployment TypeScript checks passed
- managed deployment dry-run checks passed
- multi-worker delayed-first-chunk integration passed
- Cloudflare staging runtime completed direct streams with first chunks at 3.573s and 2.144s (48,028 input tokens for the latter)