### PR TITLE
Log managed inference failure stages

### DIFF
--- a/gateway/src/inference/gsv-provider.test.ts
+++ b/gateway/src/inference/gsv-provider.test.ts
@@ -268,6 +268,41 @@ describe("GSV inference provider", () => {
     expect(abort).toHaveBeenCalledTimes(1);
     expect(dispose).toHaveBeenCalledOnce();
   });
+
+  it("logs only an allowlisted stage when stream validation fails", async () => {
+    const privatePayload = "private tool arguments";
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const malformedEvent = new TextEncoder().encode(`${JSON.stringify({
+      type: "toolcall_start",
+      contentIndex: 0,
+      toolCall: {
+        type: "toolCall",
+        id: "call_test",
+        name: "Shell",
+        arguments: {},
+        privatePayload,
+      },
+    })}\n`);
+    const { service } = managedService(vi.fn(async () => new ReadableStream({
+      start(controller) {
+        controller.enqueue(malformedEvent);
+        controller.close();
+      },
+    })));
+
+    await expect(providerStream(service, new AbortController().signal).result())
+      .resolves.toMatchObject({
+        stopReason: "error",
+        errorMessage: "GSV inference is unavailable",
+      });
+
+    expect(errorLog).toHaveBeenCalledWith(JSON.stringify({
+      component: "gsv_inference",
+      event: "stream_consume_failed",
+    }));
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain(privatePayload);
+    errorLog.mockRestore();
+  });
 });
 
 function providerStream(

--- a/gateway/src/inference/gsv-provider.ts
+++ b/gateway/src/inference/gsv-provider.ts
@@ -79,6 +79,11 @@ type AppliedManagedInferenceEvent = {
   terminal: boolean;
 };
 
+type ManagedInferenceFailureEvent =
+  | "target_acquisition_failed"
+  | "stream_start_failed"
+  | "stream_consume_failed";
+
 export function gsvInferenceProviderFactoryFromEnv(
   env: Env,
 ): InferenceProviderFactory | undefined {
@@ -201,6 +206,7 @@ async function pumpGsvInference(
   let acquisitionDisposesLateTarget = false;
   let generationStarted = false;
   let generationAbort: Promise<void> | undefined;
+  let failureEvent: ManagedInferenceFailureEvent = "target_acquisition_failed";
   const abortGeneration = () => {
     if (target && generationStarted && !generationAbort) {
       generationAbort = (async () => {
@@ -241,10 +247,12 @@ async function pumpGsvInference(
       stream.push(gsvInferenceErrorEvent(true));
       return;
     }
+    failureEvent = "stream_start_failed";
     const bodyPromise = target.generateStream(request);
     generationStarted = true;
     if (signal?.aborted) abortGeneration();
     const body = await bodyPromise;
+    failureEvent = "stream_consume_failed";
     let partial: AssistantMessage | undefined;
     let terminal = false;
     for await (const raw of decodeManagedInferenceStream(body, signal)) {
@@ -262,12 +270,17 @@ async function pumpGsvInference(
     if (!terminal) throw new Error("Managed inference stream ended early");
   } catch {
     abortGeneration();
+    if (!signal?.aborted) logManagedInferenceFailure(failureEvent);
     stream.push(gsvInferenceErrorEvent(signal?.aborted === true));
   } finally {
     signal?.removeEventListener("abort", abortGeneration);
     await generationAbort;
     disposeManagedInferenceTarget(target);
   }
+}
+
+function logManagedInferenceFailure(event: ManagedInferenceFailureEvent): void {
+  console.error(JSON.stringify({ component: "gsv_inference", event }));
 }
 
 function disposeManagedInferenceAcquisition(


### PR DESCRIPTION
## Summary
- classify managed inference failures by gateway boundary stage
- emit only fixed allowlisted JSON fields
- suppress logs for ordinary request cancellation
- cover malformed private stream payloads without logging their contents

## Validation
- npx tsc --noEmit
- npx vitest run --config vitest.config.ts src/inference/gsv-provider.test.ts
- npm run test:unit (111 files, 1678 tests)