### PR TITLE
accept nullable sglang tool deltas

### DIFF
--- a/gateway/src/inference/custom-provider.test.ts
+++ b/gateway/src/inference/custom-provider.test.ts
@@ -127,6 +127,114 @@ describe("streamWithCustomProvider", () => {
     const message = await stream.result();
     expect(message.content).toEqual([{ type: "text", text: "hel" }]);
   });
+
+  it("retains streamed tool calls with nullable SGLang delta placeholders", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response([
+      openAiChatSseChunk({
+        id: "chatcmpl-sglang",
+        model: "Qwen3.8-27B",
+        choices: [{
+          delta: {
+            role: "assistant",
+            content: "",
+            reasoning_content: null,
+          },
+        }],
+      }),
+      openAiChatSseChunk({
+        choices: [{ delta: { reasoning_content: "I should send the message." } }],
+      }),
+      openAiChatSseChunk({
+        choices: [{
+          delta: {
+            role: null,
+            content: "\n\n",
+            reasoning_content: null,
+            tool_calls: null,
+          },
+        }],
+      }),
+      openAiChatSseChunk({
+        choices: [{
+          delta: {
+            role: null,
+            content: null,
+            reasoning_content: null,
+            tool_calls: [{
+              index: 0,
+              id: "call-sglang",
+              type: "function",
+              function: { name: "Shell", arguments: "" },
+            }],
+          },
+        }],
+      }),
+      openAiChatSseChunk({
+        choices: [{
+          delta: {
+            role: null,
+            content: null,
+            reasoning_content: null,
+            tool_calls: [{
+              index: 0,
+              id: null,
+              type: "function",
+              function: { name: null, arguments: "{\"input\":\"message send " },
+            }],
+          },
+        }],
+      }),
+      openAiChatSseChunk({
+        choices: [{
+          delta: {
+            role: null,
+            content: null,
+            reasoning_content: null,
+            tool_calls: [{
+              index: 0,
+              id: null,
+              type: "function",
+              function: { name: null, arguments: "--message READY && yield\"}" },
+            }],
+          },
+        }],
+      }),
+      openAiChatSseChunk({
+        choices: [{ delta: { reasoning_content: null }, finish_reason: "tool_calls" }],
+      }),
+      "data: [DONE]\n\n",
+    ].join(""), {
+      headers: { "content-type": "text/event-stream" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stream = streamWithCustomProvider({
+      provider: "custom",
+      model: "Qwen3.8-27B",
+      baseUrl: "http://localhost:30000/v1",
+      providerStyle: "openai-chat-completions",
+      maxTokens: 2_048,
+      context: CONTEXT,
+    });
+
+    const message = await stream.result();
+
+    expect(message.stopReason).toBe("toolUse");
+    expect(message.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "I should send the message.",
+        thinkingSignature: "reasoning_content",
+      },
+      { type: "text", text: "\n\n" },
+      {
+        type: "toolCall",
+        id: "call-sglang",
+        name: "Shell",
+        arguments: { input: "message send --message READY && yield" },
+      },
+    ]);
+  });
 });
 
 function openAiChatSseChunk(payload: OpenAiPayload): string {

--- a/gateway/src/inference/custom-provider.ts
+++ b/gateway/src/inference/custom-provider.ts
@@ -56,22 +56,22 @@ export type CustomProviderGenerationRequest = {
 type RoutedRequestInit = RequestInit & { timeoutMs?: number };
 
 type OpenAIChatFunction = {
-  name?: string;
+  name?: string | null;
   arguments?: string;
 };
 
 type OpenAIChatToolCallDelta = {
   index?: number;
-  id?: string;
+  id?: string | null;
   function?: OpenAIChatFunction;
 };
 
 type OpenAIChatDelta = {
   content?: string | null;
-  reasoning_content?: string;
+  reasoning_content?: string | null;
   reasoning?: string;
   reasoning_text?: string;
-  tool_calls?: OpenAIChatToolCallDelta[];
+  tool_calls?: OpenAIChatToolCallDelta[] | null;
 };
 
 type OpenAIChatChoice = {
@@ -136,20 +136,20 @@ type CustomProviderModel =
   | Model<"anthropic-messages">;
 
 const openAIChatFunctionSchema = z.object({
-  name: z.string().optional(),
+  name: z.string().nullable().optional(),
   arguments: z.string().optional(),
 });
 const openAIChatToolCallDeltaSchema = z.object({
   index: z.number().int().nonnegative().optional(),
-  id: z.string().optional(),
+  id: z.string().nullable().optional(),
   function: openAIChatFunctionSchema.optional(),
 });
 const openAIChatDeltaSchema = z.object({
   content: z.string().nullable().optional(),
-  reasoning_content: z.string().optional(),
+  reasoning_content: z.string().nullable().optional(),
   reasoning: z.string().optional(),
   reasoning_text: z.string().optional(),
-  tool_calls: z.array(openAIChatToolCallDeltaSchema).optional(),
+  tool_calls: z.array(openAIChatToolCallDeltaSchema).nullable().optional(),
 });
 const openAIChatChoiceSchema = z.object({
   finish_reason: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary

- accept the nullable placeholder fields SGLang emits while streaming OpenAI-compatible tool calls
- preserve split tool-call ids, names, and JSON arguments through the shared custom-provider parser
- add a regression fixture shaped like the observed Qwen3.8/SGLang SSE sequence

## Why

SGLang emits `null` for `reasoning_content`, `tool_calls`, tool-call `id`, and function `name` in chunks where those values are not active. The external-boundary schema rejected each whole chunk, so GSV retained the reasoning chunks but silently lost the `Shell` tool call and terminated the Process as `generation.empty`.

The parser now admits only the nullable fields observed at that protocol boundary; existing accumulation and JSON validation remain unchanged.

## Validation

- `cd gateway && npx tsc --noEmit`
- `cd gateway && npx vitest run --config vitest.config.ts src/inference/custom-provider.test.ts`
- `cd gateway && npm run test:run`
  - 111 unit files / 1,678 tests passed
  - 6 integration files / 32 tests passed
- full local Wrangler Process harness against live Qwen3.8-27B on SGLang:
  - `status=ok`
  - `reason=run.yielded`
  - committed result `GSV-QWEN-END-TO-END`
