### PR TITLE
add provider-neutral telemetry events

### DIFF
--- a/deployment/src/runtime.ts
+++ b/deployment/src/runtime.ts
@@ -49,6 +49,9 @@ export type GsvRuntimeProps = {
   compatibility?: typeof GSV_WORKER_COMPATIBILITY;
   gatewayWorkersDev?: boolean | Cloudflare.Workers.WorkersDevConfig;
   observability?: Cloudflare.Workers.WorkerObservability;
+  telemetry?: {
+    tailConsumers: readonly (string | Cloudflare.Workers.Worker)[];
+  };
 };
 
 const adapterGatewayBindings = (
@@ -63,6 +66,16 @@ const adapterGatewayBindings = (
       ),
     ]),
   );
+
+const telemetryProducerObservability = {
+  enabled: true,
+  logs: {
+    enabled: true,
+    invocationLogs: false,
+    persist: false,
+  },
+  traces: { enabled: false },
+} satisfies Cloudflare.Workers.WorkerObservability;
 
 export const GsvRuntime = (props: GsvRuntimeProps) =>
   Effect.gen(function* () {
@@ -110,6 +123,25 @@ export const GsvRuntime = (props: GsvRuntimeProps) =>
     if (props.services?.mailOutbound) {
       managedBindings.MANAGED_MAIL_OUTBOUND = props.services.mailOutbound;
     }
+    const gatewayEnv: Cloudflare.Workers.WorkerBindingProps = {
+      KERNEL: Cloudflare.DurableObject("KERNEL", {
+        className: "Kernel",
+      }),
+      PROCESS: Cloudflare.DurableObject("PROCESS", {
+        className: "Process",
+      }),
+      CONVERSATION: Cloudflare.DurableObject("CONVERSATION", {
+        className: "Conversation",
+      }),
+      STORAGE: storageResource,
+      AI: Cloudflare.Workers.AI(),
+      RIPGIT: ripgitWorker,
+      LOADER: Cloudflare.WorkerLoader(),
+      ...managedBindings,
+      ...adapterGatewayBindings(adapters),
+      ...props.services?.extraBindings,
+    };
+    if (props.telemetry) gatewayEnv.GSV_TELEMETRY_ENABLED = "1";
     const gatewayWorker = Cloudflare.Worker(
       `${props.logicalPrefix}Gateway`,
       {
@@ -118,30 +150,19 @@ export const GsvRuntime = (props: GsvRuntimeProps) =>
         bundle: false,
         compatibility,
         workersDev: props.gatewayWorkersDev ?? false,
-        observability: props.observability ?? { enabled: true },
+        observability: props.observability
+          ?? (props.telemetry
+            ? telemetryProducerObservability
+            : { enabled: true }),
+        tailConsumers: props.telemetry
+          ? [...props.telemetry.tailConsumers]
+          : undefined,
         assets: {
           directory: props.paths.webAssets,
           notFoundHandling: "single-page-application",
           runWorkerFirst: ["/*"],
         },
-        env: {
-          KERNEL: Cloudflare.DurableObject("KERNEL", {
-            className: "Kernel",
-          }),
-          PROCESS: Cloudflare.DurableObject("PROCESS", {
-            className: "Process",
-          }),
-          CONVERSATION: Cloudflare.DurableObject("CONVERSATION", {
-            className: "Conversation",
-          }),
-          STORAGE: storageResource,
-          AI: Cloudflare.Workers.AI(),
-          RIPGIT: ripgitWorker,
-          LOADER: Cloudflare.WorkerLoader(),
-          ...managedBindings,
-          ...adapterGatewayBindings(adapters),
-          ...props.services?.extraBindings,
-        },
+        env: gatewayEnv,
       },
     ).pipe(retain());
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -32,6 +32,7 @@ A good order is:
 8. [Targets and Capability Environments](./targets.md)
 9. [Unified Protocol Peers](./unified-protocol-peers.md)
 10. [Security Model](./security-model.md)
+11. [Telemetry](./telemetry.md)
 
 ## The Current Pillars
 
@@ -260,6 +261,8 @@ of chat integrations.
 - [Resource References and Lazy Binary Resolution](./resource-references.md)
   documents the implemented common file-reference and lazy byte-streaming
   contract used by Messages, Processes, adapters, Web, and Desktop.
+- [Telemetry](./telemetry.md) defines the optional provider-neutral event seam
+  and its privacy boundary.
 
 ## Deferred design proposals
 

--- a/docs/architecture/telemetry.md
+++ b/docs/architecture/telemetry.md
@@ -1,0 +1,52 @@
+# Telemetry
+
+GSV exposes an optional, provider-neutral telemetry seam for deployment
+operators. The open-source runtime does not select an analytics vendor and
+emits no telemetry unless the deployment explicitly enables and consumes it.
+
+Telemetry records describe committed outcomes at the subsystem that owns the
+operation. For example, the Process reports a finished run after its terminal
+state is durable, the Kernel reports a Message after the Conversation accepts
+it, and managed inference reports a request after its reservation settles.
+Callers must not synthesize success events before those boundaries.
+
+## Privacy contract
+
+The public schema in `@humansandmachines/gsv/telemetry` is the complete
+allowlist. Each event has a closed property schema; there is no arbitrary
+metadata field. Records may contain:
+
+- event names, bounded categories, timings, outcomes, and aggregate counts;
+- the installation identity needed by a deployment-owned consumer to derive a
+  pseudonym; and
+- a random event id and occurrence time for idempotent export.
+
+Records must never contain prompts, messages, file paths, URLs, tool arguments,
+media, credentials, contact or channel identifiers, raw exception text, or
+other user content. Invalid records are rejected without affecting user work.
+Managed telemetry does not export Process traces or conversation activity.
+
+Operational telemetry and product analytics are separate purposes. A managed
+consumer derives unrelated pseudonyms for the two streams with different HMAC
+keys. This makes an operational installation series useful for reliability
+without giving the backend a shared installation join key for the product-usage
+series. Product events are personless: they do not create or update user
+profiles.
+
+## Deployment boundary
+
+Producers emit one structured record only when `GSV_TELEMETRY_ENABLED` is set by
+their deployment. A Tail Worker or another deployment-owned consumer may accept
+those records and export them to a backend. It must validate the shared schema,
+verify that the producing Worker is allowed to emit the claimed component, and
+discard every surrounding log, request, header, exception, and trace field.
+Because the transport record carries an installation ID until the consumer
+pseudonymizes it, a telemetry-enabled deployment must not persist producer
+console or invocation logs. `GsvRuntime` applies that non-persistent
+observability policy when the telemetry seam is enabled unless the deployment
+explicitly supplies a different policy.
+
+The managed deployment uses a Tail Worker to translate operational records to
+PostHog Logs and product records to PostHog Capture. PostHog knowledge and
+credentials stay in that deployment repository. Self-hosters can leave the seam
+disabled or attach a consumer for their own backend without changing GSV core.

--- a/gateway/src/conversation/do.ts
+++ b/gateway/src/conversation/do.ts
@@ -7,6 +7,7 @@ import type {
 import { resourceBlockSchema } from "@humansandmachines/gsv/protocol";
 import { createInstallationStorage } from "../installation/storage";
 import { parseConversationDurableObjectName } from "../installation/routing";
+import type { GatewayEnv } from "../runtime-env";
 import {
   agentArchiveMediaPath,
   isValidAgentArchiveMediaObject,
@@ -54,7 +55,7 @@ export type ConversationMediaRead = {
   stream: ReadableStream<Uint8Array>;
 };
 
-export class Conversation extends DurableObject<Env> {
+export class Conversation extends DurableObject<GatewayEnv> {
   readonly installationId: string;
   readonly conversationId: string;
   private readonly store: ConversationStore;
@@ -62,7 +63,7 @@ export class Conversation extends DurableObject<Env> {
   private archiveTransition: Promise<void> = Promise.resolve();
   private appendTransition: Promise<void> = Promise.resolve();
 
-  constructor(ctx: DurableObjectState, env: Env) {
+  constructor(ctx: DurableObjectState, env: GatewayEnv) {
     super(ctx, env);
     const identity = parseConversationDurableObjectName(ctx.id.name);
     this.installationId = identity.installationId;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -37,7 +37,6 @@ import {
   getKernelByInstallationId,
   resolveInstallationRoute,
 } from "./installation/routing";
-import type { GatewayInstallationBindings } from "./installation/routing";
 import {
   parseInstallationId,
   parseManagedInstallationId,
@@ -50,6 +49,7 @@ import { buildGitProxyRequest, getBasicAuth, matchGitPath } from "./git";
 import * as z from "zod/mini";
 import type { ServicePeerProfile } from "./kernel/peer";
 import { isFederationPublicPath } from "./kernel/federation";
+import type { GatewayEnv } from "./runtime-env";
 
 export { Kernel } from "./kernel/do";
 export { Process } from "./process/do";
@@ -157,7 +157,7 @@ export default {
     }
     return new Response("Not Found", { status: 404 });
   },
-} satisfies ExportedHandler<Env>;
+} satisfies ExportedHandler<GatewayEnv>;
 
 const ADAPTER_SERVICE_CALLS = ["adapter.inbound", "adapter.state.update"] as const;
 const LEGACY_ADAPTER_IDS = new Set(["telegram", "whatsapp", "discord", "test"]);
@@ -177,7 +177,7 @@ const adapterServicePeerProfileSchema = z.object({
 });
 
 abstract class AdapterServiceEntrypoint<Props>
-  extends WorkerEntrypoint<Env & GatewayInstallationBindings, Props>
+  extends WorkerEntrypoint<GatewayEnv, Props>
   implements GatewayAdapterInterface
 {
   protected abstract resolveServicePeerProfile(frame: Frame): ServicePeerProfile;
@@ -343,7 +343,7 @@ export class AdapterGatewayEntrypoint
 }
 
 async function routeAdapterServiceFrame(
-  bindings: Env & GatewayInstallationBindings,
+  bindings: GatewayEnv,
   installation: AdapterInstallationContext,
   profile: ServicePeerProfile,
   frame: Frame,
@@ -423,7 +423,7 @@ function adapterServiceFrameBody(
 }
 
 function resolveAdapterInstallationId(
-  bindings: Env & GatewayInstallationBindings,
+  bindings: GatewayEnv,
   installation: AdapterInstallationContext,
 ): string {
   if (bindings.INSTALLATION_DIRECTORY) {

--- a/gateway/src/inference/gsv-provider.ts
+++ b/gateway/src/inference/gsv-provider.ts
@@ -30,6 +30,7 @@ import type {
 } from "./provider";
 import { DEFAULT_TEXT_GENERATION_MAX_TOKENS } from "./default-models";
 import { raceWithAbort } from "../shared/abort";
+import type { GatewayEnv } from "../runtime-env";
 
 const GSV_INFERENCE_API = "gsv-inference";
 
@@ -49,11 +50,6 @@ const GSV_INFERENCE_MODEL_METADATA: Model<typeof GSV_INFERENCE_API> = {
   },
   contextWindow: 1_048_576,
   maxTokens: DEFAULT_TEXT_GENERATION_MAX_TOKENS,
-};
-
-type GsvInferenceBindings = {
-  MANAGED_INFERENCE?: ManagedInferenceService;
-  MANAGED_INFERENCE_INSTALLATIONS?: DurableObjectNamespace;
 };
 
 type ManagedInferenceAccess =
@@ -81,13 +77,13 @@ type AppliedManagedInferenceEvent = {
 };
 
 export function gsvInferenceProviderFactoryFromEnv(
-  env: Env,
+  env: GatewayEnv,
 ): InferenceProviderFactory | undefined {
   const access = managedInferenceAccessFromEnv(env);
   return access ? createGsvInferenceProviderFactoryForAccess(access) : undefined;
 }
 
-export function gsvInferenceFeaturesFromEnv(env: Env): string[] {
+export function gsvInferenceFeaturesFromEnv(env: GatewayEnv): string[] {
   return managedInferenceAccessFromEnv(env)
     ? [GSV_INFERENCE_FEATURE]
     : [];
@@ -481,18 +477,15 @@ function requirePartial(
 }
 
 
-function managedInferenceAccessFromEnv(value: Env): ManagedInferenceAccess | undefined {
-  // SAFETY: Managed-only bindings are optional extensions to the generated standalone Env.
-  const bindings = value as Env & GsvInferenceBindings;
-  if (bindings.MANAGED_INFERENCE_INSTALLATIONS) {
+function managedInferenceAccessFromEnv(value: GatewayEnv): ManagedInferenceAccess | undefined {
+  if (value.MANAGED_INFERENCE_INSTALLATIONS) {
     return {
       kind: "installations",
-      installations: bindings.MANAGED_INFERENCE_INSTALLATIONS,
+      installations: value.MANAGED_INFERENCE_INSTALLATIONS,
     };
   }
-  // SAFETY: Managed deployments bind MANAGED_INFERENCE; standalone deployments omit it.
-  return bindings.MANAGED_INFERENCE
-    ? { kind: "service", service: bindings.MANAGED_INFERENCE }
+  return value.MANAGED_INFERENCE
+    ? { kind: "service", service: value.MANAGED_INFERENCE }
     : undefined;
 }
 

--- a/gateway/src/installation/routing.ts
+++ b/gateway/src/installation/routing.ts
@@ -4,13 +4,13 @@ import type {
   ManagedInstallationState,
 } from "@humansandmachines/gsv/protocol";
 import type { InstallationDirectoryService } from "@humansandmachines/gsv/services/directory";
-import type { InstallationOnboardingService } from "@humansandmachines/gsv/services/onboarding";
 import type { Kernel } from "../kernel/do";
 import {
   SINGLETON_INSTALLATION_ID,
   parseInstallationId,
   parseManagedInstallationId,
 } from "./identity";
+import type { GatewayEnv } from "../runtime-env";
 
 const PROCESS_DURABLE_OBJECT_PREFIX = "process:";
 const CONVERSATION_DURABLE_OBJECT_PREFIX = "conversation:";
@@ -158,9 +158,7 @@ function assertDurableObjectNameLength(name: string): void {
 function getGatewayInstallationRoutingSource(
   request: Request,
 ) {
-  // SAFETY: deployment variants expose these optional bindings through the
-  // generated Env shape only when present; access remains feature-gated below.
-  const bindings = env as Env & GatewayInstallationBindings;
+  const bindings: GatewayEnv = env;
   if (bindings.INSTALLATION_DIRECTORY) {
     return {
       kind: "multi" as const,
@@ -229,9 +227,3 @@ export async function getKernelByInstallationId(
 
 // TODO: this should move to wherever we put an actual implementation for it
 export type { InstallationDirectoryResult, InstallationDirectoryService };
-
-export type GatewayInstallationBindings = {
-  INSTALLATION_DIRECTORY?: InstallationDirectoryService & InstallationOnboardingService;
-  MANAGED_MAIL_OUTBOUND?: Queue<import("@humansandmachines/gsv/protocol").ManagedOutboundMailCommand>;
-  GSV_CANONICAL_ORIGIN?: string;
-};

--- a/gateway/src/kernel/adapter-handlers.ts
+++ b/gateway/src/kernel/adapter-handlers.ts
@@ -63,6 +63,7 @@ import {
   validateAdapterMediaBody,
 } from "@humansandmachines/gsv/protocol";
 import { adapterServiceDescriptorSchema } from "@humansandmachines/gsv/services/adapters";
+import { emitTelemetry } from "@humansandmachines/gsv/telemetry";
 import type {
   AdapterTargetCancelResult,
   AdapterTargetDescriptor,
@@ -70,6 +71,7 @@ import type {
 } from "@humansandmachines/gsv/services/adapters";
 import * as z from "zod/mini";
 import { resolveCallerOwnerUid, type KernelContext } from "./context";
+import type { GatewayEnv } from "../runtime-env";
 import type { RequestFrame } from "../protocol/frames";
 import type {
   ProcessAdapterDeliverRequestFrame,
@@ -149,7 +151,10 @@ export type AdapterServiceBinding = Fetcher
   & Partial<AdapterWorkerInterface>
   & Partial<AdapterPairingWorkerInterface>
   & Partial<LegacyStandaloneAdapterService>;
-type AdapterBindingEnv = Env & Record<`CHANNEL_${string}`, AdapterServiceBinding | undefined>;
+type AdapterBindingEnv = GatewayEnv & Record<
+  `CHANNEL_${string}`,
+  AdapterServiceBinding | undefined
+>;
 const adapterStatusListSchema = z.array(adapterAccountStatusSchema);
 type AdapterCommandResult = {
   handled: boolean;
@@ -353,7 +358,10 @@ function adapterSendBoundaryError(args: AdapterSendArgs): string | null {
   return null;
 }
 
-export function resolveAdapterService(env: Env, adapter: string): AdapterServiceBinding | null {
+export function resolveAdapterService(
+  env: GatewayEnv,
+  adapter: string,
+): AdapterServiceBinding | null {
   const key: `CHANNEL_${string}` = `CHANNEL_${adapter.trim().toUpperCase()}`;
   // SAFETY: CHANNEL_* is the Wrangler service-binding namespace for adapters.
   return (env as AdapterBindingEnv)[key] ?? null;
@@ -895,6 +903,55 @@ async function deliverAdapterMessage(
   ctx: KernelContext,
   body?: BinaryBody,
 ): Promise<AdapterSendResult> {
+  const startedAt = Date.now();
+  try {
+    const result = await deliverAdapterMessageOwned(args, ctx, body);
+    emitTelemetry(ctx.env, {
+      installationId: ctx.installationId,
+      component: "gateway",
+      event: {
+        stream: "operational",
+        name: "adapter.delivery.finished",
+        properties: {
+          adapter: args.adapter.trim().toLowerCase(),
+          outcome: result.ok
+            ? result.deliveryState ?? "sent"
+            : result.retryable
+              ? "retryable_error"
+              : "rejected",
+          hasMedia: Boolean(args.media?.length),
+          durationMs: Math.max(0, Date.now() - startedAt),
+        },
+      },
+    });
+    return result;
+  } catch (error) {
+    emitTelemetry(ctx.env, {
+      installationId: ctx.installationId,
+      component: "gateway",
+      event: {
+        stream: "operational",
+        name: "adapter.delivery.finished",
+        properties: {
+          adapter: args.adapter.trim().toLowerCase(),
+          outcome: "error",
+          hasMedia: Boolean(args.media?.length),
+          durationMs: Math.max(0, Date.now() - startedAt),
+        },
+      },
+    });
+    throw error;
+  }
+}
+
+async function deliverAdapterMessageOwned(
+  args: Pick<AdapterSendArgs, "adapter" | "accountId" | "deliveryId" | "surface" | "text" | "media" | "replyToId"> & {
+    actorId?: string;
+    routeGeneration?: string;
+  },
+  ctx: KernelContext,
+  body?: BinaryBody,
+): Promise<AdapterSendResult> {
   const adapter = args.adapter.trim().toLowerCase();
   const accountId = args.accountId.trim();
 
@@ -1288,8 +1345,52 @@ export async function handleAdapterInbound(
   ctx: KernelContext,
   body?: BinaryBody,
 ): Promise<AdapterInboundSyscallResult> {
+  const startedAt = Date.now();
   try {
-    return await handleAdapterInboundOwned(args, ctx, body);
+    const result = await handleAdapterInboundOwned(args, ctx, body);
+    emitTelemetry(ctx.env, {
+      installationId: ctx.installationId,
+      component: "gateway",
+      event: {
+        stream: "operational",
+        name: "adapter.ingress.finished",
+        properties: {
+          adapter: args.adapter.trim().toLowerCase(),
+          outcome: !result.ok
+            ? "error"
+            : result.replayed
+              ? "replayed"
+              : result.delivered
+                ? "delivered"
+                : result.challenge
+                  ? "challenge"
+                  : result.reply
+                    ? "handled"
+                    : "dropped",
+          surface: args.message.surface.kind,
+          hasMedia: Boolean(args.message.media?.length),
+          durationMs: Math.max(0, Date.now() - startedAt),
+        },
+      },
+    });
+    return result;
+  } catch (error) {
+    emitTelemetry(ctx.env, {
+      installationId: ctx.installationId,
+      component: "gateway",
+      event: {
+        stream: "operational",
+        name: "adapter.ingress.finished",
+        properties: {
+          adapter: args.adapter.trim().toLowerCase(),
+          outcome: "error",
+          surface: args.message.surface.kind,
+          hasMedia: Boolean(args.message.media?.length),
+          durationMs: Math.max(0, Date.now() - startedAt),
+        },
+      },
+    });
+    throw error;
   } finally {
     await cancelBinaryBody(body, "adapter.inbound completed");
   }
@@ -2305,7 +2406,7 @@ function adapterAccountStatusFromRecord(status: AdapterStatusRecord): AdapterAcc
 }
 
 export async function setAdapterActivityForKernel(
-  env: Env,
+  env: GatewayEnv,
   installationId: KernelContext["installationId"],
   adapter: string,
   accountId: string,

--- a/gateway/src/kernel/connect.ts
+++ b/gateway/src/kernel/connect.ts
@@ -112,8 +112,7 @@ export async function handleConnect(
   await ensureKernelBootstrapped(ctx);
 
   if (auth.isSetupMode()) {
-    // SAFETY: the Workers environment may expose the managed installation binding at runtime.
-    if ((ctx.env as Env & { INSTALLATION_DIRECTORY?: unknown }).INSTALLATION_DIRECTORY) {
+    if (ctx.env.INSTALLATION_DIRECTORY) {
       return {
         ok: false,
         code: 503,

--- a/gateway/src/kernel/context.ts
+++ b/gateway/src/kernel/context.ts
@@ -38,9 +38,10 @@ import type { KernelConnection, KernelConnectionState } from "./connection";
 import type { PeerContext } from "./peer";
 import type { RequestFrame, ResponseFrame } from "../protocol/frames";
 import type { ConnectionIdentity } from "./identity";
+import type { GatewayEnv } from "../runtime-env";
 
 export type KernelContext = {
-  env: Env;
+  env: GatewayEnv;
   installationId: string;
   installationIdentity: InstallationIdentity | null;
   auth: AuthStore;

--- a/gateway/src/kernel/do.ts
+++ b/gateway/src/kernel/do.ts
@@ -62,8 +62,7 @@ import type {
   ConversationMessageOrigin,
   FederationDeliveryReceipt,
 } from "@humansandmachines/gsv/protocol";
-import type { InstallationDirectoryService } from "@humansandmachines/gsv/services/directory";
-import type { InstallationOnboardingService } from "@humansandmachines/gsv/services/onboarding";
+import { emitTelemetry } from "@humansandmachines/gsv/telemetry";
 import type { ConnectionIdentity } from "./identity";
 import {
   BinaryBodyChannel,
@@ -210,13 +209,13 @@ import { createInstallationRipgit } from "../installation/ripgit";
 import {
   MANAGED_LIFECYCLE_RECHECK_MS,
   managedInstallationWorkGate,
-  type ManagedInstallationLifecycleBindings,
 } from "../installation/lifecycle";
 import {
   DurableTaskScheduler,
   type DurableTask,
   type DurableTaskOptions,
 } from "../shared/durable-tasks";
+import type { GatewayEnv } from "../runtime-env";
 import {
   acceptKernelWebSocket,
   KernelConnection,
@@ -618,11 +617,11 @@ type UserProcessSignalFrame = z.infer<typeof userProcessSignalFrameSchema>;
 
 const MANAGED_ONBOARDING_COMPLETION_KEY = "managed_onboarding_completion";
 
-export class Kernel extends DurableObject<Env> {
+export class Kernel extends DurableObject<GatewayEnv> {
   private readonly installationId: string;
   private installationIdentity?: InstallationIdentity;
   private readonly installationStorage: R2Bucket;
-  private readonly installationEnv: Env;
+  private readonly installationEnv: GatewayEnv;
   private readonly auth: AuthStore;
   private readonly caps: CapabilityStore;
   private readonly config: ConfigStore;
@@ -669,7 +668,7 @@ export class Kernel extends DurableObject<Env> {
     { expiresAt: number; reason: string }
   >();
 
-  constructor(ctx: DurableObjectState, env: Env) {
+  constructor(ctx: DurableObjectState, env: GatewayEnv) {
     super(ctx, env);
     this.installationId = parseInstallationId(ctx.id.name);
     const sql = ctx.storage.sql;
@@ -1309,6 +1308,24 @@ export class Kernel extends DurableObject<Env> {
     if (route?.uid !== process.ownerUid || route?.processId !== processId) {
       if (route) this.runRoutes.delete(args.runId);
       route = null;
+    }
+    if (appended.created && conversation.kind === "ship") {
+      emitTelemetry(this.bindings, {
+        installationId: this.installationId,
+        component: "gateway",
+        event: {
+          stream: "product",
+          name: "ship.message.committed",
+          properties: {
+            delivery: route?.kind === "connection"
+              ? "client"
+              : route?.kind === "adapter"
+                ? "adapter"
+                : "background",
+            hasMedia: Boolean(message.media?.length),
+          },
+        },
+      });
     }
     if (route?.kind === "connection") {
       this.sendSignalToConnection(route.connectionId, "message.committed", {
@@ -2711,7 +2728,7 @@ export class Kernel extends DurableObject<Env> {
     };
   }
 
-  private get bindings(): Env {
+  private get bindings(): GatewayEnv {
     return this.installationEnv ?? this.env;
   }
 
@@ -3275,13 +3292,14 @@ export class Kernel extends DurableObject<Env> {
       return;
     }
 
-    const eventType = call.status === "timed_out"
-      ? "process.delegation.timed_out"
+    const outcome = call.status === "timed_out"
+      ? "timed_out"
       : call.error?.toLowerCase().includes("killed")
-        ? "process.delegation.killed"
+        ? "killed"
         : call.error
-          ? "process.delegation.failed"
-          : "process.delegation.completed";
+          ? "failed"
+          : "completed";
+    const eventType = `process.delegation.${outcome}`;
     const completedAtMs = Date.now();
     const delegation: JsonObject = {
       eventType,
@@ -3293,7 +3311,7 @@ export class Kernel extends DurableObject<Env> {
     };
     if (call.sourceRunId) delegation.sourceRunId = call.sourceRunId;
     if (call.error) delegation.error = call.error.slice(0, 2_000);
-    this.responsibilities.update({
+    const updated = this.responsibilities.update({
       ownerUid: call.ownerUid,
       id: current.id,
       expectedRevision: current.revision,
@@ -3316,6 +3334,29 @@ export class Kernel extends DurableObject<Env> {
       observedByShip: false,
       now: completedAtMs,
     });
+    if (updated.changed) {
+      const durationMs = Math.max(0, completedAtMs - call.createdAt);
+      emitTelemetry(this.bindings, {
+        installationId: this.installationId,
+        component: "gateway",
+        event: {
+          stream: "operational",
+          name: "delegation.finished",
+          properties: { outcome, durationMs },
+        },
+      });
+      if (outcome === "completed") {
+        emitTelemetry(this.bindings, {
+          installationId: this.installationId,
+          component: "gateway",
+          event: {
+            stream: "product",
+            name: "delegation.completed",
+            properties: { durationMs },
+          },
+        });
+      }
+    }
     this.ctx.waitUntil(this.reconcileResponsibilityWake(call.ownerUid).catch((error) => {
       console.warn("[Kernel] Failed to schedule delegated responsibility return:", error);
     }));
@@ -3695,6 +3736,19 @@ export class Kernel extends DurableObject<Env> {
 
     if (outcome.newMachine) {
       await recordMachineAddedResponsibility(outcome.newMachine, ctx);
+      emitTelemetry(this.bindings, {
+        installationId: this.installationId,
+        component: "gateway",
+        event: {
+          stream: "product",
+          name: "target.connected",
+          properties: {
+            targetKind: outcome.newMachine.platform.toLowerCase().includes("browser")
+              ? "browser"
+              : "machine",
+          },
+        },
+      });
     }
 
     const clientId = frame.args.peer.id.trim();
@@ -4013,19 +4067,13 @@ export class Kernel extends DurableObject<Env> {
     return data;
   }
 
-  private managedOnboardingService(): (
-    InstallationDirectoryService & InstallationOnboardingService
-  ) | null {
-    // SAFETY: managed deployments add this service binding to Wrangler's Env contract.
-    return (this.env as Env & {
-      INSTALLATION_DIRECTORY?: InstallationDirectoryService & InstallationOnboardingService;
-    }).INSTALLATION_DIRECTORY ?? null;
+  private managedOnboardingService(): GatewayEnv["INSTALLATION_DIRECTORY"] | null {
+    return this.env.INSTALLATION_DIRECTORY ?? null;
   }
 
   private async managedWorkGate() {
-    // SAFETY: managed deployments add lifecycle bindings to Wrangler's Env contract.
     return await managedInstallationWorkGate(
-      this.env as Env & ManagedInstallationLifecycleBindings,
+      this.env,
       this.installationId,
     );
   }
@@ -5260,16 +5308,16 @@ function shellStatusFromEvent(event: string): ShellSessionStatus {
 }
 
 function envWithInstallationResources(
-  env: Env,
+  env: GatewayEnv,
   storage: R2Bucket,
   ripgit: Fetcher | undefined,
-): Env {
+): GatewayEnv {
   return new Proxy(env, {
     get(target, property) {
       if (property === "STORAGE") return storage;
       if (property === "RIPGIT") return ripgit;
       // SAFETY: Proxy keys outside these overrides are ordinary Env properties.
-      return target[property as keyof Env];
+      return target[property as keyof GatewayEnv];
     },
   });
 }

--- a/gateway/src/kernel/lifecycle-responsibilities.ts
+++ b/gateway/src/kernel/lifecycle-responsibilities.ts
@@ -3,6 +3,7 @@ import type { DeviceRecord } from "./devices";
 import type { AdapterStatusRecord } from "./adapter-status";
 import type { FederationContactRecord } from "./federation-store";
 import { stableOpaqueId } from "../shared/stable-id";
+import { emitTelemetry } from "@humansandmachines/gsv/telemetry";
 
 type AdapterTransitionOptions = {
   suppressAuthenticationRequired?: boolean;
@@ -181,6 +182,15 @@ export function recordAdapterStatusTransition(
       changed ||= outcome.created;
     }
     ctx.adapters.status.markReadyForOwner(current.adapter, current.accountId, ownerUid);
+    emitTelemetry(ctx.env, {
+      installationId: ctx.installationId,
+      component: "gateway",
+      event: {
+        stream: "product",
+        name: "adapter.connected",
+        properties: { adapter: current.adapter.trim().toLowerCase() },
+      },
+    });
   }
 
   const authenticationLost = previous?.ownerUid === ownerUid

--- a/gateway/src/kernel/outbound-mail.ts
+++ b/gateway/src/kernel/outbound-mail.ts
@@ -25,10 +25,6 @@ const OUTBOUND_ENQUEUE_RETRY_BASE_MS = 5_000;
 const OUTBOUND_ENQUEUE_RETRY_MAX_MS = 60 * 60 * 1_000;
 const TEXT_ENCODER = new TextEncoder();
 
-type ManagedOutboundBindings = {
-  MANAGED_MAIL_OUTBOUND?: Queue<ManagedOutboundMailCommand>;
-};
-
 type NormalizedMailSend = {
   deliveryId: string;
   text: string;
@@ -630,9 +626,7 @@ function containsAsciiControl(value: string): boolean {
 }
 
 function managedOutboundQueue(ctx: KernelContext): Queue<ManagedOutboundMailCommand> | undefined {
-  // SAFETY: managed mail deployment adds this optional binding to the shared
-  // Gateway Env; its absence is the supported standalone configuration.
-  return (ctx.env as Env & ManagedOutboundBindings).MANAGED_MAIL_OUTBOUND;
+  return ctx.env.MANAGED_MAIL_OUTBOUND;
 }
 
 class MailSendError extends Error {

--- a/gateway/src/managed-development.ts
+++ b/gateway/src/managed-development.ts
@@ -1,8 +1,9 @@
 import gateway from "./index";
+import type { GatewayEnv } from "./runtime-env";
 
 export * from "./index";
 
-type ManagedDevelopmentEnv = Env & {
+type ManagedDevelopmentEnv = GatewayEnv & {
   ACCOUNT_HTTP: Fetcher;
   GSV_ACCOUNT_ORIGIN: string;
 };

--- a/gateway/src/process/do.ts
+++ b/gateway/src/process/do.ts
@@ -98,6 +98,10 @@ import type {
 } from "@humansandmachines/gsv/protocol";
 import { responsibilityRequiresAction } from "@humansandmachines/gsv/protocol";
 import {
+  emitTelemetry,
+  type TelemetryEvent,
+} from "@humansandmachines/gsv/telemetry";
+import {
   jsonObjectSchema,
   jsonValueSchema,
   resourceBlockSchema,
@@ -291,15 +295,32 @@ import { createInstallationRipgit } from "../installation/ripgit";
 import {
   MANAGED_LIFECYCLE_RECHECK_MS,
   managedInstallationWorkGate,
-  type ManagedInstallationLifecycleBindings,
 } from "../installation/lifecycle";
-
-type ProcessEnv = Env & ManagedInstallationLifecycleBindings;
+import type { GatewayEnv } from "../runtime-env";
 
 type ResponsibilityBatchState = {
   batchId: string;
   responsibilityIds: string[];
 };
+
+type HistoryCompactionOptions = {
+  allowActive?: boolean;
+  reason?: string;
+  activeRunId?: string;
+  signal?: AbortSignal;
+  telemetryTrigger?: "manual" | "auto-preflight" | "auto-provider-overflow";
+  contextPressure?: number;
+};
+
+type CompactionTelemetryProperties = Extract<
+  TelemetryEvent,
+  { name: "process.compaction.completed" }
+>["properties"];
+
+type RunFinishedTelemetryProperties = Extract<
+  TelemetryEvent,
+  { name: "process.run.finished" }
+>["properties"];
 
 type RunState = {
   runId: string;
@@ -1924,7 +1945,7 @@ const PROCESS_TASK_SCHEMA = z.discriminatedUnion("callback", [
   }),
 ]);
 
-export class Process extends DurableObject<ProcessEnv> {
+export class Process extends DurableObject<GatewayEnv> {
   readonly installationId: string;
   readonly pid: string;
   private readonly store: ProcessStore;
@@ -1951,7 +1972,7 @@ export class Process extends DurableObject<ProcessEnv> {
   private killedTombstone: ProcessKilledTombstone | null = null;
   private killedCleanupTransition: Promise<Extract<ProcKillResult, { ok: true }>> | null = null;
 
-  constructor(ctx: DurableObjectState, env: ProcessEnv) {
+  constructor(ctx: DurableObjectState, env: GatewayEnv) {
     super(ctx, env);
     const gsvInference = gsvInferenceProviderFactoryFromEnv(env);
     this.generation = createGenerationService(
@@ -4119,13 +4140,9 @@ export class Process extends DurableObject<ProcessEnv> {
 
   private async handleHistoryCompact(
     args: ProcHistoryCompactArgs,
-    options: {
-      allowActive?: boolean;
-      reason?: string;
-      activeRunId?: string;
-      signal?: AbortSignal;
-    } = {},
+    options: HistoryCompactionOptions = {},
   ): Promise<ProcHistoryCompactResult> {
+    const telemetryStartedAt = Date.now();
     const pid = this.pid;
     const explicitSummary = normalizeOptionalString(args.summary);
     const generateSummary = args.generateSummary === true;
@@ -4358,6 +4375,24 @@ export class Process extends DurableObject<ProcessEnv> {
       lifecycleEvent.reason = options.reason;
     }
     await this.emitProcessLifecycle(lifecycleEvent);
+
+    const telemetryProperties: CompactionTelemetryProperties = {
+      trigger: options.telemetryTrigger ?? "manual",
+      durationMs: Math.max(0, Date.now() - telemetryStartedAt),
+      archivedMessages: selected.length,
+    };
+    if (options.contextPressure !== undefined) {
+      telemetryProperties.contextPressure = options.contextPressure;
+    }
+    emitTelemetry(this.env, {
+      installationId: this.installationId,
+      component: "gateway",
+      event: {
+        stream: "operational",
+        name: "process.compaction.completed",
+        properties: telemetryProperties,
+      },
+    });
 
     return {
       ok: true,
@@ -7763,16 +7798,21 @@ export class Process extends DurableObject<ProcessEnv> {
       return "stopped";
     }
 
+    const compactionOptions: HistoryCompactionOptions = {
+      allowActive: true,
+      reason: "auto-compact",
+      activeRunId: runId,
+      telemetryTrigger: trigger === "preflight"
+        ? "auto-preflight"
+        : "auto-provider-overflow",
+    };
+    if (pressure !== null) compactionOptions.contextPressure = pressure;
     const result = await this.handleHistoryCompact(
       {
         throughMessageId: selected.at(-1)!.id,
         generateSummary: true,
       },
-      {
-        allowActive: true,
-        reason: "auto-compact",
-        activeRunId: runId,
-      },
+      compactionOptions,
     );
     if (this.handleRunStopped(runId)) {
       return "stopped";
@@ -8983,6 +9023,7 @@ export class Process extends DurableObject<ProcessEnv> {
       }));
     }
     const payload = this.runFinishedPayload(run, options);
+    const startedAt = this.store.getRunTraceStartedAt(run.runId);
     this.store.finishRunTrace(
       run.runId,
       payload.status === "ok" ? "ok" : payload.status === "error" ? "error" : "aborted",
@@ -8997,9 +9038,39 @@ export class Process extends DurableObject<ProcessEnv> {
       payload.timestamp,
     );
     const pending = this.pendingRunFinishes();
-    if (!pending.some((finish) => finish.runId === run.runId)) {
+    const newlyFinished = !pending.some((finish) => finish.runId === run.runId);
+    if (newlyFinished) {
       pending.push(payload);
       this.store.setValue(PENDING_RUN_FINISHES_KEY, JSON.stringify(pending));
+      const telemetryProperties: RunFinishedTelemetryProperties = {
+        outcome: payload.status,
+        durationMs: Math.max(
+          0,
+          payload.timestamp - (startedAt ?? payload.timestamp),
+        ),
+        runKind: run.returnToCaller
+          ? "ipc"
+          : run.conversationId
+            ? "interactive"
+            : "background",
+        delivery: payload.delivery.kind,
+        queued: payload.queuedCount > 0,
+      };
+      if (payload.usage) {
+        telemetryProperties.inputTokens = payload.usage.input;
+        telemetryProperties.outputTokens = payload.usage.output;
+        telemetryProperties.cacheReadTokens = payload.usage.cacheRead;
+        telemetryProperties.cacheWriteTokens = payload.usage.cacheWrite;
+      }
+      emitTelemetry(this.env, {
+        installationId: this.installationId,
+        component: "gateway",
+        event: {
+          stream: "operational",
+          name: "process.run.finished",
+          properties: telemetryProperties,
+        },
+      });
     }
     this.ctx.waitUntil(this.onRunFinishDelivery(run.runId));
   }

--- a/gateway/src/process/store.test.ts
+++ b/gateway/src/process/store.test.ts
@@ -594,6 +594,8 @@ describe("ProcessStore", () => {
         store.finishTraceSpan("context:trace-run", "ok", 140, {
           attributes: { messages: 3 },
         });
+        expect(store.getRunTraceStartedAt("trace-run")).toBe(100);
+        expect(store.getRunTraceStartedAt("missing-run")).toBeNull();
         store.register("dispatch-1", "call-1", "trace-run", "fs.read", {
           path: "/work/readme.md",
         });

--- a/gateway/src/process/store.ts
+++ b/gateway/src/process/store.ts
@@ -487,6 +487,16 @@ export class ProcessStore {
     this.pruneTraceRuns();
   }
 
+  getRunTraceStartedAt(runId: string): number | null {
+    return this.sql.exec<{ started_at: number }>(
+      `SELECT started_at FROM process_trace_spans
+       WHERE span_id = ? AND run_id = ? AND kind = 'run'
+       LIMIT 1`,
+      `run:${runId}`,
+      runId,
+    ).toArray()[0]?.started_at ?? null;
+  }
+
   listTraceSpans(options: { runId?: string; limit: number }): ProcessTraceSpanList {
     const filter = options.runId ? "WHERE run_id = ?" : "";
     const args = options.runId ? [options.runId] : [];

--- a/gateway/src/runtime-env.ts
+++ b/gateway/src/runtime-env.ts
@@ -1,0 +1,19 @@
+import type { ManagedOutboundMailCommand } from "@humansandmachines/gsv/protocol";
+import type { InstallationDirectoryService } from "@humansandmachines/gsv/services/directory";
+import type { InferenceService } from "@humansandmachines/gsv/services/inference";
+import type { InstallationOnboardingService } from "@humansandmachines/gsv/services/onboarding";
+import type { TelemetryEnvironment } from "@humansandmachines/gsv/telemetry";
+
+/**
+ * Wrangler generates `Env` from the standalone Gateway configuration. Managed
+ * deployments add these optional bindings through the deployment runtime.
+ */
+type GatewayDeploymentBindings = TelemetryEnvironment & {
+  INSTALLATION_DIRECTORY?: InstallationDirectoryService & InstallationOnboardingService;
+  MANAGED_INFERENCE?: InferenceService;
+  MANAGED_INFERENCE_INSTALLATIONS?: DurableObjectNamespace;
+  MANAGED_MAIL_OUTBOUND?: Queue<ManagedOutboundMailCommand>;
+  GSV_CANONICAL_ORIGIN?: string;
+};
+
+export type GatewayEnv = Env & GatewayDeploymentBindings;

--- a/packages/gsv/package.json
+++ b/packages/gsv/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/services/*.d.ts",
       "default": "./dist/services/*.js"
     },
+    "./telemetry": {
+      "types": "./dist/telemetry.d.ts",
+      "default": "./dist/telemetry.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/gsv/src/index.ts
+++ b/packages/gsv/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./protocol";
 export * from "./client";
+export * from "./telemetry";

--- a/packages/gsv/src/telemetry.ts
+++ b/packages/gsv/src/telemetry.ts
@@ -1,0 +1,245 @@
+import * as z from "zod/mini";
+
+export const GSV_TELEMETRY_MARKER = "gsv.telemetry";
+export const GSV_TELEMETRY_VERSION = 1;
+
+const installationIdSchema = z.string().check(
+  z.regex(/^[A-Za-z0-9](?:[A-Za-z0-9._:-]{0,126}[A-Za-z0-9])?$/),
+);
+const nonNegativeIntegerSchema = z.number().check(z.int(), z.nonnegative());
+const nonNegativeNumberSchema = z.number().check(z.nonnegative());
+const adapterNameSchema = z.string().check(
+  z.minLength(1),
+  z.maxLength(64),
+  z.regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/),
+);
+const modelNameSchema = z.string().check(
+  z.minLength(1),
+  z.maxLength(200),
+  z.regex(/^@?[A-Za-z0-9][A-Za-z0-9._:/-]*$/),
+);
+
+export const telemetryComponentSchema = z.enum([
+  "gateway",
+  "accounts",
+  "inference",
+]);
+
+const processRunFinishedSchema = z.strictObject({
+  stream: z.literal("operational"),
+  name: z.literal("process.run.finished"),
+  properties: z.strictObject({
+    outcome: z.enum(["ok", "error", "aborted"]),
+    durationMs: nonNegativeIntegerSchema,
+    runKind: z.enum(["interactive", "background", "ipc"]),
+    delivery: z.enum(["message", "silence", "none"]),
+    queued: z.boolean(),
+    inputTokens: z.optional(nonNegativeIntegerSchema),
+    outputTokens: z.optional(nonNegativeIntegerSchema),
+    cacheReadTokens: z.optional(nonNegativeIntegerSchema),
+    cacheWriteTokens: z.optional(nonNegativeIntegerSchema),
+  }),
+});
+
+const processCompactionCompletedSchema = z.strictObject({
+  stream: z.literal("operational"),
+  name: z.literal("process.compaction.completed"),
+  properties: z.strictObject({
+    trigger: z.enum([
+      "manual",
+      "auto-preflight",
+      "auto-provider-overflow",
+    ]),
+    durationMs: nonNegativeIntegerSchema,
+    archivedMessages: nonNegativeIntegerSchema,
+    contextPressure: z.optional(nonNegativeNumberSchema),
+  }),
+});
+
+const adapterIngressFinishedSchema = z.strictObject({
+  stream: z.literal("operational"),
+  name: z.literal("adapter.ingress.finished"),
+  properties: z.strictObject({
+    adapter: adapterNameSchema,
+    outcome: z.enum([
+      "delivered",
+      "dropped",
+      "challenge",
+      "handled",
+      "replayed",
+      "error",
+    ]),
+    surface: z.enum(["dm", "group", "channel", "thread"]),
+    hasMedia: z.boolean(),
+    durationMs: nonNegativeIntegerSchema,
+  }),
+});
+
+const adapterDeliveryFinishedSchema = z.strictObject({
+  stream: z.literal("operational"),
+  name: z.literal("adapter.delivery.finished"),
+  properties: z.strictObject({
+    adapter: adapterNameSchema,
+    outcome: z.enum([
+      "sent",
+      "deduplicated",
+      "ambiguous",
+      "retryable_error",
+      "rejected",
+      "error",
+    ]),
+    hasMedia: z.boolean(),
+    durationMs: nonNegativeIntegerSchema,
+  }),
+});
+
+const delegationFinishedSchema = z.strictObject({
+  stream: z.literal("operational"),
+  name: z.literal("delegation.finished"),
+  properties: z.strictObject({
+    outcome: z.enum(["completed", "failed", "timed_out", "killed"]),
+    durationMs: nonNegativeIntegerSchema,
+  }),
+});
+
+const inferenceRequestFinishedSchema = z.strictObject({
+  stream: z.literal("operational"),
+  name: z.literal("inference.request.finished"),
+  properties: z.strictObject({
+    outcome: z.enum(["completed", "failed", "aborted", "abandoned"]),
+    purpose: z.enum(["agent", "mail-intake"]),
+    provider: z.literal("workers-ai"),
+    model: z.optional(modelNameSchema),
+    stopReason: z.optional(z.enum([
+      "stop",
+      "length",
+      "toolUse",
+      "error",
+      "aborted",
+    ])),
+    durationMs: nonNegativeIntegerSchema,
+    inputTokens: nonNegativeIntegerSchema,
+    outputTokens: nonNegativeIntegerSchema,
+    cacheReadTokens: nonNegativeIntegerSchema,
+    cacheWriteTokens: nonNegativeIntegerSchema,
+    totalTokens: nonNegativeIntegerSchema,
+    costNanoUsd: nonNegativeIntegerSchema,
+  }),
+});
+
+const installationActivatedSchema = z.strictObject({
+  stream: z.literal("product"),
+  name: z.literal("installation.activated"),
+  properties: z.strictObject({}),
+});
+
+const shipMessageCommittedSchema = z.strictObject({
+  stream: z.literal("product"),
+  name: z.literal("ship.message.committed"),
+  properties: z.strictObject({
+    delivery: z.enum(["client", "adapter", "background"]),
+    hasMedia: z.boolean(),
+  }),
+});
+
+const targetConnectedSchema = z.strictObject({
+  stream: z.literal("product"),
+  name: z.literal("target.connected"),
+  properties: z.strictObject({
+    targetKind: z.enum(["machine", "browser"]),
+  }),
+});
+
+const adapterConnectedSchema = z.strictObject({
+  stream: z.literal("product"),
+  name: z.literal("adapter.connected"),
+  properties: z.strictObject({
+    adapter: adapterNameSchema,
+  }),
+});
+
+const delegationCompletedSchema = z.strictObject({
+  stream: z.literal("product"),
+  name: z.literal("delegation.completed"),
+  properties: z.strictObject({
+    durationMs: nonNegativeIntegerSchema,
+  }),
+});
+
+export const telemetryEventSchema = z.discriminatedUnion("name", [
+  processRunFinishedSchema,
+  processCompactionCompletedSchema,
+  adapterIngressFinishedSchema,
+  adapterDeliveryFinishedSchema,
+  delegationFinishedSchema,
+  inferenceRequestFinishedSchema,
+  installationActivatedSchema,
+  shipMessageCommittedSchema,
+  targetConnectedSchema,
+  adapterConnectedSchema,
+  delegationCompletedSchema,
+]);
+
+export const telemetryRecordSchema = z.strictObject({
+  marker: z.literal(GSV_TELEMETRY_MARKER),
+  version: z.literal(GSV_TELEMETRY_VERSION),
+  eventId: z.string().check(z.uuid()),
+  occurredAt: nonNegativeIntegerSchema,
+  installationId: installationIdSchema,
+  component: telemetryComponentSchema,
+  event: telemetryEventSchema,
+});
+
+export type TelemetryComponent = z.infer<typeof telemetryComponentSchema>;
+export type TelemetryEvent = z.infer<typeof telemetryEventSchema>;
+export type TelemetryRecord = z.infer<typeof telemetryRecordSchema>;
+
+export type TelemetryEnvironment = {
+  GSV_TELEMETRY_ENABLED?: boolean | number | string;
+};
+
+export type TelemetryRecordInput = {
+  installationId: string;
+  component: TelemetryComponent;
+  event: TelemetryEvent;
+};
+
+export function telemetryEnabled(
+  env: TelemetryEnvironment | undefined,
+): boolean {
+  if (!env) return false;
+  const enabled = env.GSV_TELEMETRY_ENABLED;
+  return enabled === true || enabled === 1 || enabled === "1";
+}
+
+export function createTelemetryRecord(
+  input: TelemetryRecordInput,
+  occurredAt = Date.now(),
+  eventId = crypto.randomUUID(),
+): TelemetryRecord {
+  return telemetryRecordSchema.parse({
+    marker: GSV_TELEMETRY_MARKER,
+    version: GSV_TELEMETRY_VERSION,
+    eventId,
+    occurredAt,
+    ...input,
+  });
+}
+
+/**
+ * Emit one provider-neutral record for an optional deployment-owned consumer.
+ * Telemetry is failure-isolated: a malformed record never affects user work.
+ */
+export function emitTelemetry(
+  env: TelemetryEnvironment | undefined,
+  input: TelemetryRecordInput,
+): boolean {
+  if (!telemetryEnabled(env)) return false;
+  try {
+    console.log(createTelemetryRecord(input));
+    return true;
+  } catch {
+    console.warn("[GSV telemetry] Rejected invalid telemetry record");
+    return false;
+  }
+}

--- a/packages/gsv/test/telemetry.test.mjs
+++ b/packages/gsv/test/telemetry.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it, mock } from "node:test";
+
+import {
+  createTelemetryRecord,
+  emitTelemetry,
+  telemetryRecordSchema,
+} from "../dist/telemetry.js";
+
+const INPUT = {
+  installationId: "inst_telemetry",
+  component: "gateway",
+  event: {
+    stream: "product",
+    name: "target.connected",
+    properties: { targetKind: "machine" },
+  },
+};
+
+describe("telemetry contract", () => {
+  it("creates a strict, versioned record", () => {
+    const record = createTelemetryRecord(
+      INPUT,
+      1_789_000_000_000,
+      "11111111-1111-4111-8111-111111111111",
+    );
+
+    assert.deepEqual(record, {
+      marker: "gsv.telemetry",
+      version: 1,
+      eventId: "11111111-1111-4111-8111-111111111111",
+      occurredAt: 1_789_000_000_000,
+      ...INPUT,
+    });
+    assert.equal(telemetryRecordSchema.safeParse(record).success, true);
+    assert.equal(telemetryRecordSchema.safeParse({
+      ...record,
+      event: {
+        ...record.event,
+        properties: { ...record.event.properties, path: "/private" },
+      },
+    }).success, false);
+  });
+
+  it("does nothing unless the deployment explicitly enables telemetry", () => {
+    const log = mock.method(console, "log", () => {});
+    try {
+      assert.equal(emitTelemetry({}, INPUT), false);
+      assert.equal(log.mock.callCount(), 0);
+      assert.equal(emitTelemetry({ GSV_TELEMETRY_ENABLED: "1" }, INPUT), true);
+      assert.equal(log.mock.callCount(), 1);
+    } finally {
+      log.mock.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a strict, versioned telemetry event contract with closed property allowlists
- emit product and operational outcomes at their owning Process, Kernel, adapter, and Conversation boundaries
- keep self-hosted telemetry disabled unless a deployment explicitly attaches a consumer
- disable producer log persistence and traces when the telemetry transport is enabled

## Privacy

The contract has no arbitrary metadata bag and excludes prompts, messages, paths, URLs, tool arguments, credentials, contact identifiers, and raw exceptions. A deployment consumer receives the installation ID only to derive a pseudonym.

## Validation

- public SDK: 73 tests passed
- Gateway TypeScript check passed
- targeted Process/store/Kernel/adapter suites passed
- Gateway integration: 32 tests passed
- full Gateway unit run: 1,680/1,683 passed; three load-sensitive timeout cases each passed when rerun in isolation
- deployment TypeScript check passed