### PR TITLE
let an automatic update replace only the daemon and the cli

### DIFF
--- a/docs/how-to/install-host-apps.md
+++ b/docs/how-to/install-host-apps.md
@@ -35,6 +35,10 @@ irm https://install.gsv.space/install.ps1 | iex
 
 Use `GSV_CHANNEL=dev` for the moving development channel, or set
 `GSV_VERSION=vX.Y.Z` to install an immutable release tag.
+`GSV_INSTALL_COMPONENTS` selects a subset of `gsv`, `gsvd`, `gsv-desktop`,
+`gsv-transcribe`, and `gsv-vision` (default: all); a helper brings its license
+and provenance files with it, and the subset is verified, installed, and rolled
+back on its own.
 
 ## Install location
 
@@ -117,6 +121,12 @@ gsv config --local set device.auto_update false
 
 The daemon reads that setting again at every handshake, so the change applies
 the next time it connects; `gsv daemon reload` applies it immediately.
+
+An automatic update replaces only `gsvd` and `gsv`, which owns the service
+definition; it passes `GSV_INSTALL_COMPONENTS=gsv,gsvd` to the installer, so
+Desktop and its transcription and gesture helpers are left exactly as they
+were and a running Desktop never meets a helper it does not know. Desktop
+updates stay yours to start.
 
 The CLI and Desktop are never replaced while a person is using them. The CLI
 prints a hint when the gateway runs a newer release; rerun the installer to

--- a/docs/how-to/install-host-apps.md
+++ b/docs/how-to/install-host-apps.md
@@ -38,7 +38,9 @@ Use `GSV_CHANNEL=dev` for the moving development channel, or set
 `GSV_INSTALL_COMPONENTS` selects a subset of `gsv`, `gsvd`, `gsv-desktop`,
 `gsv-transcribe`, and `gsv-vision` (default: all); a helper brings its license
 and provenance files with it, and the subset is verified, installed, and rolled
-back on its own.
+back on its own. `gsv` and `gsvd` move together, since the CLI refuses to
+control a daemon of another version. A pinned release whose installer predates
+this option refuses a subset rather than installing everything.
 
 ## Install location
 

--- a/docs/how-to/install-host-apps.md
+++ b/docs/how-to/install-host-apps.md
@@ -38,9 +38,11 @@ Use `GSV_CHANNEL=dev` for the moving development channel, or set
 `GSV_INSTALL_COMPONENTS` selects a subset of `gsv`, `gsvd`, `gsv-desktop`,
 `gsv-transcribe`, and `gsv-vision` (default: all); a helper brings its license
 and provenance files with it, and the subset is verified, installed, and rolled
-back on its own. `gsv` and `gsvd` move together, since the CLI refuses to
-control a daemon of another version. A pinned release whose installer predates
-this option refuses a subset rather than installing everything.
+back on its own. Components move in two groups: `gsv` with `gsvd`, since the
+CLI refuses to control a daemon of another version, and `gsv-desktop` with
+both helpers, since they share private protocols. A pinned release whose
+installer predates this option refuses a subset rather than installing
+everything.
 
 ## Install location
 

--- a/host/apps/machine/src/update.rs
+++ b/host/apps/machine/src/update.rs
@@ -29,6 +29,10 @@ fn is_release_tag(tag: &str) -> bool {
     tag == DEV_RELEASE_TAG || (tag.starts_with('v') && parse_version(tag).is_some())
 }
 
+/// The components an unattended update replaces: the daemon and the CLI
+/// that owns its service definition, never Desktop or its helpers.
+pub const UNATTENDED_COMPONENTS: &str = "gsv,gsvd";
+
 /// Where the public installer lives when the gateway does not name one.
 pub const DEFAULT_INSTALLER_URL: &str = "https://install.gsv.space";
 /// The daemon starts at most one installer per hour, whatever the outcome.
