### PR TITLE
Give the model a Send tool and stop losing replies in correction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ This document is the root engineering contract for the repository. It explains h
 
 ### Keep the agent interface small and composable
 
-The fixed model-facing surface is Read, Write, Edit, Delete, Search, Shell, and CodeMode. Add capabilities beneath that surface through syscalls, targets, or CodeMode instead of growing a bespoke tool for every integration.
+The fixed model-facing surface is Read, Write, Edit, Delete, Search, Shell, CodeMode, and Send. Send is the run control, message and yield, as a tool, and is the only tool that is not a capability. Add capabilities beneath that surface through syscalls, targets, or CodeMode instead of growing a bespoke tool for every integration.
 
 GSV is Linux-inspired because familiar, orthogonal semantics reduce instruction burden for models and humans. This is a design model, not a promise of POSIX compatibility.
 

--- a/docs/architecture/agent-loop.md
+++ b/docs/architecture/agent-loop.md
@@ -147,16 +147,19 @@ The model response can contain text, thinking blocks, and tool calls:
   that explicitly called `proc.observe`.
 - Assistant text, thinking blocks, and tool calls are stored in the `messages`
   table.
-- In a human-facing run, a direct Shell call with a literal `message send <<'GSV_MESSAGE'` block
-  commits one canonical user-visible message and any media registered by `message attach`. The run
-  continues, allowing multiple exactly-once messages from one run.
-- A direct `yield` finishes the run. Composing the final send as `message send ... && yield` avoids
-  another generation; a bare `yield` finishes without another Message and is valid only when the
-  same assistant turn contains no meaningful text.
+- In a human-facing run, the `Send` tool commits one canonical user-visible message and any media
+  registered by `message attach`: `text` alone sends and the run continues, allowing multiple
+  exactly-once messages from one run; `text` with `yield: true` sends and finishes without another
+  generation; `yield: true` alone finishes without another Message, and is valid only when the same
+  assistant turn contains no meaningful text. A direct Shell call with a literal
+  `message send <<'GSV_MESSAGE'` block, `yield`, or `message send ... && yield` is the same action as a
+  command, for people, scripts, and the model alike.
 - Once the Process validates a message command, the originating client receives
   `message.started` and `message.delta`. Adapters wait for `message.committed`.
-- Ordinary assistant text in a human-facing run that stops without yielding causes one `[GSV EVENT]`
-  correction. A second omission ends the run with an inspectable bounded error.
+- Ordinary assistant text in a human-facing run that stops without yielding causes a `[GSV EVENT]`
+  correction, and the next turn offers `Send` and nothing else, so the only question left is what to
+  send. After three omissions the run ends with an inspectable bounded error, and the person receives a
+  short notice that a reply was written but not sent, rather than silence.
 - A rejected message or run-control command gets five correction attempts. Delivery failures use a
   separate three-attempt budget and tell the model to retry the exact same message command.
 - If there are tool calls, the process evaluates approval rules and dispatches
@@ -210,8 +213,8 @@ schedules/continues the loop:
 4. Background-origin queued messages are promoted as separate runs after the
    current run finishes.
 
-This repeats until a human-facing run uses `yield`. `message send` alone commits a Message and
-continues the loop. A bounded IPC call omits the human-delivery instruction and finishes when the worker
+This repeats until a human-facing run yields. A `Send` without `yield`, or `message send` alone,
+commits a Message and continues the loop. A bounded IPC call omits the human-delivery instruction and finishes when the worker
 returns ordinary assistant output; that output becomes its caller result.
 
 Tool result content is stored as text. Non-string syscall output is JSON encoded

--- a/docs/architecture/agent-loop.md
+++ b/docs/architecture/agent-loop.md
@@ -173,15 +173,15 @@ still preserved in assistant history with synthetic terminal tool results so
 provider history remains structurally valid and the next model turn can recover
 instead of silently completing or hanging.
 
-Only the fixed syscall-backed tool surface is exposed to the model. Current agent-visible
-tool names are `Read`, `Write`, `Edit`, `Delete`, `Search`, `Shell`, and `CodeMode`;
-they map to `fs.read`, `fs.write`, `fs.edit`, `fs.delete`, `fs.search`,
-`shell.exec`, and `codemode.exec`.
+The model sees a fixed surface of eight tools. Seven are syscall-backed: `Read`, `Write`, `Edit`,
+`Delete`, `Search`, `Shell`, and `CodeMode` map to `fs.read`, `fs.write`, `fs.edit`, `fs.delete`,
+`fs.search`, `shell.exec`, and `codemode.exec`. The eighth, `Send`, is the run control as a tool and
+backs no syscall; it is offered to human-facing runs only.
 
-The message and run-control commands are Process-owned Shell intrinsics. They do not add model tools,
-require `shell.exec` approval, target a device, or enlarge the composable tool surface. An explicit
-`message send --to ... --also` remains an ordinary approved shell operation for additional or
-cross-channel delivery.
+The message and run-control commands are Process-owned Shell intrinsics, the same actions as `Send`
+in command form. They do not require `shell.exec` approval, target a device, or enlarge the composable
+tool surface. An explicit `message send --to ... --also` remains an ordinary approved shell operation
+for additional or cross-channel delivery.
 
 `CodeMode` remains the programmable tool for multi-step orchestration. It can
 call `fs.*`, `shell.exec`, and connected MCP tools as generated async

--- a/docs/architecture/conversations.md
+++ b/docs/architecture/conversations.md
@@ -33,8 +33,13 @@ work, or remain silent.
 Ordinary assistant text is Process activity. It is never implicitly sent to a user. Human-facing
 delivery and run completion are separate operations:
 
-- A literal block commits a canonical user-visible message without interpreting its contents. The
-  run remains active, so the intelligence can update the user and then continue working:
+- The `Send` tool commits a canonical user-visible message without interpreting its contents. With
+  `text` alone the run remains active, so the intelligence can update the user and then continue
+  working; with `yield: true` the run finishes after the message, preserving its durable Process; with
+  `yield: true` and no text it finishes without another user-visible message.
+- The same three actions exist as commands, so a person or a script can do what the model does. A
+  literal block sends and leaves the run active, `yield` finishes it, and a final message composes both
+  with ordinary shell success semantics:
 
   ```bash
   message send <<'GSV_MESSAGE'
@@ -42,23 +47,20 @@ delivery and run completion are separate operations:
   GSV_MESSAGE
   ```
 
-- `yield` finishes the run while preserving its durable Process. A bare `yield` completes without
-  another user-visible message.
-- A final message composes both operations with ordinary shell success semantics:
-
   ```bash
   message send <<'GSV_MESSAGE' && yield
   your final user-visible response
   GSV_MESSAGE
   ```
 
-The Process recognizes these exact commands inside a direct `Shell` call before normal shell
-dispatch. They do not require `shell.exec` capability or approval, cannot target a device, and cannot
+The Process recognizes a `Send` call, and these exact commands inside a direct `Shell` call, before
+normal shell dispatch. They do not require `shell.exec` capability or approval, cannot target a device, and cannot
 be invoked indirectly through CodeMode. The model receives only the fixed Read, Write, Edit, Delete,
