### PR TITLE
load just-bash and the chat-completions module on first use

### DIFF
--- a/workers/gateway/src/drivers/native/shell.ts
+++ b/workers/gateway/src/drivers/native/shell.ts
@@ -8,13 +8,14 @@
  * - Per-identity Bash instances with proper uid/gid/env and process info
  */
 
-import { Bash } from "just-bash";
 import type {
+  Bash,
   BashExecResult,
   Command,
   NetworkConfig,
 } from "just-bash";
 import { resolveUserPath } from "../../fs";
+import { loadJustBash } from "../../shared/just-bash";
 import type { KernelContext } from "../../kernel/context";
 import { requirePrincipal } from "../../kernel/context";
 import type { ShellExecArgs, ShellExecResult } from "../../syscalls/shell";
@@ -81,7 +82,9 @@ export async function handleShellExec(
     ? AbortSignal.any([controller.signal, ctx.requestSignal])
     : controller.signal;
   const commandFence = new NativeCommandFence();
+  const { Bash: BashRuntime } = await loadJustBash();
   const bash = createBash(
+    BashRuntime,
     { ...ctx, requestSignal: signal },
     identity,
     cwd,
@@ -159,6 +162,7 @@ export async function handleShellExec(
 }
 
 function createBash(
+  BashRuntime: typeof Bash,
   ctx: KernelContext,
   identity: ProcessIdentity,
   cwd: string,
@@ -172,7 +176,7 @@ function createBash(
   const serverVersion = ctx.config.get("config/server/version") ?? ctx.serverVersion;
   const networkEnabled = ctx.config.get("config/shell/network_enabled") !== "false";
 
-  return new Bash({
+  return new BashRuntime({
     fs,
     cwd,
     env: {

--- a/workers/gateway/src/drivers/native/shell/codemode.ts
+++ b/workers/gateway/src/drivers/native/shell/codemode.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import { GsvFs } from "../../../fs/gsv-fs";
 import { resolveUserPath } from "../../../fs";

--- a/workers/gateway/src/drivers/native/shell/command.ts
+++ b/workers/gateway/src/drivers/native/shell/command.ts
@@ -1,0 +1,11 @@
+import type { Command } from "just-bash";
+
+/**
+ * Builds a host command the way just-bash's defineCommand does: host commands
+ * are trusted, which is the boundary the native shell has always used. Defining
+ * them here keeps just-bash itself out of the Worker's start-up evaluation; the
+ * shell driver loads it on the first shell.exec instead.
+ */
+export function defineCommand(name: string, execute: Command["execute"]): Command {
+  return { name, trusted: true, execute };
+}

--- a/workers/gateway/src/drivers/native/shell/commands.ts
+++ b/workers/gateway/src/drivers/native/shell/commands.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import { GsvFs } from "../../../fs/gsv-fs";
 import type { KernelContext } from "../../../kernel/context";

--- a/workers/gateway/src/drivers/native/shell/contact.ts
+++ b/workers/gateway/src/drivers/native/shell/contact.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import type {
   ContactRequestCreateArgs,

--- a/workers/gateway/src/drivers/native/shell/core.ts
+++ b/workers/gateway/src/drivers/native/shell/core.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import { GsvFs } from "../../../fs/gsv-fs";
 import type { KernelContext } from "../../../kernel/context";

--- a/workers/gateway/src/drivers/native/shell/cp.ts
+++ b/workers/gateway/src/drivers/native/shell/cp.ts
@@ -1,4 +1,5 @@
-import { defineCommand, type ExecResult } from "just-bash";
+import type { ExecResult } from "just-bash";
+import { defineCommand } from "./command";
 import type { KernelContext } from "../../../kernel/context";
 import { handleFsCopy, type FsDeviceTransport } from "../fs";
 import { parseShellFsEndpoint } from "./fs-path";

--- a/workers/gateway/src/drivers/native/shell/crontab.ts
+++ b/workers/gateway/src/drivers/native/shell/crontab.ts
@@ -1,4 +1,5 @@
-import { defineCommand, type CommandContext } from "just-bash";
+import type { CommandContext } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import { GsvFs } from "../../../fs/gsv-fs";
 import { createCronFileService } from "../../../kernel/crontab";

--- a/workers/gateway/src/drivers/native/shell/dd.ts
+++ b/workers/gateway/src/drivers/native/shell/dd.ts
@@ -1,4 +1,5 @@
-import { defineCommand, type ByteString, type ExecResult } from "just-bash";
+import type { ByteString, ExecResult } from "just-bash";
+import { defineCommand } from "./command";
 import type { GsvFs } from "../../../fs/gsv-fs";
 
 const DD_USAGE = [

--- a/workers/gateway/src/drivers/native/shell/llm.ts
+++ b/workers/gateway/src/drivers/native/shell/llm.ts
@@ -1,9 +1,9 @@
-import {
-  defineCommand,
-  type Command,
-  type CommandContext,
-  type ExecResult,
+import type {
+  Command,
+  CommandContext,
+  ExecResult,
 } from "just-bash";
+import { defineCommand } from "./command";
 import type {
   AiTextGenerateConfig,
   AiTextGenerateResult,

--- a/workers/gateway/src/drivers/native/shell/ls.ts
+++ b/workers/gateway/src/drivers/native/shell/ls.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import { GsvFs } from "../../../fs/gsv-fs";
 import type { ExtendedStat } from "../../../fs/gsv-fs";

--- a/workers/gateway/src/drivers/native/shell/mail.ts
+++ b/workers/gateway/src/drivers/native/shell/mail.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { CommandContext, ExecResult } from "just-bash";
 import type {
   MailSendArgs,

--- a/workers/gateway/src/drivers/native/shell/mcp.ts
+++ b/workers/gateway/src/drivers/native/shell/mcp.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import type { KernelContext } from "../../../kernel/context";
 import {

--- a/workers/gateway/src/drivers/native/shell/media.ts
+++ b/workers/gateway/src/drivers/native/shell/media.ts
@@ -1,9 +1,9 @@
-import {
-  defineCommand,
-  type Command,
-  type CommandContext,
-  type ExecResult,
+import type {
+  Command,
+  CommandContext,
+  ExecResult,
 } from "just-bash";
+import { defineCommand } from "./command";
 import {
   bodyToText,
   jsonObjectSchema,

--- a/workers/gateway/src/drivers/native/shell/message.ts
+++ b/workers/gateway/src/drivers/native/shell/message.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { CommandContext, ExecResult } from "just-bash";
 import type {
   AdapterMedia,

--- a/workers/gateway/src/drivers/native/shell/net.ts
+++ b/workers/gateway/src/drivers/native/shell/net.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { CommandContext, ExecResult } from "just-bash";
 import type { KernelContext } from "../../../kernel/context";
 import {

--- a/workers/gateway/src/drivers/native/shell/oauth.ts
+++ b/workers/gateway/src/drivers/native/shell/oauth.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import type { KernelContext } from "../../../kernel/context";
 import {

--- a/workers/gateway/src/drivers/native/shell/proc.ts
+++ b/workers/gateway/src/drivers/native/shell/proc.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import type { KernelContext } from "../../../kernel/context";
 import { resolveCallerOwnerUid } from "../../../kernel/context";

--- a/workers/gateway/src/drivers/native/shell/r12y.ts
+++ b/workers/gateway/src/drivers/native/shell/r12y.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import type {
   ResponsibilityConfigurableSourcePolicyId,

--- a/workers/gateway/src/drivers/native/shell/rgit.ts
+++ b/workers/gateway/src/drivers/native/shell/rgit.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import type { KernelContext } from "../../../kernel/context";
 import {

--- a/workers/gateway/src/drivers/native/shell/sched.ts
+++ b/workers/gateway/src/drivers/native/shell/sched.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import { resolveCallerOwnerUid, type KernelContext } from "../../../kernel/context";
 import {

--- a/workers/gateway/src/drivers/native/shell/skills.ts
+++ b/workers/gateway/src/drivers/native/shell/skills.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { CommandContext, ExecResult } from "just-bash";
 import type { GsvFs } from "../../../fs/gsv-fs";
 import type { KernelContext } from "../../../kernel/context";

--- a/workers/gateway/src/drivers/native/shell/stat.ts
+++ b/workers/gateway/src/drivers/native/shell/stat.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import { GsvFs } from "../../../fs/gsv-fs";
 import type { KernelContext } from "../../../kernel/context";

--- a/workers/gateway/src/drivers/native/shell/targets.ts
+++ b/workers/gateway/src/drivers/native/shell/targets.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import type { KernelContext } from "../../../kernel/context";
 import {

--- a/workers/gateway/src/drivers/native/shell/wiki.ts
+++ b/workers/gateway/src/drivers/native/shell/wiki.ts
@@ -1,4 +1,4 @@
-import { defineCommand } from "just-bash";
+import { defineCommand } from "./command";
 import type { ExecResult } from "just-bash";
 import type {
   RepoApplyOp,

--- a/workers/gateway/src/inference/custom-provider.ts
+++ b/workers/gateway/src/inference/custom-provider.ts
@@ -24,7 +24,7 @@ import {
 import { openAiResponseEvents, parseSse } from "./sse";
 import { z } from "zod";
 import { anthropicMessagesApi } from "@earendil-works/pi-ai/api/anthropic-messages.lazy";
-import { convertMessages } from "@earendil-works/pi-ai/api/openai-completions";
+import type { convertMessages } from "@earendil-works/pi-ai/api/openai-completions";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { openAIResponsesApi } from "@earendil-works/pi-ai/api/openai-responses.lazy";
 import {
@@ -237,6 +237,24 @@ function streamWithCustomFetch(
   return streamOpenAICompletionsWithFetch(fetchImpl, model, request);
 }
 
+type OpenAICompletionsModule = { convertMessages: typeof convertMessages };
+
+let openAICompletions: Promise<OpenAICompletionsModule> | undefined;
+
+/**
+ * pi-ai's chat-completions module brings the OpenAI SDK with it, and every
+ * other pi-ai API already loads on first use. Importing this one the same way
+ * keeps the SDK out of the Worker's start-up evaluation. A failed load is not
+ * cached so the next request retries it.
+ */
+function loadOpenAICompletions(): Promise<OpenAICompletionsModule> {
+  openAICompletions ??= import("@earendil-works/pi-ai/api/openai-completions").catch((error) => {
+    openAICompletions = undefined;
+    throw error;
+  });
+  return openAICompletions;
+}
+
 function streamOpenAICompletionsWithFetch(
   fetchImpl: typeof fetch,
   model: Model<"openai-completions">,
@@ -247,9 +265,10 @@ function streamOpenAICompletionsWithFetch(
     const output = emptyAssistantMessage(model);
     try {
       const compat = resolvedOpenAICompletionsCompat(model);
+      const { convertMessages: convertChatMessages } = await loadOpenAICompletions();
       const payload: OpenAIChatPayload = {
         model: model.id,
-        messages: convertMessages(model, request.context, compat),
+        messages: convertChatMessages(model, request.context, compat),
         stream: true,
         max_tokens: request.options?.maxTokens ?? request.maxTokens,
       };

--- a/workers/gateway/src/process/run-control-command.test.ts
+++ b/workers/gateway/src/process/run-control-command.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import { parseRunControlCommand } from "./run-control-command";
 
 describe("parseRunControlCommand", () => {
-  it("parses sends that continue the run", () => {
-    expect(parseRunControlCommand(`message send --message 'Here is an update.'`)).toEqual({
+  it("parses sends that continue the run", async () => {
+    expect(await parseRunControlCommand(`message send --message 'Here is an update.'`)).toEqual({
       ok: true,
       command: { action: "message", text: "Here is an update.", finish: false },
     });
-    expect(parseRunControlCommand(`message send --message 'hey, i'm here. what's up?'`)).toEqual({
+    expect(await parseRunControlCommand(`message send --message 'hey, i'm here. what's up?'`)).toEqual({
       ok: true,
       command: {
         action: "message",
@@ -17,9 +17,9 @@ describe("parseRunControlCommand", () => {
     });
   });
 
-  it("parses opaque message blocks with optional yield composition", () => {
+  it("parses opaque message blocks with optional yield composition", async () => {
     expect(
-      parseRunControlCommand(
+      await parseRunControlCommand(
         `message send <<'GSV_MESSAGE'
 Here's $HOME, \`literal code\`, and "both" quotes.
 
@@ -35,7 +35,7 @@ GSV_MESSAGE`,
       },
     });
     expect(
-      parseRunControlCommand(
+      await parseRunControlCommand(
         `message send <<'GSV_MESSAGE' && yield
 Finished.
 GSV_MESSAGE`,
@@ -45,7 +45,7 @@ GSV_MESSAGE`,
       command: { action: "message", text: "Finished.", finish: true },
     });
     expect(
-      parseRunControlCommand(
+      await parseRunControlCommand(
         `message send <<'GSV_MESSAGE'
 Finished.
 
@@ -59,25 +59,25 @@ GSV_MESSAGE
     });
   });
 
-  it("parses standalone and one-line composed yield", () => {
-    expect(parseRunControlCommand("yield")).toEqual({
+  it("parses standalone and one-line composed yield", async () => {
+    expect(await parseRunControlCommand("yield")).toEqual({
       ok: true,
       command: { action: "yield" },
     });
-    expect(parseRunControlCommand("yield now")).toEqual({
+    expect(await parseRunControlCommand("yield now")).toEqual({
       ok: false,
       action: "yield",
       error: "yield does not accept arguments",
     });
-    expect(parseRunControlCommand(`message send --message 'Finished.' && yield`)).toEqual({
+    expect(await parseRunControlCommand(`message send --message 'Finished.' && yield`)).toEqual({
       ok: true,
       command: { action: "message", text: "Finished.", finish: true },
     });
   });
 
-  it("rejects an unterminated message block", () => {
+  it("rejects an unterminated message block", async () => {
     expect(
-      parseRunControlCommand(
+      await parseRunControlCommand(
         `message send <<'GSV_MESSAGE'
 This block never closes.`,
       ),
@@ -88,25 +88,25 @@ This block never closes.`,
     });
   });
 
-  it("accepts an attachment-only current-conversation send", () => {
-    expect(parseRunControlCommand("message send")).toEqual({
+  it("accepts an attachment-only current-conversation send", async () => {
+    expect(await parseRunControlCommand("message send")).toEqual({
       ok: true,
       command: { action: "message", text: "", finish: false },
     });
-    expect(parseRunControlCommand("message send && yield")).toEqual({
+    expect(await parseRunControlCommand("message send && yield")).toEqual({
       ok: true,
       command: { action: "message", text: "", finish: true },
     });
   });
 
-  it("leaves explicit additional sends to the ordinary shell command", () => {
+  it("leaves explicit additional sends to the ordinary shell command", async () => {
     expect(
-      parseRunControlCommand("message send --to telegram --message 'also there' --also"),
+      await parseRunControlCommand("message send --to telegram --message 'also there' --also"),
     ).toBeNull();
   });
 
-  it("rejects unsupported current-conversation options", () => {
-    expect(parseRunControlCommand("message send --to telegram --message hi")).toEqual({
+  it("rejects unsupported current-conversation options", async () => {
+    expect(await parseRunControlCommand("message send --to telegram --message hi")).toEqual({
       ok: false,
       action: "message",
       error: "message send does not accept --to for the current conversation; "
@@ -115,12 +115,12 @@ This block never closes.`,
     });
   });
 
-  it("treats the message option tail as opaque text", () => {
-    expect(parseRunControlCommand("message send --message safe; echo unsafe")).toEqual({
+  it("treats the message option tail as opaque text", async () => {
+    expect(await parseRunControlCommand("message send --message safe; echo unsafe")).toEqual({
       ok: true,
       command: { action: "message", text: "safe; echo unsafe", finish: false },
     });
-    expect(parseRunControlCommand('message send --message "$(cat /root/secret)"')).toEqual({
+    expect(await parseRunControlCommand('message send --message "$(cat /root/secret)"')).toEqual({
       ok: true,
       command: {
         action: "message",

--- a/workers/gateway/src/process/run-control-command.ts
+++ b/workers/gateway/src/process/run-control-command.ts
@@ -1,6 +1,17 @@
-import { Bash, type SimpleCommandNode, type StatementNode, type WordNode } from "just-bash";
+import type { Bash, SimpleCommandNode, StatementNode, WordNode } from "just-bash";
+import { loadJustBash } from "../shared/just-bash";
 
-const runControlBash = new Bash({ commands: [] });
+let runControlBash: Promise<Bash> | undefined;
+
+function runControlParser(): Promise<Bash> {
+  runControlBash ??= loadJustBash()
+    .then(({ Bash: BashRuntime }) => new BashRuntime({ commands: [] }))
+    .catch((error) => {
+      runControlBash = undefined;
+      throw error;
+    });
+  return runControlBash;
+}
 
 type RunControlCommand =
   | { action: "message"; text: string; finish: boolean }
@@ -10,10 +21,13 @@ export type RunControlCommandParseResult =
   | { ok: true; command: RunControlCommand }
   | { ok: false; action: RunControlCommand["action"]; error: string };
 
-export function parseRunControlCommand(input: string): RunControlCommandParseResult | null {
+export async function parseRunControlCommand(
+  input: string,
+): Promise<RunControlCommandParseResult | null> {
+  const bash = await runControlParser();
   let statements: StatementNode[];
   try {
-    statements = runControlBash.transform(input).ast.statements;
+    statements = bash.transform(input).ast.statements;
   } catch (error) {
     const delimiter = error instanceof Error ? unterminatedMessageDelimiter(input, error) : null;
     if (delimiter) {
@@ -40,7 +54,7 @@ export function parseRunControlCommand(input: string): RunControlCommandParseRes
         };
   }
   if (name !== "message" || literalWord(control.command.args[0]) !== "send") return null;
-  return parseMessageCommand(input, control.command, control.finish);
+  return parseMessageCommand(bash, input, control.command, control.finish);
 }
 
 function controlCommand(
@@ -77,6 +91,7 @@ function simpleCommand(statement: StatementNode, index: number): SimpleCommandNo
 }
 
 function parseMessageCommand(
+  bash: Bash,
   input: string,
   command: SimpleCommandNode,
   finish: boolean,
@@ -87,12 +102,12 @@ function parseMessageCommand(
     return parseMessageHeredoc(input, command, finish);
   }
   if (!args.every((arg): arg is string => arg !== null)) {
-    return parseOpaqueMessageSend(messageSource(input, finish), finish);
+    return parseOpaqueMessageSend(messageSource(bash, input, finish), finish);
   }
   const parsed = parseMessageSend(args.slice(1), finish);
   return parsed.ok
     ? parsed
-    : (parseOpaqueMessageSend(messageSource(input, finish), finish) ?? parsed);
+    : (parseOpaqueMessageSend(messageSource(bash, input, finish), finish) ?? parsed);
 }
 
 function parseMessageHeredoc(
@@ -128,9 +143,9 @@ function parseMessageHeredoc(
   return { ok: true, command: { action: "message", text, finish } };
 }
 
-function messageSource(input: string, finish: boolean): string {
+function messageSource(bash: Bash, input: string, finish: boolean): string {
   if (!finish) return input;
-  const source = runControlBash.transform(input).ast.statements[0]?.sourceText ?? input;
+  const source = bash.transform(input).ast.statements[0]?.sourceText ?? input;
   return source.replace(/[ \t]+&&[ \t]+yield[ \t]*$/, "");
 }
 

--- a/workers/gateway/src/process/run-tick-policy.test.ts
+++ b/workers/gateway/src/process/run-tick-policy.test.ts
@@ -34,7 +34,7 @@ function config(overrides: Partial<AiConfigResult> = {}): AiConfigResult {
 }
 
 describe("run tick policy", () => {
-  it("classifies assistant turns without overlapping continuation categories", () => {
+  it("classifies assistant turns without overlapping continuation categories", async () => {
     const runControl = {
       type: "toolCall" as const,
       id: "yield-call",
@@ -54,14 +54,14 @@ describe("run tick policy", () => {
       arguments: {},
     };
 
-    expect(classifyAssistantTurn(assistant([runControl]), ["Read"]).kind).toBe("run-control");
-    expect(classifyAssistantTurn(assistant([runControl, read]), ["Read"]).kind).toBe(
+    expect((await classifyAssistantTurn(assistant([runControl]), ["Read"])).kind).toBe("run-control");
+    expect((await classifyAssistantTurn(assistant([runControl, read]), ["Read"])).kind).toBe(
       "invalid-run-control",
     );
-    expect(classifyAssistantTurn(assistant([read, forged]), ["Read"]).kind).toBe("tools");
-    expect(classifyAssistantTurn(assistant([forged]), ["Read"]).kind).toBe("unoffered-tools");
+    expect((await classifyAssistantTurn(assistant([read, forged]), ["Read"])).kind).toBe("tools");
+    expect((await classifyAssistantTurn(assistant([forged]), ["Read"])).kind).toBe("unoffered-tools");
     expect(
-      classifyAssistantTurn(assistant([{ type: "text", text: "done" }]), ["Read"]),
+      await classifyAssistantTurn(assistant([{ type: "text", text: "done" }]), ["Read"]),
     ).toMatchObject({ kind: "terminal", text: "done" });
   });
 

--- a/workers/gateway/src/process/run-tick-policy.ts
+++ b/workers/gateway/src/process/run-tick-policy.ts
@@ -34,10 +34,10 @@ const terminalShellToolArgsSchema = z
   })
   .strict();
 
-export function classifyAssistantTurn(
+export async function classifyAssistantTurn(
   response: AssistantMessage,
   offeredToolNames: readonly string[],
-): AssistantTurnClassification {
+): Promise<AssistantTurnClassification> {
   const text = response.content
     .filter((block): block is TextContent => block.type === "text")
     .map((block) => block.text)
@@ -48,10 +48,9 @@ export function classifyAssistantTurn(
   const returnedToolCalls = response.content.filter(
     (block): block is ToolCall => block.type === "toolCall",
   );
-  const runControlCalls = returnedToolCalls.flatMap((toolCall) => {
-    const call = parseRunControlShellCall(toolCall);
-    return call ? [call] : [];
-  });
+  const runControlCalls = (
+    await Promise.all(returnedToolCalls.map((toolCall) => parseRunControlShellCall(toolCall)))
+  ).flatMap((call) => (call ? [call] : []));
   const runControlIds = new Set(runControlCalls.map(({ toolCall }) => toolCall.id));
   const offered = new Set(offeredToolNames);
   const toolCalls = returnedToolCalls.filter(
@@ -98,11 +97,11 @@ export function nextAiConfigFallback(
   return null;
 }
 
-function parseRunControlShellCall(toolCall: ToolCall): RunControlShellCall | null {
+async function parseRunControlShellCall(toolCall: ToolCall): Promise<RunControlShellCall | null> {
   if (toolCall.name !== "Shell") return null;
   const args = terminalShellToolArgsSchema.safeParse(toolCall.arguments);
   if (!args.success) return null;
-  const parsed = parseRunControlCommand(args.data.input);
+  const parsed = await parseRunControlCommand(args.data.input);
   return parsed ? { toolCall, parsed } : null;
 }
 

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -1256,7 +1256,7 @@ export class ProcessRun {
     generated: GeneratedRunTick,
   ): Promise<PersistedRunTick | null> {
     const { prepared, response, fallbackMetadata, inferenceSpanId } = generated;
-    const turn = classifyAssistantTurn(
+    const turn = await classifyAssistantTurn(
       response,
       prepared.workTools.map((tool) => tool.name),
     );

--- a/workers/gateway/src/shared/just-bash.ts
+++ b/workers/gateway/src/shared/just-bash.ts
@@ -1,0 +1,19 @@
+import type { Bash } from "just-bash";
+
+export type JustBash = { Bash: typeof Bash };
+
+let justBash: Promise<JustBash> | undefined;
+
+/**
+ * just-bash is the largest single piece of the Worker's start-up evaluation,
+ * and only the native shell and the run-control parser need it. Loading it on
+ * first use keeps that cost off every isolate start. A failed load is not
+ * cached, so the next caller retries it.
+ */
+export function loadJustBash(): Promise<JustBash> {
+  justBash ??= import("just-bash").catch((error) => {
+    justBash = undefined;
+    throw error;
+  });
+  return justBash;
+}

--- a/workers/gateway/test-support/preload-lazy-modules.ts
+++ b/workers/gateway/test-support/preload-lazy-modules.ts
@@ -1,0 +1,5 @@
+// The custom provider driver loads pi-ai's chat-completions module on first
+// use. In a full parallel run that first import can wait several seconds on
+// the Vite server, longer than a test's budget, so each test file loads it
+// before its tests start.
+import "@earendil-works/pi-ai/api/openai-completions";

--- a/workers/gateway/vitest.config.ts
+++ b/workers/gateway/vitest.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       "**/test-integration/**",
       "src/process/do.*.test.ts",
     ],
+    setupFiles: ["./test-support/preload-lazy-modules.ts"],
     deps: {
       optimizer: {
         ssr: {


### PR DESCRIPTION
## What this is

The approved eager-loading pass: keep just-bash and pi-ai's chat-completions module out of the Worker's start-up evaluation. Three small commits, behaviour unchanged. The measured win is real but modest, and the body below says exactly how modest so the merge decision is an informed one.

## Changes

- **pi-ai chat completions on first use.** `custom-provider.ts` was the one static import of `api/openai-completions`, which drags the OpenAI SDK into start-up evaluation. It is now a cached dynamic import, the same shape pi-ai uses for its own `.lazy` wrappers. A failed load is not cached, so the next request retries and surfaces the same error as before.
- **Native shell commands without just-bash.** The 23 command modules imported just-bash's `defineCommand`, which is literally `{ name, trusted, execute }`. A local `defineCommand` in `shell/command.ts` keeps only type imports from just-bash in those modules.
- **just-bash on the first shell command or run-control parse.** `shared/just-bash.ts` is a cached loader. The shell driver awaits it in `handleShellExec`; the run-control parser built a `Bash` at module load, so `parseRunControlCommand`, `parseRunControlShellCall`, and `classifyAssistantTurn` became async, with one production call site in the run runtime.
- **Test harness.** A vitest `setupFiles` preload of the chat-completions module. Under a full parallel run the first dynamic import of that module waited on the Vite server for over five seconds and timed out whichever test hit it first; preloading makes it deterministic.

## What it measured

Whole bundled Worker evaluated under Node with `cloudflare:*` stubbed, minified, seven interleaved runs, medians.

| Variant | bytes | gzip | evaluation |
|---|---|---|---|
| main | 5,167,827 | 1,224,396 | 254 ms |
| this branch | 5,170,200 | 1,225,842 | 236 ms |

Two findings behind the numbers:

- **wrangler does not code-split**, so a dynamic import defers a module's evaluation, not its bytes or its parse. That caps what lazy loading can do here.
- **The providers were already lazy.** pi-ai's provider modules use `.lazy` API wrappers, so Google GenAI, Anthropic, and the rest were already evaluated on first use on main; only the OpenAI SDK was eager, through the static import above. What `providers/all` still costs at start-up is its catalog (40 factories plus about 500 KB of model JSON, roughly 25 ms). Making that lazy means async model resolution through the sync stream path and the module-level Workers AI provider, so it is deliberately not in this PR.

A tried-and-rejected shape is worth recording: dynamically importing the whole shell driver made esbuild wrap the driver's entire shared subtree and came out about 40 ms slower.

The side effect that may matter more day to day: the unit suite's wall clock dropped from 101 s to 57–84 s, since most test files no longer import just-bash and the chat chain.

## Validation

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | clean |
| `npm run test:unit` | 116 files, 1733 tests, twice |
| `npm run test:integration` | 32 tests (the harness resolves the browser condition, which the dynamic just-bash import needs) |
| Bundle budget | 1,225,842 gzip bytes, 1.57 MB headroom |