@@ -717,6 +721,14 @@ pub fn installer_invocation(
         (
             "GSV_INSTALL_DIR".to_string(),
             install_dir.display().to_string(),
+        ),
+        // Only the daemon and the CLI that owns its service definition.
+        // Desktop and its helpers stay as they are: a running Desktop must
+        // not find a helper that no longer speaks its private protocol, and
+        // Desktop updates are the person's to start.
+        (
+            "GSV_INSTALL_COMPONENTS".to_string(),
+            UNATTENDED_COMPONENTS.to_string(),
         ),
     ];
     if cfg!(windows) {
@@ -1741,6 +1753,9 @@ mod tests {
         assert!(invocation
             .env
             .contains(&("GSV_INSTALL_DIR".to_string(), "/usr/local/bin".to_string())));
+        assert!(invocation
+            .env
+            .contains(&("GSV_INSTALL_COMPONENTS".to_string(), "gsv,gsvd".to_string())));
         if cfg!(windows) {
             assert_eq!(invocation.program, "powershell.exe");
             assert!(invocation.args.contains(&"-NonInteractive".to_string()));

--- a/install.ps1
+++ b/install.ps1
@@ -8,6 +8,13 @@ $InstallDir = if ($env:GSV_INSTALL_DIR) {
   Join-Path $env:LOCALAPPDATA "Programs\gsv\bin"
 }
 $Channel = if ($env:GSV_CHANNEL) { $env:GSV_CHANNEL } else { "stable" }
+# Which parts of the distribution to install; Windows publishes gsv and gsvd.
+$AllComponents = @("gsv", "gsvd")
+$Components = if ($env:GSV_INSTALL_COMPONENTS) {
+  @($env:GSV_INSTALL_COMPONENTS -split "," | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+} else {
+  $AllComponents
+}
 $Version = if ($env:GSV_VERSION) { $env:GSV_VERSION } else { "" }
 $ConfigRoot = if ($env:APPDATA) { $env:APPDATA } else { Join-Path $env:USERPROFILE "AppData\Roaming" }
 $ConfigDir = Join-Path $ConfigRoot "gsv"
@@ -176,9 +183,15 @@ function Install-GsvHost {
 
   $releaseRef = Resolve-ReleaseRef
   $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString("N"))
-  $assets = [ordered]@{
-    "gsv-$Platform.exe" = "gsv.exe"
-    "gsvd-$Platform.exe" = "gsvd.exe"
+  if ($Components.Count -eq 0) { throw "GSV_INSTALL_COMPONENTS must name at least one component" }
+  foreach ($component in $Components) {
+    if ($AllComponents -notcontains $component) {
+      throw "Unknown component in GSV_INSTALL_COMPONENTS: $component (choose from $($AllComponents -join ','))"
+    }
+  }
+  $assets = [ordered]@{}
+  foreach ($component in $Components) {
+    $assets["$component-$Platform.exe"] = "$component.exe"
   }
   $taskExisted = $false
   $taskWasRunning = $false
@@ -275,7 +288,7 @@ if (-not $Version) {
     Write-Warn "Could not persist release.channel"
   }
 }
-Write-Success "Installed gsv and gsvd to $InstallDir"
+Write-Success "Installed $($Components -join ', ') to $InstallDir"
 Write-Warn "GSV Desktop is not yet released for Windows."
 Write-Host ""
 Write-Host "  Next: gsv auth setup"

--- a/install.ps1
+++ b/install.ps1
@@ -184,10 +184,17 @@ function Install-GsvHost {
   $releaseRef = Resolve-ReleaseRef
   $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString("N"))
   if ($Components.Count -eq 0) { throw "GSV_INSTALL_COMPONENTS must name at least one component" }
+  $seen = @{}
   foreach ($component in $Components) {
     if ($AllComponents -notcontains $component) {
       throw "Unknown component in GSV_INSTALL_COMPONENTS: $component (choose from $($AllComponents -join ','))"
     }
+    if ($seen.ContainsKey($component)) { throw "Component listed twice in GSV_INSTALL_COMPONENTS: $component" }
+    $seen[$component] = $true
+  }
+  # gsv controls gsvd and refuses a daemon of another version, so the pair moves together
+  if (($Components -contains "gsv") -ne ($Components -contains "gsvd")) {
+    throw "gsv and gsvd move together: select both or neither"
   }
   $assets = [ordered]@{}
   foreach ($component in $Components) {

--- a/install.sh
+++ b/install.sh
@@ -111,6 +111,8 @@ validate_components() {
     # gsv controls gsvd and refuses a daemon of another version; Desktop and its helpers share private protocols
     validate_group "$HOST_GROUP" "$seen" "gsv and gsvd"
     validate_group "$DESKTOP_GROUP" "$seen" "gsv-desktop, gsv-transcribe and gsv-vision"
+    HOST_SELECTED=0
+    case "$seen" in *,gsv,*) HOST_SELECTED=1 ;; esac
 }
 
 # The release assets for the selected components, in install order. A
@@ -436,8 +438,10 @@ service_snapshot() {
     SERVICE_WAS_ACTIVE=0
     SERVICE_WAS_ENABLED=0
     # Desktop owns that service and the executable it runs; do not stop,
-    # migrate, or restart it here.
+    # migrate, or restart it here. An install that does not touch the daemon
+    # leaves its service alone as well.
     [ "$DESKTOP_MANAGED_DAEMON" -eq 0 ] || return 0
+    [ "$HOST_SELECTED" -eq 1 ] || return 0
     if [ "$OS" = "linux" ]; then
         SERVICE_PATH="${CONFIG_HOME}/systemd/user/gsvd.service"
         if [ -f "$SERVICE_PATH" ]; then
@@ -685,10 +689,13 @@ main() {
         exit 1
     fi
 
-    # The config must be complete before the replacement daemon starts, or
-    # it reads the old release channel until its next restart.
-    ensure_config_file
-    persist_release_channel
+    # The config belongs to the daemon and must be complete before its
+    # replacement starts, or it reads the old release channel until its next
+    # restart; an install without the daemon leaves it as it is.
+    if [ "$HOST_SELECTED" -eq 1 ]; then
+        ensure_config_file
+        persist_release_channel
+    fi
 
     if [ "$SERVICE_INSTALLED" -eq 1 ]; then
         if ! "${INSTALL_DIR}/gsv" daemon start >/dev/null || ! health_check_service; then

--- a/install.sh
+++ b/install.sh
@@ -76,13 +76,24 @@ validate_channel() {
 
 validate_components() {
     [ -n "$COMPONENTS" ] || { error "GSV_INSTALL_COMPONENTS must name at least one component"; exit 1; }
-    local component
+    local component seen="," has_gsv=0 has_gsvd=0
     for component in $(printf '%s' "$COMPONENTS" | tr ',' ' '); do
         case ",${ALL_COMPONENTS}," in
             *",${component},"*) ;;
             *) error "Unknown component in GSV_INSTALL_COMPONENTS: $component (choose from ${ALL_COMPONENTS})"; exit 1 ;;
         esac
+        case "$seen" in
+            *",${component},"*) error "Component listed twice in GSV_INSTALL_COMPONENTS: $component"; exit 1 ;;
+        esac
+        seen="${seen}${component},"
+        [ "$component" = gsv ] && has_gsv=1
+        [ "$component" = gsvd ] && has_gsvd=1
     done
+    # gsv controls gsvd and refuses a daemon of another version, so the pair moves together
+    if [ "$has_gsv" -ne "$has_gsvd" ]; then
+        error "gsv and gsvd move together: select both or neither"
+        exit 1
+    fi
 }
 
 # The release assets for the selected components, in install order. A
@@ -297,6 +308,12 @@ delegate_to_pinned_installer() {
         exit 1
     fi
     success "Verified installer for $VERSION"
+    # an installer from before component selection would install everything; refuse rather than surprise
+    if [ "$COMPONENTS" != "$ALL_COMPONENTS" ] && ! grep -q "GSV_INSTALL_COMPONENTS" "$installer_file"; then
+        rm -rf "$bootstrap_dir"
+        error "The installer for $VERSION predates component selection; unset GSV_INSTALL_COMPONENTS or pin a newer release"
+        exit 1
+    fi
 
     local status=0
     GSV_INSTALLER_RELEASE_BOUND=1 bash "$installer_file" || status=$?

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,11 @@ INSTALL_DIR_SOURCE=""
 DESKTOP_MANAGED_DAEMON=0
 CHANNEL="${GSV_CHANNEL:-stable}"
 VERSION="${GSV_VERSION:-}"
+# Which parts of the distribution to install. The daemon's unattended update
+# passes `gsv,gsvd` so Desktop and its helpers are never swapped under a
+# running Desktop; a person installs everything.
+ALL_COMPONENTS="gsv,gsvd,gsv-desktop,gsv-transcribe,gsv-vision"
+COMPONENTS="${GSV_INSTALL_COMPONENTS:-$ALL_COMPONENTS}"
 if [ "$(uname -s)" = "Darwin" ]; then
     CONFIG_HOME="${HOME}/Library/Application Support"
 else
@@ -67,6 +72,44 @@ validate_channel() {
             *[!A-Za-z0-9._-]*) error "Invalid GSV_VERSION release tag"; exit 1 ;;
         esac
     fi
+}
+
+validate_components() {
+    [ -n "$COMPONENTS" ] || { error "GSV_INSTALL_COMPONENTS must name at least one component"; exit 1; }
+    local component
+    for component in $(printf '%s' "$COMPONENTS" | tr ',' ' '); do
+        case ",${ALL_COMPONENTS}," in
+            *",${component},"*) ;;
+            *) error "Unknown component in GSV_INSTALL_COMPONENTS: $component (choose from ${ALL_COMPONENTS})"; exit 1 ;;
+        esac
+    done
+}
+
+# The release assets for the selected components, in install order. A
+# helper brings its license and provenance sidecars with it, so a subset is
+# complete, verified, and rolled back on its own.
+select_assets() {
+    ASSETS=()
+    TARGETS=()
+    EXECUTABLES=()
+    local component
+    for component in $(printf '%s' "$COMPONENTS" | tr ',' ' '); do
+        ASSETS+=("${component}-${PLATFORM}")
+        TARGETS+=("$component")
+        EXECUTABLES+=(1)
+        case "$component" in
+            gsv-transcribe)
+                ASSETS+=("gsv-transcribe-THIRD_PARTY.md")
+                TARGETS+=("gsv-transcribe-THIRD_PARTY.md")
+                EXECUTABLES+=(0)
+                ;;
+            gsv-vision)
+                ASSETS+=("gsv-vision-LICENSE.apache-2.0" "gsv-vision-PROVENANCE.md")
+                TARGETS+=("gsv-vision-LICENSE.apache-2.0" "gsv-vision-PROVENANCE.md")
+                EXECUTABLES+=(0 0)
+                ;;
+        esac
+    done
 }
 
 # Turn a plist string back into the path it encodes: the five XML entities