-Search, Shell, and CodeMode surface. A successful send returns a tool result and schedules the next
-model turn unless it was composed with `yield`. If a generation stops without yielding, the Process
-adds one `[GSV EVENT]` correction and retries once. A second omission ends the run with an inspectable
-error instead of looping indefinitely. A malformed message or run-control command has its own
+Search, Shell, CodeMode, and Send surface. A successful send returns a tool result and schedules the
+next model turn unless it yielded. If a generation stops without yielding, the Process adds a
+`[GSV EVENT]` correction and offers `Send` alone on the next turn, up to three times. A further
+omission ends the run with an inspectable error instead of looping indefinitely, and the person
+receives a short notice that a reply was written but not sent. A malformed message or run-control command has its own
 five-attempt recovery budget. Delivery failures are tracked separately, so they cannot exhaust either
 omission or command correction. Each send has a stable action id, allowing several exactly-once
 Messages in one run and safe replay after an uncertain response.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -169,7 +169,8 @@ GSV_MESSAGE
 
 Run `yield` when the work is complete. A final message can commit and yield without another model
 turn by placing `&& yield` after the block declaration. The Process recognizes these message and
-run-control commands without shell approval. During an active run,
+run-control commands without shell approval; the model usually reaches the same three actions
+through its `Send` tool, whose `text` and `yield` map onto them exactly. During an active run,
 `message send --to ... --also` creates an
 additional outbound message or sends to another authorized destination.
 `message destinations` lists observed destinations that are online; `--all`

