### PR TITLE
classify managed inference telemetry

### DIFF
--- a/docs/architecture/telemetry.md
+++ b/docs/architecture/telemetry.md
@@ -17,6 +17,8 @@ allowlist. Each event has a closed property schema; there is no arbitrary
 metadata field. Records may contain:
 
 - event names, bounded categories, timings, outcomes, and aggregate counts;
+- content-free inference failure categories, lifecycle stages, retryability,
+  HTTP status codes, and workload classes;
 - the installation identity needed by a deployment-owned consumer to derive a
   pseudonym; and
 - a random event id and occurrence time for idempotent export.
@@ -25,6 +27,14 @@ Records must never contain prompts, messages, file paths, URLs, tool arguments,
 media, credentials, contact or channel identifiers, raw exception text, or
 other user content. Invalid records are rejected without affecting user work.
 Managed telemetry does not export Process traces or conversation activity.
+
+Managed inference reports every admitted logical request at its terminal owner
+boundary. Failed and abandoned requests include a provider-neutral failure kind
+and stage rather than exception text. The provider HTTP status is included when
+one was observed; network, timeout, policy, admission, protocol, and settlement
+failures remain distinguishable when no response existed. Workload classes let
+operators separate interactive, background, delegated IPC, compaction, Kernel,
+and mail-intake reliability without exposing a process or request identifier.
 
 Operational telemetry and product analytics are separate purposes. A managed
 consumer derives unrelated pseudonyms for the two streams with different HMAC