@@ -563,6 +606,7 @@ cleanup() {
 main() {
     detect_platform
     validate_channel
+    validate_components
     delegate_to_pinned_installer
     resolve_install_dir
     local release_ref
@@ -572,30 +616,14 @@ main() {
     BACKUPS=()
     trap cleanup EXIT INT TERM
 
-    ASSETS=(
-        "gsv-${PLATFORM}"
-        "gsvd-${PLATFORM}"
-        "gsv-desktop-${PLATFORM}"
-        "gsv-transcribe-${PLATFORM}"
-        "gsv-vision-${PLATFORM}"
-        "gsv-transcribe-THIRD_PARTY.md"
-        "gsv-vision-LICENSE.apache-2.0"
-        "gsv-vision-PROVENANCE.md"
-    )
-    TARGETS=(
-        "gsv"
-        "gsvd"
-        "gsv-desktop"
-        "gsv-transcribe"
-        "gsv-vision"
-        "gsv-transcribe-THIRD_PARTY.md"
-        "gsv-vision-LICENSE.apache-2.0"
-        "gsv-vision-PROVENANCE.md"
-    )
-    EXECUTABLES=(1 1 1 1 1 0 0 0)
+    select_assets
 
     echo ""
-    echo -e "  ${BOLD}GSV host installer${NC} · ${PLATFORM} · ${release_ref}"
+    if [ "$COMPONENTS" = "$ALL_COMPONENTS" ]; then
+        echo -e "  ${BOLD}GSV host installer${NC} · ${PLATFORM} · ${release_ref}"
+    else
+        echo -e "  ${BOLD}GSV host installer${NC} · ${PLATFORM} · ${release_ref} · ${COMPONENTS}"
+    fi
     echo ""
     info "Downloading release manifest"
     local checksum_url
@@ -643,7 +671,11 @@ main() {
     INSTALL_IN_PROGRESS=0
     remove_backups
     configure_path
-    success "Installed gsv, gsvd, Desktop, and local helpers to $INSTALL_DIR"
+    if [ "$COMPONENTS" = "$ALL_COMPONENTS" ]; then
+        success "Installed gsv, gsvd, Desktop, and local helpers to $INSTALL_DIR"
+    else
+        success "Installed ${COMPONENTS//,/, } to $INSTALL_DIR"
+    fi
     echo ""
     if [ "$INSTALL_DIR_SOURCE" = "default" ] && ! path_already_configured; then
         echo "  Open a new shell, or run now: export PATH=\"\$HOME/.gsv/bin:\$PATH\""

--- a/install.sh
+++ b/install.sh
@@ -18,10 +18,13 @@ INSTALL_DIR_SOURCE=""
 DESKTOP_MANAGED_DAEMON=0
 CHANNEL="${GSV_CHANNEL:-stable}"
 VERSION="${GSV_VERSION:-}"
-# Which parts of the distribution to install. The daemon's unattended update
-# passes `gsv,gsvd` so Desktop and its helpers are never swapped under a
-# running Desktop; a person installs everything.
+# Which parts of the distribution to install, in two groups that move as one:
+# the host pair (`gsv,gsvd`, what the daemon's unattended update passes so
+# Desktop is never swapped under itself) and Desktop with its helpers, which
+# share private protocols. A person installs everything.
 ALL_COMPONENTS="gsv,gsvd,gsv-desktop,gsv-transcribe,gsv-vision"
+HOST_GROUP="gsv gsvd"
+DESKTOP_GROUP="gsv-desktop gsv-transcribe gsv-vision"
 COMPONENTS="${GSV_INSTALL_COMPONENTS:-$ALL_COMPONENTS}"
 if [ "$(uname -s)" = "Darwin" ]; then
     CONFIG_HOME="${HOME}/Library/Application Support"
@@ -74,10 +77,28 @@ validate_channel() {
     fi
 }
 
+# Every member of a group is selected, or none is.
+validate_group() {
+    local group="$1" seen="$2" name="$3" member present=0 missing=0
+    for member in $group; do
+        case "$seen" in
+            *",${member},"*) present=1 ;;
+            *) missing=1 ;;
+        esac
+    done
+    if [ "$present" -eq 1 ] && [ "$missing" -eq 1 ]; then
+        error "$name move together: select all of them or none"
+        exit 1
+    fi
+}
+
 validate_components() {
-    [ -n "$COMPONENTS" ] || { error "GSV_INSTALL_COMPONENTS must name at least one component"; exit 1; }
-    local component seen="," has_gsv=0 has_gsvd=0
-    for component in $(printf '%s' "$COMPONENTS" | tr ',' ' '); do
+    local tokens component seen=","
+    tokens="$(printf '%s' "$COMPONENTS" | tr ',' ' ')"
+    # shellcheck disable=SC2086
+    set -- $tokens
+    [ "$#" -gt 0 ] || { error "GSV_INSTALL_COMPONENTS must name at least one component"; exit 1; }
+    for component in "$@"; do
         case ",${ALL_COMPONENTS}," in
             *",${component},"*) ;;
             *) error "Unknown component in GSV_INSTALL_COMPONENTS: $component (choose from ${ALL_COMPONENTS})"; exit 1 ;;
@@ -86,14 +107,10 @@ validate_components() {
             *",${component},"*) error "Component listed twice in GSV_INSTALL_COMPONENTS: $component"; exit 1 ;;
         esac
         seen="${seen}${component},"
-        [ "$component" = gsv ] && has_gsv=1
-        [ "$component" = gsvd ] && has_gsvd=1
     done
-    # gsv controls gsvd and refuses a daemon of another version, so the pair moves together
-    if [ "$has_gsv" -ne "$has_gsvd" ]; then
-        error "gsv and gsvd move together: select both or neither"
-        exit 1
-    fi
+    # gsv controls gsvd and refuses a daemon of another version; Desktop and its helpers share private protocols
+    validate_group "$HOST_GROUP" "$seen" "gsv and gsvd"
+    validate_group "$DESKTOP_GROUP" "$seen" "gsv-desktop, gsv-transcribe and gsv-vision"
 }
 
 # The release assets for the selected components, in install order. A

