### PR TITLE
list a link to a directory as a directory

### DIFF
--- a/host/apps/machine/src/tools/read.rs
+++ b/host/apps/machine/src/tools/read.rs
@@ -81,7 +81,16 @@ fn read_directory(path: &Path) -> Result<ToolOutput, String> {
             .file_type()
             .map_err(|e| format!("Failed to inspect '{}': {}", entry.path().display(), e))?;
 
-        if file_type.is_dir() {
+        // A link to a directory is a directory to whoever lists it: follow links when deciding.
+        let is_directory = if file_type.is_symlink() {
+            fs::metadata(entry.path())
+                .map(|metadata| metadata.is_dir())
+                .unwrap_or(false)
+        } else {
+            file_type.is_dir()
+        };
+
+        if is_directory {
             directories.push(name);
         } else {
             files.push(name);
@@ -458,5 +467,33 @@ mod tests {
         assert_eq!(actual, "é");
 
         fs::remove_dir_all(root).unwrap();
+    }
+}
+
+#[cfg(all(test, unix))]
+mod symlink_tests {
+    use super::read_directory;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn a_link_to_a_directory_lists_as_a_directory() {
+        let root = std::env::temp_dir().join(format!("gsv-read-symlink-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("real")).expect("create real dir");
+        fs::write(root.join("note.txt"), "hi").expect("write file");
+        symlink(root.join("real"), root.join("linked")).expect("link dir");
+        symlink(root.join("note.txt"), root.join("linked-note")).expect("link file");
+
+        let output = read_directory(&root).expect("listing");
+        let directories: Vec<String> =
+            serde_json::from_value(output.data["directories"].clone()).expect("dirs");
+        let files: Vec<String> =
+            serde_json::from_value(output.data["files"].clone()).expect("files");
+        assert!(directories.contains(&"linked".to_string()));
+        assert!(directories.contains(&"real".to_string()));
+        assert!(files.contains(&"linked-note".to_string()));
+        assert!(files.contains(&"note.txt".to_string()));
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/host/apps/machine/src/tools/read.rs
+++ b/host/apps/machine/src/tools/read.rs
@@ -146,7 +146,12 @@ impl Tool for ReadTool {
             .map_err(|e| format!("Failed to read '{}': {}", resolved.display(), e))?;
 
         if metadata.is_dir() {
-            return read_directory(&resolved);
+            // Listing walks the directory and follows links synchronously; a slow mount must not hold a
+            // runtime worker, so the whole listing runs on the blocking pool.
+            let listing_path = resolved.clone();
+            return tokio::task::spawn_blocking(move || read_directory(&listing_path))
+                .await
+                .map_err(|e| format!("Failed to read '{}': {}", resolved.display(), e))?;
         }
 
         let size = metadata.len();


### PR DESCRIPTION
## What this is

A machine's directory listing classified an entry by the link itself, so a symlink to a directory was reported as a file. Reading it then returned a listing, which surprised every client: the web showed such entries as files that "would not open".

## Change

`read_directory` follows links when deciding whether an entry is a directory (`fs::metadata` on the entry's path), and falls back to the link's own type when the target is missing, so a broken link still lists as a file rather than failing the whole listing. One test creates a real directory, a file, and a link to each, and asserts the linked directory lists as a directory and the linked file as a file.

## Validation

| Check | Result |
|---|---|
| `cargo test -p machine symlink` | passing |
| `cargo clippy --package machine --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

Seen on the maintainer's own machine with `~/.agents/skills/`, whose entries are links to directories.
