### PR TITLE
select managed inference by deployment

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -66,7 +66,7 @@ An agent or Process may prefer an entry by its stable ID through `users/{uid}/ai
 
 | System Key | User Override | Default | Description |
 |---|---|---|---|
-| `config/ai/models` | `users/{ownerUid}/ai/models` | Workers AI primary plus fallback | Ordered complete text-model stack. |
+| `config/ai/models` | `users/{ownerUid}/ai/models` | GSV included inference when its managed binding is configured; otherwise Workers AI primary plus fallback | Ordered complete text-model stack. |
 | — | `users/{uid}/ai/preferred_model` | empty | Stable entry ID preferred by this agent account. |
 | `config/ai/reasoning` | `users/{uid}/ai/reasoning` | `medium` | Reasoning mode hint: `off`, `minimal`, `low`, `medium`, `high`, or `xhigh`. Unsupported values are clamped to the nearest model-supported level at generation time. |
 | `config/ai/max_context_bytes` | `users/{uid}/ai/max_context_bytes` | `32768` | Prompt context budget before messages. |

--- a/workers/gateway/src/inference/default-models.ts
+++ b/workers/gateway/src/inference/default-models.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_TEXT_GENERATION_MAX_TOKENS = 32_768;
+export const GSV_INCLUDED_CONTEXT_WINDOW_TOKENS = 1_048_576;
 export const DEFAULT_WORKERS_AI_MODEL = "@cf/zai-org/glm-5.3-flash";
 export const DEFAULT_WORKERS_AI_FALLBACK_MODEL = "@cf/moonshotai/kimi-k2.6";
 export const DEFAULT_WORKERS_AI_FALLBACK_PROFILE_ID = "workers-ai-kimi-k2-6";

--- a/workers/gateway/src/inference/gsv-provider.test.ts
+++ b/workers/gateway/src/inference/gsv-provider.test.ts
@@ -59,6 +59,8 @@ describe("GSV inference provider", () => {
 
     expect(models.getModel(GSV_INFERENCE_PROVIDER, GSV_INFERENCE_MODEL)?.maxTokens)
       .toBe(32_768);
+    expect(models.getModel(GSV_INFERENCE_PROVIDER, GSV_INFERENCE_MODEL)?.contextWindow)
+      .toBe(1_048_576);
   });
 
   it("registers when either managed inference binding is present", () => {

--- a/workers/gateway/src/inference/gsv-provider.ts
+++ b/workers/gateway/src/inference/gsv-provider.ts
@@ -28,9 +28,15 @@ import type {
   InferenceAttribution,
   InferenceProviderFactory,
 } from "./provider";
-import { DEFAULT_TEXT_GENERATION_MAX_TOKENS } from "./default-models";
+import {
+  DEFAULT_TEXT_GENERATION_MAX_TOKENS,
+  GSV_INCLUDED_CONTEXT_WINDOW_TOKENS,
+} from "./default-models";
 import { raceWithAbort } from "../shared/abort";
-import type { GatewayEnv } from "../runtime-env";
+import {
+  hasManagedInferenceBinding,
+  type GatewayEnv,
+} from "../runtime-env";
 
 const GSV_INFERENCE_API = "gsv-inference";
 
@@ -48,7 +54,7 @@ const GSV_INFERENCE_MODEL_METADATA: Model<typeof GSV_INFERENCE_API> = {
     cacheRead: 0,
     cacheWrite: 0,
   },
-  contextWindow: 1_048_576,
+  contextWindow: GSV_INCLUDED_CONTEXT_WINDOW_TOKENS,
   maxTokens: DEFAULT_TEXT_GENERATION_MAX_TOKENS,
 };
 
@@ -84,7 +90,7 @@ export function gsvInferenceProviderFactoryFromEnv(
 }
 
 export function gsvInferenceFeaturesFromEnv(env: GatewayEnv): string[] {
-  return managedInferenceAccessFromEnv(env)
+  return hasManagedInferenceBinding(env)
     ? [GSV_INFERENCE_FEATURE]
     : [];
 }

--- a/workers/gateway/src/kernel/config.test.ts
+++ b/workers/gateway/src/kernel/config.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_WORKERS_AI_FALLBACK_MODEL,
   DEFAULT_WORKERS_AI_FALLBACK_PROFILE_ID,
   DEFAULT_WORKERS_AI_MODEL,
+  GSV_INCLUDED_CONTEXT_WINDOW_TOKENS,
 } from "../inference/default-models";
 import { runWithRealKernelSql } from "../test-support/real-kernel-sql";
 import { MAIL_STATUS } from "../syscalls/constants";
@@ -19,6 +20,39 @@ describe("ConfigStore", () => {
     expect(SYSTEM_CONFIG_DEFAULTS["config/ai/image/read/max_tokens"])
       .toBe("28672");
   });
+
+  it("defaults managed deployments to GSV included inference", () =>
+    runWithRealKernelSql((sql) => {
+      const store = new ConfigStore(sql, { managedInferenceAvailable: true });
+      expect(store.getExplicit("config/ai/models")).toBeNull();
+      expect(parseAiModelStack(store.get("config/ai/models"))).toEqual({
+        version: 1,
+        models: [{
+          id: "gsv-included",
+          name: "GSV Included",
+          provider: "gsv",
+          model: "default",
+          maxTokens: DEFAULT_TEXT_GENERATION_MAX_TOKENS,
+          contextWindowTokens: GSV_INCLUDED_CONTEXT_WINDOW_TOKENS,
+        }],
+      });
+    }));
+
+  it("keeps an explicit system stack over the managed deployment default", () =>
+    runWithRealKernelSql((sql) => {
+      const store = new ConfigStore(sql, { managedInferenceAvailable: true });
+      const configured = JSON.stringify({
+        version: 1,
+        models: [{
+          id: "custom",
+          name: "Custom",
+          provider: "openai",
+          model: "gpt-5.4",
+        }],
+      });
+      store.set("config/ai/models", configured);
+      expect(store.get("config/ai/models")).toBe(configured);
+    }));
 
   it("defaults native shell execution to two minutes", () => {
     expect(SYSTEM_CONFIG_DEFAULTS["config/shell/timeout_ms"]).toBe("120000");

--- a/workers/gateway/src/kernel/config.ts
+++ b/workers/gateway/src/kernel/config.ts
@@ -26,9 +26,14 @@ import {
   DEFAULT_WORKERS_AI_FALLBACK_PROFILE_ID,
   DEFAULT_WORKERS_AI_FALLBACK_PROFILE_NAME,
   DEFAULT_WORKERS_AI_MODEL,
+  GSV_INCLUDED_CONTEXT_WINDOW_TOKENS,
 } from "../inference/default-models";
 import { MAIL_SEND } from "../syscalls/constants";
-import { DEFAULT_SHELL_EXEC_TIMEOUT_MS } from "@humansandmachines/gsv/protocol";
+import {
+  DEFAULT_SHELL_EXEC_TIMEOUT_MS,
+  GSV_INFERENCE_MODEL,
+  GSV_INFERENCE_PROVIDER,
+} from "@humansandmachines/gsv/protocol";
 import {
   aiModelApiKeyConfigKey,
   isAiModelStackConfigKey,
@@ -81,6 +86,18 @@ const DEFAULT_AI_MODELS = JSON.stringify({
       maxTokens: DEFAULT_TEXT_GENERATION_MAX_TOKENS,
     },
   ],
+});
+
+const MANAGED_DEFAULT_AI_MODELS = JSON.stringify({
+  version: 1,
+  models: [{
+    id: "gsv-included",
+    name: "GSV Included",
+    provider: GSV_INFERENCE_PROVIDER,
+    model: GSV_INFERENCE_MODEL,
+    maxTokens: DEFAULT_TEXT_GENERATION_MAX_TOKENS,
+    contextWindowTokens: GSV_INCLUDED_CONTEXT_WINDOW_TOKENS,
+  }],
 });
 
 export const SYSTEM_CONFIG_DEFAULTS = defineSystemConfigDefaults({
@@ -157,11 +174,27 @@ export const SYSTEM_CONFIG_DEFAULTS = defineSystemConfigDefaults({
 // user-overridable; server/shell/process config is system-only.
 export const USER_OVERRIDABLE_PREFIXES = ["ai/", "ui/"] as const;
 
+type ConfigStoreOptions = {
+  managedInferenceAvailable?: boolean;
+};
+
 export class ConfigStore {
-  constructor(private readonly sql: SqlStorage) {}
+  private readonly defaults: SystemConfigDefaults;
+
+  constructor(
+    private readonly sql: SqlStorage,
+    options: ConfigStoreOptions = {},
+  ) {
+    this.defaults = options.managedInferenceAvailable
+      ? {
+        ...SYSTEM_CONFIG_DEFAULTS,
+        "config/ai/models": MANAGED_DEFAULT_AI_MODELS,
+      }
+      : SYSTEM_CONFIG_DEFAULTS;
+  }
 
   get(key: string): string | null {
-    return this.getExplicit(key) ?? SYSTEM_CONFIG_DEFAULTS[key] ?? null;
+    return this.getExplicit(key) ?? this.defaults[key] ?? null;
   }
 
   getExplicit(key: string): string | null {
@@ -216,7 +249,7 @@ export class ConfigStore {
    */
   list(prefix: string): { key: string; value: string }[] {
     const merged = new Map<string, string>();
-    for (const [key, value] of Object.entries(SYSTEM_CONFIG_DEFAULTS)) {
+    for (const [key, value] of Object.entries(this.defaults)) {
       if (matchesConfigPrefix(key, prefix)) {
         merged.set(key, value);
       }

--- a/workers/gateway/src/kernel/do.ts
+++ b/workers/gateway/src/kernel/do.ts
@@ -218,7 +218,10 @@ import {
   type DurableTask,
   type DurableTaskOptions,
 } from "../shared/durable-tasks";
-import type { GatewayEnv } from "../runtime-env";
+import {
+  hasManagedInferenceBinding,
+  type GatewayEnv,
+} from "../runtime-env";
 import {
   acceptKernelWebSocket,
   KernelConnection,
@@ -751,7 +754,9 @@ export class Kernel extends DurableObject<GatewayEnv> {
     this.caps = new CapabilityStore(sql);
     this.caps.seed();
 
-    this.config = new ConfigStore(sql);
+    this.config = new ConfigStore(sql, {
+      managedInferenceAvailable: hasManagedInferenceBinding(env),
+    });
 
     this.devices = new DeviceRegistry(sql);
 

--- a/workers/gateway/src/runtime-env.ts
+++ b/workers/gateway/src/runtime-env.ts
@@ -17,3 +17,7 @@ type GatewayDeploymentBindings = TelemetryEnvironment & {
 };
 
 export type GatewayEnv = Env & GatewayDeploymentBindings;
+
+export function hasManagedInferenceBinding(env: GatewayEnv): boolean {
+  return Boolean(env.MANAGED_INFERENCE_INSTALLATIONS || env.MANAGED_INFERENCE);
+}


### PR DESCRIPTION
## Summary

- default an installation to `gsv/default` when a managed inference binding is configured
- retain the GLM/Kimi stack for standalone deployments
- preserve explicit system and owner model stacks over deployment defaults
- document the deployment-aware default

This repairs existing managed installations that have no canonical model stack after the hard cutover in #269. Their ignored legacy scalar keys remain ignored; no compatibility path or data migration is introduced.

## Validation

- `cd workers/gateway && npx tsc --noEmit`
- `cd workers/gateway && npm run test:run` (1702 unit, 32 integration)
- `npm run lint`