--- a/scripts/test-host-installer.sh
+++ b/scripts/test-host-installer.sh
@@ -531,6 +531,13 @@ test "$("$SUBSET_DIR/gsv-transcribe")" = "transcribe-v2"
 test "$(cat "$SUBSET_DIR/gsv-transcribe-THIRD_PARTY.md")" = "license-v2"
 test "$("$SUBSET_DIR/gsv-vision")" = "vision-v2"
 test "$("$SUBSET_DIR/gsv")" = "gsv-v2"
+# Desktop and its helpers into a directory of their own leave the daemon's service and config alone.
+DESKTOP_DIR="$TEST_ROOT/desktop-bin"
+SYSTEMCTL_LINES_BEFORE="$(wc -l < "$SYSTEMCTL_LOG")"
+grep -q "Installed gsv-desktop, gsv-transcribe, gsv-vision to $DESKTOP_DIR" <<< "$(run_subset_installer env GSV_INSTALL_DIR="$DESKTOP_DIR" GSV_INSTALL_COMPONENTS="gsv-desktop,gsv-transcribe,gsv-vision")"
+test "$("$DESKTOP_DIR/gsv-desktop")" = "desktop-v2"
+test ! -e "$DESKTOP_DIR/gsv"
+test "$(wc -l < "$SYSTEMCTL_LOG")" = "$SYSTEMCTL_LINES_BEFORE"
 # A replacement gsv whose doctor fails rolls back gsv and gsvd only.
 cp "$SUBSET_DIR"/gsv-desktop "$SUBSET_DIR"/gsv-transcribe* "$SUBSET_DIR"/gsv-vision* "$SUBSET_BEFORE/"
 make_fixture gsv-linux-x64 gsv-v3 fail-doctor

