### PR TITLE
reject assistant text with silent yield

### DIFF
--- a/docs/architecture/agent-loop.md
+++ b/docs/architecture/agent-loop.md
@@ -151,7 +151,8 @@ The model response can contain text, thinking blocks, and tool calls:
   commits one canonical user-visible message and any media registered by `message attach`. The run
   continues, allowing multiple exactly-once messages from one run.
 - A direct `yield` finishes the run. Composing the final send as `message send ... && yield` avoids
-  another generation; a bare `yield` finishes without another Message.
+  another generation; a bare `yield` finishes without another Message and is valid only when the
+  same assistant turn contains no meaningful text.
 - Once the Process validates a message command, the originating client receives
   `message.started` and `message.delta`. Adapters wait for `message.committed`.
 - Ordinary assistant text in a human-facing run that stops without yielding causes one `[GSV EVENT]`

--- a/workers/gateway/src/process/do.model-context-2.test.ts
+++ b/workers/gateway/src/process/do.model-context-2.test.ts
@@ -844,20 +844,29 @@ describe("model context", () => {
     });
   });
 
-  it("finishes silently without committing a canonical message", async () => {
+  it("rejects assistant text before finishing silently without a canonical message", async () => {
     const pid = "mech-terminal-silence";
     const runId = "run-terminal-silence";
     const stub = await initProcess(pid, ROOT_IDENTITY);
 
     const result = await runInProcess(stub, async (process) => {
       const emitted = captureSignals(process);
+      let generationCalls = 0;
       process.streams.emitProjection = vi.fn(async () => {});
+      process.run.scheduleTick = vi.fn(async () => {});
       process.kernel.dispatchSyscall = vi.fn(async () => {});
       mockGeneration(process, async () => {
-        return terminalTestResponse([
-          { type: "thinking", thinking: "No interruption is useful." },
-          yieldAction("yield-action"),
-        ]);
+        generationCalls += 1;
+        return terminalTestResponse(generationCalls === 1
+          ? [
+              { type: "text", text: "This reply should be delivered." },
+              yieldAction("text-yield-action"),
+            ]
+          : [
+              { type: "text", text: "" },
+              { type: "thinking", thinking: "No interruption is useful." },
+              yieldAction("yield-action"),
+            ]);
       }, async () => {
         return "unused";
       });
@@ -870,6 +879,21 @@ describe("model context", () => {
           rules: [{ match: "shell.exec", action: "ask" }],
         }
       });
+
+      await process.run.runTick(runId);
+      expect(process.runs.active).toMatchObject({
+        runId,
+        terminalCommandFailures: 1,
+      });
+      expect(process.run.scheduleTick).toHaveBeenCalledOnce();
+      const rejectedYield = process.store.messages
+        .getMessages()
+        .find((message: any) => message.toolCallId === "text-yield-action");
+      expect(rejectedYield).toMatchObject({
+        content: expect.stringContaining("yield cannot accompany non-empty assistant text"),
+      });
+      expect(JSON.parse(rejectedYield.toolCalls)).toMatchObject({ isError: true });
+      expect(emitted.some((entry) => entry.signal === "proc.run.finished")).toBe(false);
 
       await process.run.runTick(runId);
       return {

--- a/workers/gateway/src/process/internal/lifecycle.ts
+++ b/workers/gateway/src/process/internal/lifecycle.ts
@@ -107,7 +107,7 @@ export const FINAL_MESSAGE_BLOCK_EXAMPLE =
   "message send <<'GSV_MESSAGE' && yield\nyour user-visible response\nGSV_MESSAGE";
 
 export const RUN_CONTROL_INSTRUCTION =
-  `Use a direct \`message send\` Shell call whenever the user should receive a message; sending does not finish the run. After all work is complete, run \`yield\`, or compose the final message as:\n${FINAL_MESSAGE_BLOCK_EXAMPLE}\nOrdinary assistant text is Process activity and is not sent to the user.`;
+  `Use a direct \`message send\` Shell call whenever the user should receive a message; sending does not finish the run. After all work is complete, run \`yield\`, or compose the final message as:\n${FINAL_MESSAGE_BLOCK_EXAMPLE}\nOrdinary assistant text is Process activity and is not sent to the user. In a human-facing run, do not combine meaningful assistant text with a bare \`yield\`; send that text with \`message send\` instead.`;
 
 export const PENDING_RUN_CONTROL_CALL = "Shell";
 

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -78,6 +78,7 @@ export class ProcessRun {
     actionId: string,
     parsed: RunControlCommandParseResult,
     media: RunOutputMedia[],
+    assistantText = "",
   ): Promise<RunControlResult> {
     if (!parsed.ok) {
       return {
@@ -87,6 +88,16 @@ export class ProcessRun {
         delivery: { kind: "none" },
         failureKind: "command",
         error: parsed.error,
+      };
+    }
+    if (parsed.command.action === "yield" && assistantText.trim()) {
+      return {
+        ok: false,
+        action: "yield",
+        text: "",
+        delivery: { kind: "none" },
+        failureKind: "command",
+        error: "yield cannot accompany non-empty assistant text",
       };
     }
     if (parsed.command.action === "message" && !parsed.command.text.trim() && media.length === 0) {
@@ -1163,6 +1174,7 @@ export class ProcessRun {
         call.toolCall.id,
         call.parsed,
         outputMedia,
+        turn.text,
       );
     } catch (error) {
       this.persistRunControlExecutionError(

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -90,7 +90,9 @@ export class ProcessRun {
         error: parsed.error,
       };
     }
-    if (parsed.command.action === "yield" && assistantText.trim()) {
+    const activeRun = this.host.runs.active;
+    const isHumanFacingRun = activeRun?.runId === runId && !activeRun.returnToCaller;
+    if (parsed.command.action === "yield" && isHumanFacingRun && assistantText.trim()) {
       return {
         ok: false,
         action: "yield",


### PR DESCRIPTION
## Summary

- reject a bare yield when the same assistant turn contains meaningful text
- preserve whitespace-only silent yields
- keep the run active and use the existing bounded command-correction path

## Testing

- focused Process runtime test (1 passed, 254 skipped)