--- a/workers/gateway/src/process/do.model-context-2.test.ts
+++ b/workers/gateway/src/process/do.model-context-2.test.ts
@@ -280,7 +280,7 @@ describe("model context", () => {
       process.generation = {
         async generate(request: any) {
           generationCalls += 1;
-          expect(request.context.tools.map((tool: any) => tool.name)).toEqual(["Read", "Shell"]);
+          expect(request.context.tools.map((tool: any) => tool.name)).toEqual(["Read", "Shell", "Send"]);
           return generationCalls === 1
             ? assistantResponse([
                 {
@@ -542,15 +542,18 @@ describe("model context", () => {
     }
   });
 
-  it("requires an explicit yield and bounds the correction", async () => {
+  it("offers Send alone while correcting, then tells the person rather than going silent", async () => {
     const pid = "mech-terminal-action-required";
     const runId = "run-terminal-action-required";
     const stub = await initProcess(pid, ROOT_IDENTITY);
 
     const result = await runInProcess(stub, async (process) => {
       const emitted = captureSignals(process);
+      const offered: string[][] = [];
       process.run.scheduleTick = vi.fn(async () => {});
-      mockGeneration(process, async () => {
+      process.run.commitRunControlMessage = vi.fn(async () => ({ conversationId: "conv", id: "notice" }));
+      mockGeneration(process, async (request: any) => {
+        offered.push((request.context?.tools ?? []).map((tool: any) => tool.name));
         return terminalTestResponse([{ type: "text", text: "This is only a draft." }]);
       }, async () => {
         return "unused";
@@ -563,20 +566,35 @@ describe("model context", () => {
       const correction = process.store.messages
         .getMessages()
         .find((message: any) => message.role === "system" && message.runId === runId);
-      expect(correction?.content).toContain("Run `yield` now");
+      expect(correction?.content).toContain("Call the Send tool");
       expect(
         (await process.history.buildContextMessages("default")).find((message: any) =>
-          message.content.includes("Run `yield` now"),
+          message.content.includes("Call the Send tool"),
         )?.content,
       ).toContain("[GSV EVENT]");
 
       await process.run.runTick(runId);
-      return { emitted, messages: process.store.messages.getMessages() };
+      await process.run.runTick(runId);
+      await process.run.runTick(runId);
+      return {
+        emitted,
+        offered,
+        notices: process.run.commitRunControlMessage.mock.calls,
+        messages: process.store.messages.getMessages(),
+      };
     });
 
-    expect(result.messages.filter((message: any) => message.role === "assistant")).toHaveLength(
-      2,
-    );
+    expect(result.messages.filter((message: any) => message.role === "assistant")).toHaveLength(4);
+    expect(
+      result.messages.filter((message: any) => message.role === "system" && message.content.includes("Call the Send tool")),
+    ).toHaveLength(3);
+    expect(result.offered[0]).toEqual(["Shell", "Send"]);
+    expect(result.offered.slice(1)).toEqual([["Send"], ["Send"], ["Send"]]);
+    expect(result.notices).toHaveLength(1);
+    expect(result.notices[0][2]).toMatchObject({
+      call: "proc.message.commit",
+      args: { runId, text: "I wrote a reply but did not send it. Ask me again." },
+    });
     expect(
       result.emitted.findLast((entry) => entry.signal === "proc.run.finished")?.payload,
     ).toMatchObject({
@@ -584,6 +602,46 @@ describe("model context", () => {
       reason: "message.action.missing",
       error: "The model did not yield after correction",
     });
+  });
+
+  it("sends and ends the run through the Send tool", async () => {
+    const pid = "mech-send-tool";
+    const runId = "run-send-tool";
+    const stub = await initProcess(pid, ROOT_IDENTITY);
+
+    const result = await runInProcess(stub, async (process) => {
+      const emitted = captureSignals(process);
+      process.run.scheduleTick = vi.fn(async () => {});
+      process.run.commitRunControlMessage = vi.fn(async () => ({ conversationId: "conv", id: "sent" }));
+      mockGeneration(process, async () => {
+        return terminalTestResponse([
+          { type: "toolCall", id: "send-1", name: "Send", arguments: { text: "all done", yield: true } },
+        ]);
+      }, async () => {
+        return "unused";
+      });
+      process.store.messages.appendMessage("user", "Do the thing.", { runId });
+      process.runs.active = generationRun(runId, terminalTestConfig(pid));
+
+      await process.run.runTick(runId);
+      return {
+        emitted,
+        commits: process.run.commitRunControlMessage.mock.calls,
+        messages: process.store.messages.getMessages(),
+      };
+    });
+
+    expect(result.commits).toHaveLength(1);
+    expect(result.commits[0][2]).toMatchObject({
+      call: "proc.message.commit",
+      args: { runId, actionId: "send-1", text: "all done" },
+    });
+    expect(result.messages.find((message: any) => message.role === "toolResult")?.content).toBe(
+      "Message committed and run yielded",
+    );
+    expect(
+      result.emitted.findLast((entry) => entry.signal === "proc.run.finished")?.payload,
+    ).toMatchObject({ status: "ok", reason: "run.yielded" });
   });
 
   it("does not resurrect a superseded run after yield correction awaits", async () => {

--- a/workers/gateway/src/process/do.model-context-2.test.ts
+++ b/workers/gateway/src/process/do.model-context-2.test.ts
@@ -609,6 +609,43 @@ describe("model context", () => {
     });
   });
 
+  it("treats a Send that only yields as a bare yield, or as a final message when media is staged", async () => {
+    const pid = "mech-send-yield-only";
+    const runId = "run-send-yield-only";
+    const stub = await initProcess(pid, ROOT_IDENTITY);
+
+    await runInProcess(stub, async (process) => {
+      process.runs.active = generationRun(runId, terminalTestConfig(pid));
+      process.streams.silence = vi.fn(async () => {});
+      process.streams.complete = vi.fn(async () => {});
+      process.run.commitMessageRunControlAction = vi.fn(async (options: any) => ({
+        ok: true,
+        action: "message",
+        finish: options.finish,
+        text: options.text,
+        delivery: { kind: "none" },
+      }));
+      const yieldOnly = {
+        ok: true as const,
+        command: { action: "message" as const, text: "", finish: true, emptyMeansYield: true as const },
+      };
+      expect(await process.run.executeRunControlAction(runId, "send-yield-1", yieldOnly, [], "")).toMatchObject({
+        ok: true,
+        action: "yield",
+        finish: true,
+      });
+      const staged = [{ type: "image", mimeType: "image/png", key: "k", path: "p", size: 1 }];
+      expect(
+        await process.run.executeRunControlAction(runId, "send-yield-2", yieldOnly, staged, ""),
+      ).toMatchObject({ ok: true, action: "message", finish: true });
+      expect(process.run.commitMessageRunControlAction).toHaveBeenCalledOnce();
+      // a bare yield still may not carry meaningful assistant text
+      expect(
+        await process.run.executeRunControlAction(runId, "send-yield-3", yieldOnly, [], "the real reply"),
+      ).toMatchObject({ ok: false, error: "yield cannot accompany non-empty assistant text" });
+    });
+  });
+
   it("sends and ends the run through the Send tool", async () => {
     const pid = "mech-send-tool";
     const runId = "run-send-tool";

--- a/workers/gateway/src/process/do.model-context-2.test.ts
+++ b/workers/gateway/src/process/do.model-context-2.test.ts
@@ -636,9 +636,10 @@ describe("model context", () => {
       call: "proc.message.commit",
       args: { runId, actionId: "send-1", text: "all done" },
     });
-    expect(result.messages.find((message: any) => message.role === "toolResult")?.content).toBe(
-      "Message committed and run yielded",
-    );
+    const sendResult = result.messages.find((message: any) => message.role === "toolResult");
+    expect(sendResult).toMatchObject({ content: "Message committed and run yielded", toolCallId: "send-1" });
+    // the result is recorded under the tool's own name, so the call and its result pair up for every provider
+    expect(sendResult?.toolCalls).toContain('"toolName":"Send"');
     expect(
       result.emitted.findLast((entry) => entry.signal === "proc.run.finished")?.payload,
     ).toMatchObject({ status: "ok", reason: "run.yielded" });

--- a/workers/gateway/src/process/do.model-context-2.test.ts
+++ b/workers/gateway/src/process/do.model-context-2.test.ts
@@ -572,6 +572,11 @@ describe("model context", () => {
           message.content.includes("Call the Send tool"),
         )?.content,
       ).toContain("[GSV EVENT]");
+      // the restriction survives a tick that loads its inputs and is interrupted before generating
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const inputs = await process.run.loadRunTickInputs(runId, process.runs.active);
+        expect(inputs?.tools.map((tool: any) => tool.name)).toEqual(["Send"]);
+      }
 
       await process.run.runTick(runId);
       await process.run.runTick(runId);

--- a/workers/gateway/src/process/do.model-context-4.test.ts
+++ b/workers/gateway/src/process/do.model-context-4.test.ts
@@ -753,7 +753,7 @@ describe("model context", () => {
             providerStyle: "openai-chat-completions",
             transportTarget: "gsv",
             maxTokens: 100,
-            contextWindowTokens: 1000,
+            contextWindowTokens: 1200,
             contextWindowSource: "config",
             generationTimeoutMs: 180000,
             generationStreaming: "auto",

--- a/workers/gateway/src/process/do.process-history-1.test.ts
+++ b/workers/gateway/src/process/do.process-history-1.test.ts
@@ -929,7 +929,7 @@ describe("process history", () => {
         provider: "workers-ai",
         model: "@cf/test/model",
         maxTokens: 100,
-        contextWindowTokens: 1000,
+        contextWindowTokens: 1500,
         generationTimeoutMs: 180000,
         fallbacks: [
           {
@@ -937,7 +937,7 @@ describe("process history", () => {
             model: "fallback-model",
             apiKey: "fallback-key",
             maxTokens: 100,
-            contextWindowTokens: 1000,
+            contextWindowTokens: 1500,
             contextWindowSource: "config",
             generationTimeoutMs: 180000,
           },

--- a/workers/gateway/src/process/internal/lifecycle.ts
+++ b/workers/gateway/src/process/internal/lifecycle.ts
@@ -97,7 +97,7 @@ export const UNKNOWN_SHELL_SESSION_TARGET_MESSAGE =
 
 export const USER_INTERRUPTED_TOOL_MESSAGE = "User interrupted tool execution";
 
-export const MAX_TERMINAL_CORRECTION_ROUNDS = 1;
+export const MAX_TERMINAL_CORRECTION_ROUNDS = 3;
 
 export const MAX_TERMINAL_COMMAND_FAILURES = 5;
 
@@ -107,7 +107,17 @@ export const FINAL_MESSAGE_BLOCK_EXAMPLE =
   "message send <<'GSV_MESSAGE' && yield\nyour user-visible response\nGSV_MESSAGE";
 
 export const RUN_CONTROL_INSTRUCTION =
-  `Use a direct \`message send\` Shell call whenever the user should receive a message; sending does not finish the run. After all work is complete, run \`yield\`, or compose the final message as:\n${FINAL_MESSAGE_BLOCK_EXAMPLE}\nOrdinary assistant text is Process activity and is not sent to the user. In a human-facing run, do not combine meaningful assistant text with a bare \`yield\`; send that text with \`message send\` instead.`;
+  "Messages for the user go through the Send tool; `message send` and `yield` here are the same actions. Assistant text is not sent to the user; do not pair meaningful text with a bare yield.";
+
+export const SEND_TOOL_DESCRIPTION =
+  "Send a message to the person this run is for, end the run, or both. Assistant text is never delivered; this is how the person hears from you. yield true ends the run after the message, or silently when there is no text.";
+
+/** Appended to history when a turn ended in text alone; the next turn offers Send and nothing else. */
+export const YIELD_CORRECTION_MESSAGE =
+  "Your last turn was plain assistant text, which is Process activity and was not sent to the user. Call the Send tool: text for the person, with yield true when the work is complete, or yield true alone if there is nothing to say. Only Send is offered on this turn.";
+
+/** What the person hears when the run could not be corrected into sending, rather than nothing. */
+export const CORRECTION_FAILURE_NOTICE = "I wrote a reply but did not send it. Ask me again.";
 
 export const PENDING_RUN_CONTROL_CALL = "Shell";
 

--- a/workers/gateway/src/process/internal/lifecycle.ts
+++ b/workers/gateway/src/process/internal/lifecycle.ts
@@ -121,6 +121,13 @@ export const CORRECTION_FAILURE_NOTICE = "I wrote a reply but did not send it. A
 
 export const PENDING_RUN_CONTROL_CALL = "Shell";
 
+export const SEND_TOOL_NAME = "Send";
+
+/** A pending tool call registered under one of these names is run control, not a syscall to dispatch. */
+export function isRunControlCall(call: string): boolean {
+  return call === PENDING_RUN_CONTROL_CALL || call === SEND_TOOL_NAME;
+}
+
 export const INTERRUPTED_RUN_CONTROL_MESSAGE =
   "Run-control completion was interrupted before its result was recorded; its external effect may already have completed";
 

--- a/workers/gateway/src/process/internal/schemas.ts
+++ b/workers/gateway/src/process/internal/schemas.ts
@@ -1,7 +1,7 @@
 /** Internal Process schemas primitives. */
 
 import type { CodeModeExecArgs } from "../../syscalls/codemode";
-import { RUN_CONTROL_INSTRUCTION, SEND_TOOL_DESCRIPTION } from "./lifecycle";
+import { RUN_CONTROL_INSTRUCTION, SEND_TOOL_DESCRIPTION, SEND_TOOL_NAME } from "./lifecycle";
 import type { Tool } from "@earendil-works/pi-ai";
 import { jsonObjectSchema, jsonValueSchema } from "@humansandmachines/gsv/protocol";
 import { z } from "zod";
@@ -41,7 +41,7 @@ export const RUN_CONTROL_SHELL_TOOL: Tool = {
 
 /** The run-control actions as one tool: text sends, yield ends, both send and end. */
 export const SEND_TOOL: Tool = {
-  name: "Send",
+  name: SEND_TOOL_NAME,
   description: SEND_TOOL_DESCRIPTION,
   parameters: {
     type: "object",

--- a/workers/gateway/src/process/internal/schemas.ts
+++ b/workers/gateway/src/process/internal/schemas.ts
@@ -1,7 +1,7 @@
 /** Internal Process schemas primitives. */
 
 import type { CodeModeExecArgs } from "../../syscalls/codemode";
-import { RUN_CONTROL_INSTRUCTION } from "./lifecycle";
+import { RUN_CONTROL_INSTRUCTION, SEND_TOOL_DESCRIPTION } from "./lifecycle";
 import type { Tool } from "@earendil-works/pi-ai";
 import { jsonObjectSchema, jsonValueSchema } from "@humansandmachines/gsv/protocol";
 import { z } from "zod";
@@ -38,6 +38,31 @@ export const RUN_CONTROL_SHELL_TOOL: Tool = {
     additionalProperties: false,
   },
 };
+
+/** The run-control actions as one tool: text sends, yield ends, both send and end. */
+export const SEND_TOOL: Tool = {
+  name: "Send",
+  description: SEND_TOOL_DESCRIPTION,
+  parameters: {
+    type: "object",
+    properties: {
+      text: {
+        type: "string",
+        description: "The message for the person.",
+      },
+      yield: {
+        type: "boolean",
+        description: "True when all work is complete; the run ends after this call.",
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+export const sendToolArgsSchema = z.object({
+  text: z.string().optional(),
+  yield: z.boolean().optional(),
+}).strict();
 
 export const routedFetchOptionsSchema = z.object({
   timeoutMs: z.number().optional(),

--- a/workers/gateway/src/process/run-control-command.ts
+++ b/workers/gateway/src/process/run-control-command.ts
@@ -3,7 +3,13 @@ import { Bash, type SimpleCommandNode, type StatementNode, type WordNode } from 
 const runControlBash = new Bash({ commands: [] });
 
 export type RunControlCommand =
-  | { action: "message"; text: string; finish: boolean }
+  | {
+    action: "message";
+    text: string;
+    finish: boolean;
+    /** A send with nothing to say: a final message when staged media makes it one, a bare yield otherwise. */
+    emptyMeansYield?: true;
+  }
   | { action: "yield" };
 
 export type RunControlCommandParseResult =

--- a/workers/gateway/src/process/run-control-command.ts
+++ b/workers/gateway/src/process/run-control-command.ts
@@ -2,7 +2,7 @@ import { Bash, type SimpleCommandNode, type StatementNode, type WordNode } from 
 
 const runControlBash = new Bash({ commands: [] });
 
-type RunControlCommand =
+export type RunControlCommand =
   | { action: "message"; text: string; finish: boolean }
   | { action: "yield" };
 

--- a/workers/gateway/src/process/run-tick-policy.test.ts
+++ b/workers/gateway/src/process/run-tick-policy.test.ts
@@ -74,9 +74,15 @@ describe("run tick policy", () => {
     });
     const read = { type: "toolCall" as const, id: "read-call", name: "Read", arguments: { path: "/tmp/value" } };
     const parsedOf = (content: AssistantMessage["content"]) =>
-      classifyAssistantTurn(assistant(content), ["Read"]).runControlCalls[0]?.parsed;
+      classifyAssistantTurn(assistant(content), ["Read", "Send"]).runControlCalls[0]?.parsed;
 
-    expect(classifyAssistantTurn(assistant([send("s1", { text: "hello" })]), ["Read"]).kind).toBe("run-control");
+    expect(classifyAssistantTurn(assistant([send("s1", { text: "hello" })]), ["Read", "Send"]).kind).toBe(
+      "run-control",
+    );
+    // where Send was not offered, as in a bounded IPC run, a fabricated call is unoffered like any other
+    expect(classifyAssistantTurn(assistant([send("s0", { text: "hello" })]), ["Read"]).kind).toBe(
+      "unoffered-tools",
+    );
     expect(parsedOf([send("s1", { text: "hello" })])).toEqual({
       ok: true,
       command: { action: "message", text: "hello", finish: false },
@@ -89,7 +95,7 @@ describe("run tick policy", () => {
     // an empty send is a message with no text: the runtime decides whether staged media makes it one
     expect(parsedOf([send("s4", {})])).toEqual({ ok: true, command: { action: "message", text: "", finish: false } });
     expect(parsedOf([send("s5", { text: "x", extra: 1 })])).toMatchObject({ ok: false, action: "message" });
-    expect(classifyAssistantTurn(assistant([send("s6", { text: "x" }), read]), ["Read"]).kind).toBe(
+    expect(classifyAssistantTurn(assistant([send("s6", { text: "x" }), read]), ["Read", "Send"]).kind).toBe(
       "invalid-run-control",
     );
   });

--- a/workers/gateway/src/process/run-tick-policy.test.ts
+++ b/workers/gateway/src/process/run-tick-policy.test.ts
@@ -65,6 +65,35 @@ describe("run tick policy", () => {
     ).toMatchObject({ kind: "terminal", text: "done" });
   });
 
+  it("classifies Send tool calls as the same run control as the commands", () => {
+    const send = (id: string, args: Record<string, string | boolean | number>) => ({
+      type: "toolCall" as const,
+      id,
+      name: "Send",
+      arguments: args,
+    });
+    const read = { type: "toolCall" as const, id: "read-call", name: "Read", arguments: { path: "/tmp/value" } };
+    const parsedOf = (content: AssistantMessage["content"]) =>
+      classifyAssistantTurn(assistant(content), ["Read"]).runControlCalls[0]?.parsed;
+
+    expect(classifyAssistantTurn(assistant([send("s1", { text: "hello" })]), ["Read"]).kind).toBe("run-control");
+    expect(parsedOf([send("s1", { text: "hello" })])).toEqual({
+      ok: true,
+      command: { action: "message", text: "hello", finish: false },
+    });
+    expect(parsedOf([send("s2", { text: "bye", yield: true })])).toEqual({
+      ok: true,
+      command: { action: "message", text: "bye", finish: true },
+    });
+    expect(parsedOf([send("s3", { yield: true })])).toEqual({ ok: true, command: { action: "yield" } });
+    // an empty send is a message with no text: the runtime decides whether staged media makes it one
+    expect(parsedOf([send("s4", {})])).toEqual({ ok: true, command: { action: "message", text: "", finish: false } });
+    expect(parsedOf([send("s5", { text: "x", extra: 1 })])).toMatchObject({ ok: false, action: "message" });
+    expect(classifyAssistantTurn(assistant([send("s6", { text: "x" }), read]), ["Read"]).kind).toBe(
+      "invalid-run-control",
+    );
+  });
+
   it("skips duplicate fallback stacks without carrying fallback chains", () => {
     const primary = config({
       fallbacks: [

--- a/workers/gateway/src/process/run-tick-policy.test.ts
+++ b/workers/gateway/src/process/run-tick-policy.test.ts
@@ -91,7 +91,11 @@ describe("run tick policy", () => {
       ok: true,
       command: { action: "message", text: "bye", finish: true },
     });
-    expect(parsedOf([send("s3", { yield: true })])).toEqual({ ok: true, command: { action: "yield" } });
+    // yield alone is a final message when media is staged and a bare yield otherwise; the runtime decides
+    expect(parsedOf([send("s3", { yield: true })])).toEqual({
+      ok: true,
+      command: { action: "message", text: "", finish: true, emptyMeansYield: true },
+    });
     // an empty send is a message with no text: the runtime decides whether staged media makes it one
     expect(parsedOf([send("s4", {})])).toEqual({ ok: true, command: { action: "message", text: "", finish: false } });
     expect(parsedOf([send("s5", { text: "x", extra: 1 })])).toMatchObject({ ok: false, action: "message" });

--- a/workers/gateway/src/process/run-tick-policy.ts
+++ b/workers/gateway/src/process/run-tick-policy.ts
@@ -114,8 +114,9 @@ function parseRunControlShellCall(toolCall: ToolCall): RunControlCall | null {
 
 /**
  * The Send tool is the same command as a tool call. Text alone sends and the
- * run continues; text with yield sends and ends; yield alone ends. Whether an
- * empty text is a message is decided where the staged media is known.
+ * run continues; text with yield sends and ends; yield alone ends, or sends
+ * staged media and ends. Whether an empty text is a message is decided where
+ * the staged media is known.
  */
 function parseRunControlSendCall(toolCall: ToolCall): RunControlCall | null {
   if (toolCall.name !== SEND_TOOL.name) return null;
@@ -133,7 +134,7 @@ function parseRunControlSendCall(toolCall: ToolCall): RunControlCall | null {
   const text = args.data.text ?? "";
   const finish = args.data.yield === true;
   const command: RunControlCommand = finish && !text.trim()
-    ? { action: "yield" }
+    ? { action: "message", text: "", finish: true, emptyMeansYield: true }
     : { action: "message", text, finish };
   return { toolCall, parsed: { ok: true, command } };
 }

--- a/workers/gateway/src/process/run-tick-policy.ts
+++ b/workers/gateway/src/process/run-tick-policy.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
 import type { AiConfigResult } from "@humansandmachines/gsv/protocol";
 import type { AssistantMessage, TextContent, ThinkingContent, ToolCall } from "@earendil-works/pi-ai";
-import { parseRunControlCommand, type RunControlCommandParseResult } from "./run-control-command";
+import {
+  parseRunControlCommand, type RunControlCommand, type RunControlCommandParseResult,
+} from "./run-control-command";
+import { SEND_TOOL, sendToolArgsSchema } from "./internal/schemas";
 
-type RunControlShellCall = {
+/** A run-control action the model took: a Shell `message send` or `yield`, or a Send tool call. */
+type RunControlCall = {
   toolCall: ToolCall;
   parsed: RunControlCommandParseResult;
 };
@@ -20,7 +24,7 @@ export type AssistantTurnClassification = {
   text: string;
   thinking: ThinkingContent[];
   returnedToolCalls: ToolCall[];
-  runControlCalls: RunControlShellCall[];
+  runControlCalls: RunControlCall[];
   toolCalls: ToolCall[];
   unofferedToolCalls: ToolCall[];
 };
@@ -49,7 +53,7 @@ export function classifyAssistantTurn(
     (block): block is ToolCall => block.type === "toolCall",
   );
   const runControlCalls = returnedToolCalls.flatMap((toolCall) => {
-    const call = parseRunControlShellCall(toolCall);
+    const call = parseRunControlShellCall(toolCall) ?? parseRunControlSendCall(toolCall);
     return call ? [call] : [];
   });
   const runControlIds = new Set(runControlCalls.map(({ toolCall }) => toolCall.id));
@@ -98,12 +102,38 @@ export function nextAiConfigFallback(
   return null;
 }
 
-function parseRunControlShellCall(toolCall: ToolCall): RunControlShellCall | null {
+function parseRunControlShellCall(toolCall: ToolCall): RunControlCall | null {
   if (toolCall.name !== "Shell") return null;
   const args = terminalShellToolArgsSchema.safeParse(toolCall.arguments);
   if (!args.success) return null;
   const parsed = parseRunControlCommand(args.data.input);
   return parsed ? { toolCall, parsed } : null;
+}
+
+/**
+ * The Send tool is the same command as a tool call. Text alone sends and the
+ * run continues; text with yield sends and ends; yield alone ends. Whether an
+ * empty text is a message is decided where the staged media is known.
+ */
+function parseRunControlSendCall(toolCall: ToolCall): RunControlCall | null {
+  if (toolCall.name !== SEND_TOOL.name) return null;
+  const args = sendToolArgsSchema.safeParse(toolCall.arguments);
+  if (!args.success) {
+    return {
+      toolCall,
+      parsed: {
+        ok: false,
+        action: "message",
+        error: "Send accepts text (a string) and yield (a boolean) and nothing else",
+      },
+    };
+  }
+  const text = args.data.text ?? "";
+  const finish = args.data.yield === true;
+  const command: RunControlCommand = finish && !text.trim()
+    ? { action: "yield" }
+    : { action: "message", text, finish };
+  return { toolCall, parsed: { ok: true, command } };
 }
 
 function aiConfigWithFallback(

--- a/workers/gateway/src/process/run-tick-policy.ts
+++ b/workers/gateway/src/process/run-tick-policy.ts
@@ -52,12 +52,14 @@ export function classifyAssistantTurn(
   const returnedToolCalls = response.content.filter(
     (block): block is ToolCall => block.type === "toolCall",
   );
+  const offered = new Set(offeredToolNames);
+  // Send is run control only where it was offered; a bounded IPC run never offers it, so a fabricated call is unoffered
   const runControlCalls = returnedToolCalls.flatMap((toolCall) => {
-    const call = parseRunControlShellCall(toolCall) ?? parseRunControlSendCall(toolCall);
+    const call = parseRunControlShellCall(toolCall)
+      ?? (offered.has(SEND_TOOL.name) ? parseRunControlSendCall(toolCall) : null);
     return call ? [call] : [];
   });
   const runControlIds = new Set(runControlCalls.map(({ toolCall }) => toolCall.id));
-  const offered = new Set(offeredToolNames);
   const toolCalls = returnedToolCalls.filter(
     (toolCall) => offered.has(toolCall.name) && !runControlIds.has(toolCall.id),
   );

--- a/workers/gateway/src/process/run/helpers.ts
+++ b/workers/gateway/src/process/run/helpers.ts
@@ -5,7 +5,7 @@ import {
   MAX_TERMINAL_COMMAND_FAILURES, MAX_TERMINAL_DELIVERY_FAILURES, RUN_CONTROL_INSTRUCTION,
 } from "../internal/lifecycle";
 import type { Message, Tool } from "@earendil-works/pi-ai";
-import { RUN_CONTROL_SHELL_TOOL, conversationProvenanceSchema } from "../internal/schemas";
+import { RUN_CONTROL_SHELL_TOOL, SEND_TOOL, conversationProvenanceSchema } from "../internal/schemas";
 import type { RunControlResult } from "../internal/contracts";
 import type { RunState } from "./state";
 import { z } from "zod";
@@ -75,6 +75,7 @@ export function conversationRunState(
   }
 }
 
+/** A human-facing run gets the Send tool, and a Shell that knows the same actions as commands. */
 export function withRunControlInstructions(workTools: Tool[]): Tool[] {
   let foundShell = false;
   const tools = workTools.map((tool) => {
@@ -85,7 +86,7 @@ export function withRunControlInstructions(workTools: Tool[]): Tool[] {
       description: `${tool.description} ${RUN_CONTROL_INSTRUCTION}`,
     };
   });
-  return foundShell ? tools : [...tools, RUN_CONTROL_SHELL_TOOL];
+  return foundShell ? [...tools, SEND_TOOL] : [...tools, RUN_CONTROL_SHELL_TOOL, SEND_TOOL];
 }
 
 export type RunControlFailureKind = Extract<RunControlResult, { ok: false; }>["failureKind"];
@@ -140,7 +141,7 @@ export function formatRunControlToolResult(
       : MAX_TERMINAL_DELIVERY_FAILURES,
   };
   if (result.failureKind === "command") {
-    return `Run-control command rejected (attempt ${failureAttempt.count} of ${failureAttempt.limit}): ${result.error}\nTo reply here, stage files first with \`message attach PATH...\`. Then issue \`message send ...\` as its own direct Shell tool call with no other tool calls or shell commands. Omit --to and --also. Run \`yield\` only when the work is complete.`;
+    return `Run-control command rejected (attempt ${failureAttempt.count} of ${failureAttempt.limit}): ${result.error}\nCall Send with the text for the person, and yield true only when the work is complete. To attach files, stage them first with \`message attach PATH...\` in the Shell. In the Shell, \`message send ...\` as its own call with no other tool calls is the same action; omit --to and --also.`;
   }
   return `Message delivery failed (attempt ${failureAttempt.count} of ${failureAttempt.limit}): ${result.error}\nRetry the exact same message command unchanged.`;
 }

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -17,7 +17,7 @@ import {
   type ResponsibilityRecord, jsonObjectSchema, type AiConfigResult, type AiTextGenerateConfig,
   type AiTextGenerateOptions, type ProcUsageState, jsonValueSchema, type JsonObject, type ProcTraceSpanStatus,
 } from "@humansandmachines/gsv/protocol";
-import type { RunControlCommandParseResult } from "../run-control-command";
+import type { RunControlCommand, RunControlCommandParseResult } from "../run-control-command";
 import type { RunOutputMedia, RunState } from "./state";
 import {
   errorMessageFromUnknown, isProviderContextOverflow, isProviderContextOverflowErrorMessage,
@@ -92,7 +92,15 @@ export class ProcessRun {
     }
     const activeRun = this.host.runs.active;
     const isHumanFacingRun = activeRun?.runId === runId && !activeRun.returnToCaller;
-    if (parsed.command.action === "yield" && isHumanFacingRun && assistantText.trim()) {
+    // a Send with yield and nothing to say is a bare yield, unless staged media makes it a final message
+    const command: RunControlCommand =
+      parsed.command.action === "message"
+        && parsed.command.emptyMeansYield === true
+        && !parsed.command.text.trim()
+        && media.length === 0
+        ? { action: "yield" }
+        : parsed.command;
+    if (command.action === "yield" && isHumanFacingRun && assistantText.trim()) {
       return {
         ok: false,
         action: "yield",
@@ -102,7 +110,7 @@ export class ProcessRun {
         error: "yield cannot accompany non-empty assistant text",
       };
     }
-    if (parsed.command.action === "message" && !parsed.command.text.trim() && media.length === 0) {
+    if (command.action === "message" && !command.text.trim() && media.length === 0) {
       return {
         ok: false,
         action: "message",
@@ -112,7 +120,6 @@ export class ProcessRun {
         error: "Message requires non-empty text or attached media",
       };
     }
-    const command = parsed.command;
     let responsibilityAdmissionKey: string | undefined;
     if (command.action === "yield" || command.finish) {
       const responsibilityCheck = await this.verifyTerminalResponsibilities(runId);

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -10,7 +10,7 @@ import type {
 } from "../internal/contracts";
 import {
   CORRECTION_FAILURE_NOTICE, MAX_TERMINAL_CORRECTION_ROUNDS, RUNTIME_EVENT_WAKE_MESSAGE, YIELD_CORRECTION_MESSAGE,
-  MAX_RETRYABLE_GENERATION_ATTEMPTS, PENDING_RUN_CONTROL_CALL, UNKNOWN_SHELL_SESSION_TARGET_MESSAGE,
+  MAX_RETRYABLE_GENERATION_ATTEMPTS, SEND_TOOL_NAME, UNKNOWN_SHELL_SESSION_TARGET_MESSAGE, isRunControlCall,
   MEDIA_PREPARATION_TIMEOUT_MS, TOOL_DISPATCH_TIMEOUT_MS,
 } from "../internal/lifecycle";
 import {
@@ -58,16 +58,16 @@ import { createContextProjection, parseContextProjection } from "../context";
 import { deriveGenerationContextId } from "../context-message-metadata";
 import { SEND_TOOL, piToolParametersSchema } from "../internal/schemas";
 
-function hasRunControlRegistration(
+/** The name a run-control result is recorded under: the Send tool's own, or the Shell's syscall. */
+function runControlRegistration(
   host: Process,
   runId: string,
   dispatchId: string,
   toolCallId: string,
-): boolean {
+): { resultName: string } | null {
   const pending = host.store.tools.getPending(dispatchId);
-  return pending?.runId === runId
-    && pending.callId === toolCallId
-    && pending.call === PENDING_RUN_CONTROL_CALL;
+  if (pending?.runId !== runId || pending.callId !== toolCallId || !isRunControlCall(pending.call)) return null;
+  return { resultName: pending.call === SEND_TOOL_NAME ? SEND_TOOL_NAME : "shell.exec" };
 }
 
 export class ProcessRun {
@@ -1224,7 +1224,8 @@ export class ProcessRun {
     return this.host.ctx.storage.transactionSync(() => {
       const active = this.host.runs.active;
       if (this.host.killed || !active || active.runId !== runId) return false;
-      if (!hasRunControlRegistration(this.host, runId, dispatchId, toolCallId)) {
+      const registration = runControlRegistration(this.host, runId, dispatchId, toolCallId);
+      if (!registration) {
         throw new Error("Run-control tool registration was lost before its result");
       }
       const updated = result.ok ? active : incrementRunControlFailure(active, result.failureKind);
@@ -1238,7 +1239,7 @@ export class ProcessRun {
       }
       this.host.store.messages.appendToolResult(
         toolCallId,
-        "shell.exec",
+        registration.resultName,
         content,
         !result.ok,
         runId,
@@ -1258,12 +1259,13 @@ export class ProcessRun {
     this.host.ctx.storage.transactionSync(() => {
       const active = this.host.runs.active;
       if (this.host.killed || !active || active.runId !== runId) return;
-      if (!hasRunControlRegistration(this.host, runId, dispatchId, toolCallId)) return;
+      const registration = runControlRegistration(this.host, runId, dispatchId, toolCallId);
+      if (!registration) return;
       const message = `Run-control execution failed: ${error}`;
       this.host.store.tools.fail(dispatchId, message, "failed");
       this.host.store.messages.appendToolResult(
         toolCallId,
-        "shell.exec",
+        registration.resultName,
         message,
         true,
         runId,
@@ -1413,11 +1415,12 @@ export class ProcessRun {
       const call = turn.runControlCalls[0];
       if (!call) throw new Error("Run-control turn omitted its command");
       const dispatchId = crypto.randomUUID();
+      // registered under the tool's own name, Shell or Send, so its result and any interruption carry that name
       this.host.store.tools.register(
         dispatchId,
         call.toolCall.id,
         runId,
-        PENDING_RUN_CONTROL_CALL,
+        call.toolCall.name,
         jsonObjectSchema.parse(call.toolCall.arguments),
       );
       return dispatchId;

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -1314,6 +1314,10 @@ export class ProcessRun {
       assistantMetadata,
     );
     if (!assistantHistory) return null;
+    // the correction turn has produced its response; only now does the restriction lift, so an interrupted tick keeps it
+    if (this.host.runs.active?.runId === runId && this.host.runs.active.terminalCorrectionPending) {
+      this.host.mutateActiveRun(runId, (current) => ({ ...current, terminalCorrectionPending: undefined }));
+    }
     if (inferenceSpanId) {
       this.host.store.traces.setTraceSpanReference(inferenceSpanId, {
         kind: "message",
@@ -1864,7 +1868,6 @@ export class ProcessRun {
     const offeredRun = this.host.mutateActiveRun(runId, (current) => ({
       ...current,
       offeredToolNames,
-      terminalCorrectionPending: undefined,
     }));
     if (!offeredRun) return null;
     return { run: offeredRun, activeConfig, workTools: offeredWork, tools };

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -1280,7 +1280,7 @@ export class ProcessRun {
     const { prepared, response, fallbackMetadata, inferenceSpanId } = generated;
     const turn = classifyAssistantTurn(
       response,
-      prepared.workTools.map((tool) => tool.name),
+      prepared.run.offeredToolNames ?? prepared.workTools.map((tool) => tool.name),
     );
     let outputMedia =
       turn.toolCalls.length === 0 && turn.unofferedToolCalls.length === 0
@@ -1853,7 +1853,11 @@ export class ProcessRun {
     const correcting = run.terminalCorrectionPending === true && !run.returnToCaller;
     const offeredWork = correcting ? [] : workTools;
     const tools = run.returnToCaller ? workTools : correcting ? [SEND_TOOL] : withRunControlInstructions(workTools);
-    const offeredToolNames = [...new Set(offeredWork.map((tool) => tool.name))];
+    // the offered names are what the turn is classified against; Send counts only where the model was given it
+    const offeredToolNames = [
+      ...new Set(offeredWork.map((tool) => tool.name)),
+      ...(run.returnToCaller ? [] : [SEND_TOOL.name]),
+    ];
     const offeredRun = this.host.mutateActiveRun(runId, (current) => ({
       ...current,
       offeredToolNames,

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -9,7 +9,7 @@ import type {
   PersistedRunTick, RunTickContextState, RunTickInputs,
 } from "../internal/contracts";
 import {
-  FINAL_MESSAGE_BLOCK_EXAMPLE, MAX_TERMINAL_CORRECTION_ROUNDS, RUNTIME_EVENT_WAKE_MESSAGE,
+  CORRECTION_FAILURE_NOTICE, MAX_TERMINAL_CORRECTION_ROUNDS, RUNTIME_EVENT_WAKE_MESSAGE, YIELD_CORRECTION_MESSAGE,
   MAX_RETRYABLE_GENERATION_ATTEMPTS, PENDING_RUN_CONTROL_CALL, UNKNOWN_SHELL_SESSION_TARGET_MESSAGE,
   MEDIA_PREPARATION_TIMEOUT_MS, TOOL_DISPATCH_TIMEOUT_MS,
 } from "../internal/lifecycle";
@@ -56,7 +56,7 @@ import { MANAGED_LIFECYCLE_RECHECK_MS, managedInstallationWorkGate } from "../..
 import { GSV_DELEGATED_TASK_CONTEXT } from "../../prompts/system";
 import { createContextProjection, parseContextProjection } from "../context";
 import { deriveGenerationContextId } from "../context-message-metadata";
-import { piToolParametersSchema } from "../internal/schemas";
+import { SEND_TOOL, piToolParametersSchema } from "../internal/schemas";
 
 function hasRunControlRegistration(
   host: Process,
@@ -391,6 +391,7 @@ export class ProcessRun {
     const run = this.host.runs.active;
     if (!run || run.runId !== runId) return;
     if ((run.terminalCorrectionRounds ?? 0) >= MAX_TERMINAL_CORRECTION_ROUNDS) {
+      await this.deliverCorrectionNotice(runId);
       await this.finishRun(runId, {
         reason: "message.action.missing",
         status: "error",
@@ -403,15 +404,36 @@ export class ProcessRun {
     const correctedRun = this.host.mutateActiveRun(runId, (current) => ({
       ...current,
       terminalCorrectionRounds: (current.terminalCorrectionRounds ?? 0) + 1,
+      terminalCorrectionPending: true,
     }));
     if (!correctedRun) return;
-    const message = [
-      "This run is not complete. Ordinary assistant text is Process activity and is not sent to the user.",
-      "Run `yield` now if the work is complete.",
-      `If the user still needs a final message, send and finish with:\n${FINAL_MESSAGE_BLOCK_EXAMPLE}`,
-    ].join("\n");
-    await this.host.history.appendSystemMessage(runId, message);
+    await this.host.history.appendSystemMessage(runId, YIELD_CORRECTION_MESSAGE);
     if (!this.host.handleRunStopped(runId)) await this.scheduleTick(runId);
+  }
+
+  /** The run could not be corrected into sending; the person hears that much rather than nothing. */
+  async deliverCorrectionNotice(runId: string): Promise<void> {
+    const run = this.host.runs.active;
+    if (!run || run.runId !== runId || run.returnToCaller) return;
+    const actionId = `correction-notice-${runId}`;
+    try {
+      const release = this.beginRunControlCommit(runId);
+      try {
+        const request = this.buildRunControlMessageCommitRequest(run, {
+          runId,
+          actionId,
+          text: CORRECTION_FAILURE_NOTICE,
+          media: [],
+        });
+        await this.commitRunControlMessage(runId, actionId, request);
+      } finally {
+        release();
+      }
+    } catch (error) {
+      console.warn(
+        `[Process] Could not deliver the correction notice for ${runId}: ${errorMessageFromUnknown(error)}`,
+      );
+    }
   }
 
   async finishRun(
@@ -1827,14 +1849,18 @@ export class ProcessRun {
       description: tool.description,
       parameters: piToolParametersSchema.parse(tool.inputSchema),
     }));
-    const tools = run.returnToCaller ? workTools : withRunControlInstructions(workTools);
-    const offeredToolNames = [...new Set(workTools.map((tool) => tool.name))];
+    // a correction turn offers Send alone: the model stopped in text, and the only question left is what to send
+    const correcting = run.terminalCorrectionPending === true && !run.returnToCaller;
+    const offeredWork = correcting ? [] : workTools;
+    const tools = run.returnToCaller ? workTools : correcting ? [SEND_TOOL] : withRunControlInstructions(workTools);
+    const offeredToolNames = [...new Set(offeredWork.map((tool) => tool.name))];
     const offeredRun = this.host.mutateActiveRun(runId, (current) => ({
       ...current,
       offeredToolNames,
+      terminalCorrectionPending: undefined,
     }));
     if (!offeredRun) return null;
-    return { run: offeredRun, activeConfig, workTools, tools };
+    return { run: offeredRun, activeConfig, workTools: offeredWork, tools };
   }
 
   async prepareRunTickContext(

--- a/workers/gateway/src/process/run/state.ts
+++ b/workers/gateway/src/process/run/state.ts
@@ -139,6 +139,7 @@ export const runStateSchema = z.object({
   responsibilityBatches: z.array(responsibilityBatchStateSchema).optional(),
   offeredToolNames: z.array(z.string()).optional(),
   terminalCorrectionRounds: z.number().optional(),
+  terminalCorrectionPending: z.boolean().optional(),
   terminalCommandFailures: z.number().optional(),
   terminalDeliveryFailures: z.number().optional(),
   config: aiConfigResultSchema.optional(),

--- a/workers/gateway/src/process/tools/runtime.ts
+++ b/workers/gateway/src/process/tools/runtime.ts
@@ -12,7 +12,7 @@ import type { PreparedJsonToolArgs, DynamicRequestFrameData } from "../internal/
 import type { Process } from "../do";
 import type { RunState } from "../run/state";
 import {
-  INTERRUPTED_RUN_CONTROL_MESSAGE, PENDING_RUN_CONTROL_CALL, SHELL_SESSION_TARGET_KEY_PREFIX,
+  INTERRUPTED_RUN_CONTROL_MESSAGE, SHELL_SESSION_TARGET_KEY_PREFIX, isRunControlCall,
   TOOL_APPROVAL_OVERRIDES_KEY, TOOL_DISPATCH_TIMEOUT_MS, CODE_MODE_APPROVAL_TIMEOUT_MS,
   CODE_MODE_NESTED_SYSCALL_TIMEOUT_MS, UNKNOWN_SHELL_SESSION_TARGET_MESSAGE,
 } from "../internal/lifecycle";
@@ -436,7 +436,7 @@ export class ProcessTools {
     toolCall: ToolCallRecord,
     approvalPolicy: ToolApprovalPolicy,
   ): AdmittedToolCall | null {
-    if (toolCall.call === PENDING_RUN_CONTROL_CALL) {
+    if (isRunControlCall(toolCall.call)) {
       this.host.store.tools.fail(toolCall.dispatchId, INTERRUPTED_RUN_CONTROL_MESSAGE);
       return null;
     }


### PR DESCRIPTION
## Why

The Ship lost three replies in one day. Each time the model wrote its reply as assistant text, got one correction nudge, narrated the shell heredoc as prose instead of running it, and the run ended with `message.action.missing` without a word to the person. The person found out by asking again.

## What

- **A `Send` tool** with `text` and `yield`. Text alone sends and the run continues; text with `yield: true` sends and ends; `yield: true` alone ends silently. It is the same run control as the `message send` and `yield` commands and shares their handlers, so nothing a model can do here is something a person cannot type. The silent-yield guard, the responsibility gate, staged media and the five-attempt command budget all apply unchanged.
- **Correction offers Send alone.** A turn that ends in text alone gets a `[GSV EVENT]` saying so, and the next turn is offered `Send` and nothing else. Up to three rounds instead of one.
- **Never silent.** When correction still fails, the person receives "I wrote a reply but did not send it. Ask me again." before the run ends with its error.
- The Shell's run-control instruction and the rejection text now point at Send; the shell forms remain documented as the same actions.

## Notes

- Two process tests that model a 1,000-token window needed a little more room, since the fixed part of the context now carries a second tool.
- The `src/process/do.*.test.ts` suite is excluded from the unit config since 010de552 and is not run by CI. It was run locally for this change with the exclusion lifted: 661 passed.