--- a/scripts/test-host-installer.sh
+++ b/scripts/test-host-installer.sh
@@ -505,8 +505,16 @@ if run_subset_installer env GSV_INSTALL_COMPONENTS="gsv,gsvd,gsv" >/dev/null 2>&
     echo "installer accepted a component listed twice" >&2
     exit 1
 fi
-if run_subset_installer env GSV_INSTALL_COMPONENTS="gsvd,gsv-transcribe" >/dev/null 2>&1; then
+if run_subset_installer env GSV_INSTALL_COMPONENTS="gsvd,gsv-transcribe,gsv-vision,gsv-desktop" >/dev/null 2>&1; then
     echo "installer accepted gsvd without gsv" >&2
+    exit 1
+fi
+if run_subset_installer env GSV_INSTALL_COMPONENTS="gsv-transcribe" >/dev/null 2>&1; then
+    echo "installer accepted a helper without Desktop" >&2
+    exit 1
+fi
+if run_subset_installer env GSV_INSTALL_COMPONENTS="," >/dev/null 2>&1; then
+    echo "installer accepted a component list with no components" >&2
     exit 1
 fi
 test "$("$SUBSET_DIR/gsv")" = "gsv-v1"
@@ -516,14 +524,15 @@ grep -q "Installed gsv, gsvd to $SUBSET_DIR" <<< "$SUBSET_OUTPUT"
 test "$("$SUBSET_DIR/gsv")" = "gsv-v2"
 test "$("$SUBSET_DIR/gsvd")" = "gsvd-v2"
 untouched_by_subset