--- a/gateway/src/inference/gsv-provider.test.ts
+++ b/gateway/src/inference/gsv-provider.test.ts
@@ -23,6 +23,7 @@ const ATTRIBUTION = {
   installationId: "inst_test",
   logicalRequestId: "request_test",
   actor: { localUid: 1000, processId: "proc_test", runId: "run_test" },
+  workload: "ipc" as const,
 };
 
 const CONTEXT: Context = {
@@ -111,6 +112,9 @@ describe("GSV inference provider", () => {
     expect(getByName).toHaveBeenCalledWith(ATTRIBUTION.installationId);
     expect(service.getInstallation).not.toHaveBeenCalled();
     expect(target.generateStream).toHaveBeenCalledOnce();
+    expect(target.generateStream).toHaveBeenCalledWith(
+      expect.objectContaining({ workload: "ipc" }),
+    );
     expect(dispose).toHaveBeenCalledOnce();
   });
 

--- a/gateway/src/inference/gsv-provider.ts
+++ b/gateway/src/inference/gsv-provider.ts
@@ -179,6 +179,7 @@ function buildManagedInferenceRequest(
     maxOutputTokens: options?.maxTokens ?? GSV_INFERENCE_MODEL_METADATA.maxTokens,
     timeoutMs: options?.timeoutMs ?? 180_000,
   };
+  if (attribution.workload) request.workload = attribution.workload;
   if (context.systemPrompt) request.systemPrompt = context.systemPrompt;
   if (context.tools && context.tools.length > 0) {
     // SAFETY: pi-ai tools and the managed protocol share the same JSON Schema contract.

--- a/gateway/src/inference/provider.ts
+++ b/gateway/src/inference/provider.ts
@@ -1,4 +1,5 @@
 import type { Provider } from "@earendil-works/pi-ai";
+import type { ManagedInferenceWorkload } from "@humansandmachines/gsv/protocol";
 import { stableOpaqueId } from "../shared/stable-id";
 
 export type InferenceAttribution = {
@@ -9,6 +10,7 @@ export type InferenceAttribution = {
     processId?: string;
     runId?: string;
   };
+  workload?: ManagedInferenceWorkload;
 };
 
 export type InferenceProviderFactory = {

--- a/gateway/src/kernel/ai.test.ts
+++ b/gateway/src/kernel/ai.test.ts
@@ -962,6 +962,7 @@ describe("handleAiConfig", () => {
     generateMock.mockImplementationOnce(async (request: any) => {
       expect(request.attribution).toMatchObject({
         installationId: "inst_managed",
+        workload: "kernel",
         actor: {
           localUid: 1000,
           processId: "task-1",

--- a/gateway/src/kernel/ai.ts
+++ b/gateway/src/kernel/ai.ts
@@ -510,6 +510,7 @@ async function inferenceAttribution(
     actor: {
       localUid: process?.uid ?? 0,
     },
+    workload: "kernel",
   };
   if (ctx.processId) attribution.actor.processId = ctx.processId;
   if (ctx.processRunId) attribution.actor.runId = ctx.processRunId;

--- a/gateway/src/process/do.test.ts
+++ b/gateway/src/process/do.test.ts
@@ -506,6 +506,7 @@ describe("Process DO — mechanical", () => {
     expect(result.first).toMatchObject({
       installationId,
       actor: { localUid: 0, processId: pid, runId: "run-managed" },
+      workload: "background",
     });
     expect(result.first.logicalRequestId).toMatch(/^inference:[a-f0-9]{64}$/);
     expect(result.repeated.logicalRequestId).toBe(result.first.logicalRequestId);

--- a/gateway/src/process/do.ts
+++ b/gateway/src/process/do.ts
@@ -7482,6 +7482,13 @@ export class Process extends DurableObject<GatewayEnv> {
         purposeKey,
       ]),
       actor,
+      workload: purpose === "compaction"
+        ? "compaction"
+        : this.currentRun?.returnToCaller
+          ? "ipc"
+          : this.currentRun?.conversationId
+            ? "interactive"
+            : "background",
     };
   }
 

--- a/gateway/test-integration/fixtures/dependencies.ts
+++ b/gateway/test-integration/fixtures/dependencies.ts
@@ -64,6 +64,7 @@ type RecordedWorkersAiRequest = {
   endpoint: string;
   model: string;
   collectLog: string | null;
+  collectLogPayload: string | null;
   hasProviderCredential: boolean;
 };
 
@@ -695,6 +696,8 @@ class WorkersAiGatewayFixture extends RpcTarget {
       endpoint: request.endpoint,
       model,
       collectLog: request.headers["cf-aig-collect-log"] ?? null,
+      collectLogPayload:
+        request.headers["cf-aig-collect-log-payload"] ?? null,
       hasProviderCredential: Object.keys(request.headers).some((name) => (
         credentialHeaders.has(name.toLowerCase())
       )),

--- a/packages/gsv/src/protocol/managed.ts
+++ b/packages/gsv/src/protocol/managed.ts
@@ -21,6 +21,7 @@ export type {
   ManagedInferenceRequest,
   ManagedInferenceResult,
   ManagedInferenceStreamEvent,
+  ManagedInferenceWorkload,
 } from "../services/inference";
 
 export type ManagedMailSummaryRequest = {

--- a/packages/gsv/src/services/inference.ts
+++ b/packages/gsv/src/services/inference.ts
@@ -21,11 +21,21 @@ export type ManagedInferenceActor = {
 
 export type ManagedInferencePurpose = "agent" | "mail-intake";
 
+export type ManagedInferenceWorkload =
+  | "interactive"
+  | "background"
+  | "ipc"
+  | "compaction"
+  | "kernel"
+  | "mail-intake";
+
 export type ManagedInferenceRequest = {
   version: 1;
   installationId: string;
   logicalRequestId: string;
   actor: ManagedInferenceActor;
+  /** Additive for rolling deployments; omitted callers are reported as unknown. */
+  workload?: ManagedInferenceWorkload;
   model: typeof GSV_INFERENCE_PRODUCT_MODEL;
   systemPrompt?: string;
   messages: AiTextMessage[];

--- a/packages/gsv/src/telemetry.ts
+++ b/packages/gsv/src/telemetry.ts
@@ -18,6 +18,47 @@ const modelNameSchema = z.string().check(
   z.maxLength(200),
   z.regex(/^@?[A-Za-z0-9][A-Za-z0-9._:/-]*$/),
 );
+const httpStatusCodeSchema = z.number().check(
+  z.int(),
+  z.gte(100),
+  z.lte(599),
+);
+
+export const inferenceWorkloadSchema = z.enum([
+  "interactive",
+  "background",
+  "ipc",
+  "compaction",
+  "kernel",
+  "mail-intake",
+  "unknown",
+]);
+
+export const inferenceFailureKindSchema = z.enum([
+  "rate_limited",
+  "capacity",
+  "timeout",
+  "authentication",
+  "billing",
+  "invalid_request",
+  "context_overflow",
+  "network",
+  "provider_unavailable",
+  "policy",
+  "quota",
+  "protocol",
+  "internal",
+  "unknown",
+]);
+
+export const inferenceFailureStageSchema = z.enum([
+  "policy",
+  "admission",
+  "provider",
+  "stream",
+  "settlement",
+  "lifecycle",
+]);
 
 export const telemetryComponentSchema = z.enum([
   "gateway",
@@ -108,6 +149,8 @@ const inferenceRequestFinishedSchema = z.strictObject({
   properties: z.strictObject({
     outcome: z.enum(["completed", "failed", "aborted", "abandoned"]),
     purpose: z.enum(["agent", "mail-intake"]),
+    // Optional only for compatibility with producers during rolling upgrades.
+    workload: z.optional(inferenceWorkloadSchema),
     provider: z.literal("workers-ai"),
     model: z.optional(modelNameSchema),
     stopReason: z.optional(z.enum([
@@ -124,6 +167,12 @@ const inferenceRequestFinishedSchema = z.strictObject({
     cacheWriteTokens: nonNegativeIntegerSchema,
     totalTokens: nonNegativeIntegerSchema,
     costNanoUsd: nonNegativeIntegerSchema,
+    // Failure diagnostics are a closed, content-free taxonomy. Managed
+    // producers attach all three fields to failed and abandoned outcomes.
+    failureKind: z.optional(inferenceFailureKindSchema),
+    failureStage: z.optional(inferenceFailureStageSchema),
+    retryable: z.optional(z.boolean()),
+    providerStatusCode: z.optional(httpStatusCodeSchema),
   }),
 });
 
@@ -193,6 +242,11 @@ export const telemetryRecordSchema = z.strictObject({
 export type TelemetryComponent = z.infer<typeof telemetryComponentSchema>;
 export type TelemetryEvent = z.infer<typeof telemetryEventSchema>;
 export type TelemetryRecord = z.infer<typeof telemetryRecordSchema>;
+export type InferenceWorkload = z.infer<typeof inferenceWorkloadSchema>;
+export type InferenceFailureKind = z.infer<typeof inferenceFailureKindSchema>;
+export type InferenceFailureStage = z.infer<
+  typeof inferenceFailureStageSchema
+>;
 
 export type TelemetryEnvironment = {
   GSV_TELEMETRY_ENABLED?: boolean | number | string;

--- a/packages/gsv/test/telemetry.test.mjs
+++ b/packages/gsv/test/telemetry.test.mjs
@@ -53,4 +53,46 @@ describe("telemetry contract", () => {
       log.mock.restore();
     }
   });
+
+  it("accepts bounded inference failure diagnostics without raw errors", () => {
+    const failure = createTelemetryRecord({
+      installationId: "inst_telemetry",
+      component: "inference",
+      event: {
+        stream: "operational",
+        name: "inference.request.finished",
+        properties: {
+          outcome: "failed",
+          purpose: "agent",
+          workload: "ipc",
+          provider: "workers-ai",
+          model: "@cf/example/model",
+          stopReason: "error",
+          durationMs: 123,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          totalTokens: 0,
+          costNanoUsd: 0,
+          failureKind: "rate_limited",
+          failureStage: "provider",
+          retryable: true,
+          providerStatusCode: 429,
+        },
+      },
+    });
+
+    assert.equal(telemetryRecordSchema.safeParse(failure).success, true);
+    assert.equal(telemetryRecordSchema.safeParse({
+      ...failure,
+      event: {
+        ...failure.event,
+        properties: {
+          ...failure.event.properties,
+          errorMessage: "private provider response",
+        },
+      },
+    }).success, false);
+  });
 });


### PR DESCRIPTION
## Summary
- add bounded failure kind, stage, retryability, provider status, and workload fields to managed inference telemetry
- attribute interactive, delegated, IPC, compaction, kernel, and mail inference workloads
- keep all diagnostic fields content-free and rolling-deploy compatible

## Validation
- npm run gsv:check
- npm test --workspace packages/gsv
- gateway npx tsc --noEmit
- gateway npm run test:run (1694 unit, 32 integration)
- npm run lint