### PR TITLE
drain binary body bursts

### DIFF
--- a/docs/reference/websocket-protocol.md
+++ b/docs/reference/websocket-protocol.md
@@ -468,6 +468,13 @@ the `request.cancel` control signal above. The two mechanisms are independent:
 a request may have no body, and a completed request may leave a response body
 that its consumer can still cancel.
 
+A WebSocket may expose several already-buffered data frames without an I/O
+wait between them. Receiver pumps must give the registered body owner a chance
+to drain its bounded queue between those frames; transport scheduling alone
+must not turn a valid body into a buffer-overflow failure. That cooperation
+must not suspend the connection-wide reader on one body consumer: cancellation,
+unrelated frames, and peer closure must remain readable.
+
 The current body-bearing syscalls are:
 
 | Syscall | Request body | Response body |

--- a/host/apps/machine/src/device/transfer.rs
+++ b/host/apps/machine/src/device/transfer.rs
@@ -309,12 +309,16 @@ mod tests {
             length: Some(4),
         };
         let body = channel.receive(descriptor).unwrap();
-        channel.handle_frame(&build_binary_frame(23, BINARY_FRAME_DATA, &[0, 0xff]));
-        channel.handle_frame(&build_binary_frame(
-            23,
-            BINARY_FRAME_DATA | BINARY_FRAME_END,
-            &[1, 2],
-        ));
+        channel
+            .handle_frame(&build_binary_frame(23, BINARY_FRAME_DATA, &[0, 0xff]))
+            .await;
+        channel
+            .handle_frame(&build_binary_frame(
+                23,
+                BINARY_FRAME_DATA | BINARY_FRAME_END,
+                &[1, 2],
+            ))
+            .await;
 
         let output = handle_receive(
             json!({

--- a/host/crates/gateway-client/src/body.rs
+++ b/host/crates/gateway-client/src/body.rs
@@ -332,7 +332,7 @@ impl BinaryBodyChannel {
         })
     }
 
-    pub fn handle_frame(&self, data: &[u8]) -> bool {
+    pub async fn handle_frame(&self, data: &[u8]) -> bool {
         let Some((stream_id, flags, payload)) = parse_binary_frame(data) else {
             return false;
         };
@@ -369,6 +369,12 @@ impl BinaryBodyChannel {
             .unwrap_or(false);
         if registered {
             self.dispatch_frame(stream_id, flags, payload);
+            // A WebSocket can surface an already-buffered burst without yielding
+            // between frames. Give the body owner a chance to drain its bounded
+            // queue before the connection reads the next ready data frame.
+            if flags & BINARY_FRAME_DATA != 0 {
+                tokio::task::yield_now().await;
+            }
         } else {
             self.buffer_orphan(stream_id, flags, payload);
         }
@@ -888,8 +894,12 @@ mod tests {
     async fn incoming_body_accepts_frames_before_descriptor_registration() {
         let sent = Arc::new(StdMutex::new(Vec::new()));
         let channel = channel(sent);
-        channel.handle_frame(&build_binary_frame(9, BINARY_FRAME_DATA, b"hello"));
-        channel.handle_frame(&build_binary_frame(9, BINARY_FRAME_END, &[]));
+        channel
+            .handle_frame(&build_binary_frame(9, BINARY_FRAME_DATA, b"hello"))
+            .await;
+        channel
+            .handle_frame(&build_binary_frame(9, BINARY_FRAME_END, &[]))
+            .await;
         let body = channel
             .receive(FrameBodyDescriptor {
                 stream_id: 9,
@@ -927,8 +937,12 @@ mod tests {
             })
             .expect("incoming body");
         body.cancel("caller stopped reading");
-        channel.handle_frame(&build_binary_frame(17, BINARY_FRAME_DATA, b"late"));
-        channel.handle_frame(&build_binary_frame(17, BINARY_FRAME_END, &[]));
+        channel
+            .handle_frame(&build_binary_frame(17, BINARY_FRAME_DATA, b"late"))
+            .await;
+        channel
+            .handle_frame(&build_binary_frame(17, BINARY_FRAME_END, &[]))
+            .await;
         {
             let state = channel.state.lock().expect("body state");
             assert!(!state.orphans.contains_key(&17));
@@ -977,7 +991,9 @@ mod tests {
                 length: Some(6),
             })
             .expect("incoming body");
-        channel.handle_frame(&build_binary_frame(19, BINARY_FRAME_DATA, b"one"));
+        channel
+            .handle_frame(&build_binary_frame(19, BINARY_FRAME_DATA, b"one"))
+            .await;
 
         channel.close("transport disconnected");
 
@@ -1038,13 +1054,60 @@ mod tests {
                 length: None,
             })
             .expect("incoming body");
-        channel.handle_frame(&build_binary_frame(11, BINARY_FRAME_DATA, b"one"));
-        channel.handle_frame(&build_binary_frame(11, BINARY_FRAME_DATA, b"two"));
+        channel
+            .handle_frame(&build_binary_frame(11, BINARY_FRAME_DATA, b"one"))
+            .await;
+        channel
+            .handle_frame(&build_binary_frame(11, BINARY_FRAME_DATA, b"two"))
+            .await;
         assert_eq!(
             body.recv().await.expect("first chunk"),
             Some(b"one".to_vec())
         );
         assert!(body.recv().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn registered_body_drains_between_ready_frames() {
+        let sent = Arc::new(StdMutex::new(Vec::new()));
+        let limits = BinaryBodyLimits {
+            max_buffered_frames_per_stream: 1,
+            ..BinaryBodyLimits::default()
+        };
+        let channel = BinaryBodyChannel::new(limits, {
+            let sent = sent.clone();
+            move |frame| {
+                let sent = sent.clone();
+                async move {
+                    sent.lock().expect("sent frames").push(frame);
+                    Ok(())
+                }
+            }
+        })
+        .expect("body channel");
+        let body = channel
+            .receive(FrameBodyDescriptor {
+                stream_id: 12,
+                length: Some(6),
+            })
+            .expect("incoming body");
+        let reading = tokio::spawn(async move { body.read_all(6).await });
+
+        channel
+            .handle_frame(&build_binary_frame(12, BINARY_FRAME_DATA, b"one"))
+            .await;
+        channel
+            .handle_frame(&build_binary_frame(12, BINARY_FRAME_DATA, b"two"))
+            .await;
+        channel
+            .handle_frame(&build_binary_frame(12, BINARY_FRAME_END, &[]))
+            .await;
+
+        assert_eq!(
+            reading.await.expect("reader task").expect("body bytes"),
+            b"onetwo"
+        );
+        assert!(sent.lock().expect("sent frames").is_empty());
     }
 
     #[test]

--- a/host/crates/gateway-client/src/connection.rs
+++ b/host/crates/gateway-client/src/connection.rs
@@ -345,7 +345,7 @@ impl Connection {
                         }
                     }
                     Message::Binary(data) => {
-                        let _ = body_channel_clone.handle_frame(&data);
+                        let _ = body_channel_clone.handle_frame(&data).await;
                     }
                     Message::Ping(payload) => {
                         tokio::select! {


### PR DESCRIPTION
## Summary

- give registered binary-body consumers a cooperative scheduling turn between already-buffered WebSocket data frames
- preserve the bounded receiver fail-fast behavior instead of blocking the connection-wide reader on one body
- keep request cancellation, unrelated frames, and peer closure readable
- document the receiver scheduling and control-readability invariant

## Observed failure

This incident did not involve a slow consumer. The WebSocket already had a burst of binary frames ready, and its read task could dispatch them synchronously with try_send. Because that path had no scheduling point, it filled the eight-frame queue before the healthy in-memory net.fetch body consumer ran. The ninth frame was misclassified as receiver overflow and the inference request was cancelled before reaching SGLang.

## Scope

This patch deliberately does not await body queue capacity in the shared WebSocket read loop: doing so can prevent request.cancel, unrelated requests, and peer close frames from being read when one consumer stalls. True lossless per-stream backpressure requires protocol-level flow control or a separately scoped multiplexing design.

## Validation

- cargo fmt --package gateway-client --package machine --check
- cargo test --package gateway-client --package machine
- cargo clippy --package gateway-client --package machine --all-targets -- -D warnings
- regressions verify a ready-frame burst drains with a one-frame queue while a genuinely stalled receiver remains bounded and is cancelled