-# A helper brings its sidecars: the transcription subset is three files.
-grep -q "Verified 2 release artifacts" <<< "$(run_subset_installer env GSV_INSTALL_COMPONENTS="gsv-transcribe")"
+# Desktop and its helpers move as one group, and a helper brings its sidecars: six files, gsv and gsvd untouched.
+grep -q "Verified 6 release artifacts" <<< "$(run_subset_installer env GSV_INSTALL_COMPONENTS="gsv-desktop,gsv-transcribe,gsv-vision")"
+test "$("$SUBSET_DIR/gsv-desktop")" = "desktop-v2"
 test "$("$SUBSET_DIR/gsv-transcribe")" = "transcribe-v2"
 test "$(cat "$SUBSET_DIR/gsv-transcribe-THIRD_PARTY.md")" = "license-v2"
-test "$("$SUBSET_DIR/gsv-desktop")" = "desktop-v1"
+test "$("$SUBSET_DIR/gsv-vision")" = "vision-v2"
+test "$("$SUBSET_DIR/gsv")" = "gsv-v2"
 # A replacement gsv whose doctor fails rolls back gsv and gsvd only.
-cp "$SUBSET_DIR/gsv-transcribe" "$SUBSET_BEFORE/gsv-transcribe"
-cp "$SUBSET_DIR/gsv-transcribe-THIRD_PARTY.md" "$SUBSET_BEFORE/gsv-transcribe-THIRD_PARTY.md"
+cp "$SUBSET_DIR"/gsv-desktop "$SUBSET_DIR"/gsv-transcribe* "$SUBSET_DIR"/gsv-vision* "$SUBSET_BEFORE/"
 make_fixture gsv-linux-x64 gsv-v3 fail-doctor
 make_fixture gsvd-linux-x64 gsvd-v3
 write_checksums

--- a/scripts/test-host-installer.sh
+++ b/scripts/test-host-installer.sh
@@ -128,6 +128,12 @@ run_pinned_installer() {
 run_pinned_installer
 test "$(cat "$PINNED_INSTALL_DIR/pinned-installer-ran")" = "v-legacy:1"
 rm "$PINNED_INSTALL_DIR/pinned-installer-ran"
+# A subset is refused when the pinned release's installer predates component selection.
+if GSV_INSTALL_COMPONENTS="gsv,gsvd" run_pinned_installer 2>/dev/null; then
+    echo "installer delegated a component subset to an installer that cannot honour it" >&2
+    exit 1
+fi
+test ! -e "$PINNED_INSTALL_DIR/pinned-installer-ran"
 printf '\n# changed after checksums were written\n' >> "$PINNED_FIXTURES/install.sh"
 if run_pinned_installer 2>/dev/null; then
     echo "installer accepted a pinned release installer that did not match checksums.txt" >&2
@@ -493,6 +499,14 @@ untouched_by_subset() {
 }
 if run_subset_installer env GSV_INSTALL_COMPONENTS="gsv,gsvd,gsv-mystery" >/dev/null 2>&1; then
     echo "installer accepted an unknown component" >&2
+    exit 1
+fi
+if run_subset_installer env GSV_INSTALL_COMPONENTS="gsv,gsvd,gsv" >/dev/null 2>&1; then
+    echo "installer accepted a component listed twice" >&2
+    exit 1
+fi
+if run_subset_installer env GSV_INSTALL_COMPONENTS="gsvd,gsv-transcribe" >/dev/null 2>&1; then
+    echo "installer accepted gsvd without gsv" >&2
     exit 1
 fi
 test "$("$SUBSET_DIR/gsv")" = "gsv-v1"

--- a/scripts/test-host-installer.sh
+++ b/scripts/test-host-installer.sh
@@ -24,9 +24,13 @@ mkdir -p \
 make_fixture() {
     local name="$1"
     local marker="$2"
+    local behaviour="${3:-}"
     {
         printf '#!/usr/bin/env sh\n'
         printf 'if [ "${1:-}" = "daemon" ] && [ "${2:-}" = "start" ]; then systemctl --user start gsvd.service; fi\n'
+        if [ "$behaviour" = "fail-doctor" ]; then
+            printf 'if [ "${1:-}" = "daemon" ] && [ "${2:-}" = "doctor" ]; then exit 1; fi\n'
+        fi
         printf 'printf "%%s\\n" "%s"\n' "$marker"
     } > "$FIXTURES/$name"
     chmod 0755 "$FIXTURES/$name"
@@ -232,7 +236,7 @@ test "$(grep -c 'Added by the GSV installer' "$DEFAULT_HOME/.bashrc")" = "1"
 # directory needs nothing.
 OPT_OUT_HOME="$TEST_ROOT/opt-out-home"
 mkdir -p "$OPT_OUT_HOME"
-DEFAULT_HOME="$OPT_OUT_HOME" run_default_installer env GSV_NO_MODIFY_PATH=1 | grep -q "Left PATH alone"
+grep -q "Left PATH alone" <<< "$(DEFAULT_HOME="$OPT_OUT_HOME" run_default_installer env GSV_NO_MODIFY_PATH=1)"
 test ! -e "$OPT_OUT_HOME/.profile"
 ON_PATH_HOME="$TEST_ROOT/on-path-home"
 mkdir -p "$ON_PATH_HOME"
@@ -460,4 +464,65 @@ DEFAULT_HOME="$DEV_SERVICE_HOME" run_default_installer env GSV_VERSION=dev >/dev
 grep -qF -- '--user start gsvd.service channel=channel = "dev"' "$SYSTEMCTL_LOG"
 test "$(grep -c '^channel = "dev"$' "$DEV_SERVICE_HOME/.config/gsv/config.toml")" = "1"
 
-echo "host installer checksum, replacement, default directory, PATH, bundle, launcher, encoded-path, and dev-channel smoke passed"
+# An unattended-style install replaces only the selected components, leaves
+# the rest byte-identical, and rolls back only that subset when the health
+# check fails.
+SUBSET_HOME="$TEST_ROOT/subset-home"
+SUBSET_DIR="$TEST_ROOT/subset-bin"
+SUBSET_BEFORE="$TEST_ROOT/subset-before"
+mkdir -p "$SUBSET_HOME/.config/systemd/user"
+cp -r "$INSTALL_DIR" "$SUBSET_DIR"
+cp -r "$SUBSET_DIR" "$SUBSET_BEFORE"
+printf '[Service]\nExecStart="%s/gsvd" "--foreground"\n' "$SUBSET_DIR" > "$SUBSET_HOME/.config/systemd/user/gsvd.service"
+run_subset_installer() {
+    env -u XDG_CONFIG_HOME \
+        HOME="$SUBSET_HOME" \
+        PATH="$FAKE_BIN:/usr/bin:/bin" \
+        GSV_INSTALL_DIR="$SUBSET_DIR" \
+        GSV_INSTALLER_RELEASE_BOUND=0 \
+        GSV_TEST_RELEASE_DIR="$FIXTURES" \
+        GSV_TEST_SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+        GSV_VERSION="v-test" \
+        "$@" bash "$REPOSITORY_ROOT/install.sh"
+}
+untouched_by_subset() {
+    local name
+    for name in gsv-desktop gsv-transcribe gsv-vision gsv-transcribe-THIRD_PARTY.md gsv-vision-LICENSE.apache-2.0 gsv-vision-PROVENANCE.md; do
+        cmp -s "$SUBSET_BEFORE/$name" "$SUBSET_DIR/$name" || return 1
+    done
+}
+if run_subset_installer env GSV_INSTALL_COMPONENTS="gsv,gsvd,gsv-mystery" >/dev/null 2>&1; then
+    echo "installer accepted an unknown component" >&2
+    exit 1
+fi
+test "$("$SUBSET_DIR/gsv")" = "gsv-v1"
+SUBSET_OUTPUT="$(run_subset_installer env GSV_INSTALL_COMPONENTS="gsv,gsvd")"
+grep -q "Verified 2 release artifacts" <<< "$SUBSET_OUTPUT"
+grep -q "Installed gsv, gsvd to $SUBSET_DIR" <<< "$SUBSET_OUTPUT"
+test "$("$SUBSET_DIR/gsv")" = "gsv-v2"
+test "$("$SUBSET_DIR/gsvd")" = "gsvd-v2"
+untouched_by_subset
+# A helper brings its sidecars: the transcription subset is three files.
+grep -q "Verified 2 release artifacts" <<< "$(run_subset_installer env GSV_INSTALL_COMPONENTS="gsv-transcribe")"
+test "$("$SUBSET_DIR/gsv-transcribe")" = "transcribe-v2"
+test "$(cat "$SUBSET_DIR/gsv-transcribe-THIRD_PARTY.md")" = "license-v2"
+test "$("$SUBSET_DIR/gsv-desktop")" = "desktop-v1"
+# A replacement gsv whose doctor fails rolls back gsv and gsvd only.
+cp "$SUBSET_DIR/gsv-transcribe" "$SUBSET_BEFORE/gsv-transcribe"
+cp "$SUBSET_DIR/gsv-transcribe-THIRD_PARTY.md" "$SUBSET_BEFORE/gsv-transcribe-THIRD_PARTY.md"
+make_fixture gsv-linux-x64 gsv-v3 fail-doctor
+make_fixture gsvd-linux-x64 gsvd-v3
+write_checksums
+if run_subset_installer env GSV_INSTALL_COMPONENTS="gsv,gsvd" >/dev/null 2>&1; then
+    echo "installer ignored a failed health check for a component subset" >&2
+    exit 1
+fi
+test "$("$SUBSET_DIR/gsv")" = "gsv-v2"
+test "$("$SUBSET_DIR/gsvd")" = "gsvd-v2"
+untouched_by_subset
+test ! -e "$SUBSET_DIR/.gsv.new.$$"
+make_fixture gsv-linux-x64 gsv-v2
+make_fixture gsvd-linux-x64 gsvd-v2
+write_checksums
+
+echo "host installer checksum, replacement, default directory, PATH, bundle, launcher, encoded-path, dev-channel, and component-subset smoke passed"


### PR DESCRIPTION
## What

The installer gains a component selection, `GSV_INSTALL_COMPONENTS` (default: everything, as before), honoured by `install.sh` and `install.ps1` in the download, verify, swap, and rollback steps, so a subset is checksum-verified and transactional on its own. A helper brings its license and provenance sidecars with it. The daemon's unattended launch passes `gsv,gsvd`.

## Why

The automatic update from #284 ran the ordinary installer, which also replaced `gsv-desktop`, `gsv-transcribe`, and `gsv-vision`. A running Desktop could then spawn a freshly installed helper that no longer speaks its private helper protocol, and the how-to promises Desktop updates stay user-initiated. The CLI moves with the daemon because it owns the service definition; Desktop and the helpers are left untouched, and the how-to now says so.

## Validation

- `bash scripts/test-host-installer.sh`: passing. New cases: an unknown component is rejected before anything changes; a `gsv,gsvd` install over a full installation replaces those two and leaves the other five files byte-identical; a `gsv-transcribe` install brings its sidecar; a replacement `gsv` whose `daemon doctor` fails rolls back only `gsv` and `gsvd`. One pre-existing `… | grep -q` pipeline that could take SIGPIPE under `pipefail` now reads through a here-string.
- `cargo test --locked -p host-config -p gateway-client -p machine`: 26 / 13 / 89, the invocation test asserting the new variable.
- `cargo test --locked --package gsv`, clippy for machine, gateway-client, and host-config with `-D warnings`, `cargo fmt --all --check`: clean.
- `install.ps1` could not be run here (no PowerShell); the change mirrors the shell installer.
