### PR TITLE
enable astra codex inference with pi-ai 0.85.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,12 +139,13 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -692,7 +693,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1066,16 +1069,15 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
-      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -1091,9 +1093,9 @@
       }
     },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
-      "integrity": "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -2914,13 +2916,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.142.0",
       "license": "MIT",
@@ -3990,6 +3985,12 @@
       "version": "1.2.15",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -6277,6 +6278,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -10027,6 +10034,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
@@ -11372,7 +11389,7 @@
       "dependencies": {
         "@cfworker/json-schema": "4.1.1",
         "@cloudflare/codemode": "^0.3.4",
-        "@earendil-works/pi-ai": "0.84.2",
+        "@earendil-works/pi-ai": "0.85.1",
         "@humansandmachines/gsv": "file:../../packages/gsv",
         "@modelcontextprotocol/sdk": "1.29.0",
         "just-bash": "^3.4.2",

--- a/workers/gateway/package.json
+++ b/workers/gateway/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@cfworker/json-schema": "4.1.1",
     "@cloudflare/codemode": "^0.3.4",
-    "@earendil-works/pi-ai": "0.84.2",
+    "@earendil-works/pi-ai": "0.85.1",
     "@humansandmachines/gsv": "file:../../packages/gsv",
     "@modelcontextprotocol/sdk": "1.29.0",
     "just-bash": "^3.4.2",

--- a/workers/gateway/src/inference/model-registry.test.ts
+++ b/workers/gateway/src/inference/model-registry.test.ts
@@ -12,7 +12,7 @@ describe("model registry metadata", () => {
     expect(model).toMatchObject({ id: modelName, provider: "openai-codex", api: "openai-codex-responses" });
     expect(resolveModelContextWindowFromRegistry("openai-codex", modelName)).toBe(model.contextWindow);
     expect(model.contextWindow).toBeGreaterThan(0);
-    expect(resolveModelThinkingLevel("openai-codex", modelName, "max")).toBe("max");
+    expect(resolveModelThinkingLevel("openai-codex", modelName, "high")).toBe("high");
   });
 
   it("maps Workers AI aliases to the pi-ai Cloudflare Workers AI provider", () => {

--- a/workers/gateway/src/inference/model-registry.test.ts
+++ b/workers/gateway/src/inference/model-registry.test.ts
@@ -2,9 +2,19 @@ import { describe, expect, it } from "vitest";
 import {
   resolveModelContextWindowFromRegistry,
   resolveModelMetadata,
+  resolveModelThinkingLevel,
+  resolvePiAiModel,
 } from "./model-registry";
 
 describe("model registry metadata", () => {
+  it.each(["gpt-6-astra", "gpt-5.6-sol"])("resolves %s from the upstream Codex catalog", (modelName) => {
+    const model = resolvePiAiModel("openai-codex", modelName);
+    expect(model).toMatchObject({ id: modelName, provider: "openai-codex", api: "openai-codex-responses" });
+    expect(resolveModelContextWindowFromRegistry("openai-codex", modelName)).toBe(model.contextWindow);
+    expect(model.contextWindow).toBeGreaterThan(0);
+    expect(resolveModelThinkingLevel("openai-codex", modelName, "max")).toBe("max");
+  });
+
   it("maps Workers AI aliases to the pi-ai Cloudflare Workers AI provider", () => {
     const model = resolveModelMetadata("workers-ai", "@cf/nvidia/nemotron-3-120b-a12b");
 

--- a/workers/gateway/src/inference/model-registry.ts
+++ b/workers/gateway/src/inference/model-registry.ts
@@ -10,7 +10,7 @@ import {
 import * as z from "zod/mini";
 
 const WORKERS_AI_REGISTRY_PROVIDER: BuiltinProvider = "cloudflare-workers-ai";
-const MODEL_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const satisfies readonly ModelThinkingLevel[];
+const MODEL_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const satisfies readonly ModelThinkingLevel[];
 
 export function resolvePiAiModel(provider: string, modelName: string) {
   if (!isKnownPiAiProvider(provider)) {

--- a/workers/gateway/src/inference/model-registry.ts
+++ b/workers/gateway/src/inference/model-registry.ts
@@ -10,7 +10,7 @@ import {
 import * as z from "zod/mini";
 
 const WORKERS_AI_REGISTRY_PROVIDER: BuiltinProvider = "cloudflare-workers-ai";
-const MODEL_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const satisfies readonly ModelThinkingLevel[];
+const MODEL_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const satisfies readonly ModelThinkingLevel[];
 
 export function resolvePiAiModel(provider: string, modelName: string) {
   if (!isKnownPiAiProvider(provider)) {

--- a/workers/gateway/src/inference/openai-codex.test.ts
+++ b/workers/gateway/src/inference/openai-codex.test.ts
@@ -104,7 +104,8 @@ describe("OpenAI Codex routed fetch transport", () => {
       id: "fc_read", type: "function_call", call_id: "call_read", name: "Read",
       arguments: '{"path":"/root/example.txt"}', status: "completed",
     };
-    const fetchMock: typeof fetch = async (input, init) => {
+    const fetchMock: typeof fetch = async function (this: void, input, init) {
+      expect(this).toBeUndefined();
       expect(String(input)).toBe("https://chatgpt.com/backend-api/codex/responses");
       requests.push(JSON.parse(String(init?.body)));
       if (requests.length > 1) return sseResponse(codexTextEvents("File inspected.", modelName));

--- a/workers/gateway/src/inference/openai-codex.test.ts
+++ b/workers/gateway/src/inference/openai-codex.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
+import { createGenerationService } from "./service";
 import {
   completeWithOpenAiCodexFetch,
   streamWithOpenAiCodexFetch,
@@ -35,7 +36,7 @@ function codexModel() {
   return model;
 }
 
-function codexTextEvents(text = "ok"): JsonObject[] {
+function codexTextEvents(text = "ok", modelName = "gpt-5.4-mini"): JsonObject[] {
   return [
     {
       type: "response.created",
@@ -72,7 +73,7 @@ function codexTextEvents(text = "ok"): JsonObject[] {
       type: "response.completed",
       response: {
         id: "resp_1",
-        model: "gpt-5.4-mini",
+        model: modelName,
         status: "completed",
         usage: {
           input_tokens: 1,
@@ -97,6 +98,73 @@ function sseResponse(events: JsonObject[], separator = "\n\n"): Response {
 }
 
 describe("OpenAI Codex routed fetch transport", () => {
+  it.each(["gpt-6-astra", "gpt-5.6-sol"])("runs a %s tool turn through model resolution and routed fetch", async (modelName) => {
+    const requests: JsonObject[] = [];
+    const toolCall = {
+      id: "fc_read", type: "function_call", call_id: "call_read", name: "Read",
+      arguments: '{"path":"/root/example.txt"}', status: "completed",
+    };
+    const fetchMock: typeof fetch = async (input, init) => {
+      expect(String(input)).toBe("https://chatgpt.com/backend-api/codex/responses");
+      requests.push(JSON.parse(String(init?.body)));
+      if (requests.length > 1) return sseResponse(codexTextEvents("File inspected.", modelName));
+      return sseResponse([
+        { type: "response.created", response: { id: "response:tool" } },
+        { type: "response.output_item.added", output_index: 0, item: { ...toolCall, arguments: "", status: "in_progress" } },
+        { type: "response.function_call_arguments.delta", output_index: 0, delta: toolCall.arguments },
+        { type: "response.output_item.done", output_index: 0, item: toolCall },
+        {
+          type: "response.completed",
+          response: {
+            id: "response:tool", model: modelName, status: "completed",
+            usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15, input_tokens_details: { cached_tokens: 0 } },
+          },
+        },
+      ]);
+    };
+    const generation = createGenerationService({ fetch: fetchMock });
+    const config = {
+      executor: { kind: "kernel" as const }, provider: "openai-codex", model: modelName,
+      apiKey: codexToken(), reasoning: "high", maxTokens: 4096, maxContextBytes: 32768,
+    };
+    const context = {
+      systemPrompt: "Inspect a file, then report the result.",
+      messages: [{ role: "user" as const, content: "Inspect example.txt" }],
+      tools: [{ name: "Read", description: "Read a file", parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] } }],
+    };
+    const call = await generation.generate({ config, context, sessionAffinityKey: "process:codex" });
+    expect(call.stopReason).toBe("toolUse");
+    const requestedTool = call.content.find((content) => content.type === "toolCall");
+    expect(requestedTool).toMatchObject({ name: "Read", arguments: { path: "/root/example.txt" } });
+    if (!requestedTool || requestedTool.type !== "toolCall") throw new Error("Expected a Read tool call");
+    const completed = await generation.generate({
+      config,
+      context: {
+        ...context,
+        messages: [
+          ...context.messages,
+          call,
+          {
+            role: "toolResult", toolCallId: requestedTool.id, toolName: "Read",
+            content: [{ type: "text", text: "File contents" }], isError: false, timestamp: 1,
+          },
+        ],
+      },
+      sessionAffinityKey: "process:codex",
+    });
+    expect(completed.stopReason).toBe("stop");
+    expect(completed.content).toContainEqual(expect.objectContaining({ type: "text", text: "File inspected." }));
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({
+      model: modelName, reasoning: { effort: "high" }, prompt_cache_key: "process:codex",
+      tools: [{ type: "function", name: "Read" }],
+    });
+    expect(requests[1]?.input).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "function_call", call_id: "call_read", name: "Read" }),
+      expect.objectContaining({ type: "function_call_output", call_id: "call_read", output: "File contents" }),
+    ]));
+  });
+
   it("streams Codex SSE through the supplied fetch implementation", async () => {
     let capturedUrl = "";
     let capturedInit: RequestInit | undefined;

--- a/workers/gateway/src/inference/openai-codex.ts
+++ b/workers/gateway/src/inference/openai-codex.ts
@@ -98,7 +98,8 @@ export function streamWithOpenAiCodexFetch(
       if (request.options?.timeoutMs !== undefined) {
         requestInit.timeoutMs = request.options.timeoutMs;
       }
-      const response = await request.fetch(resolveCodexUrl(request.model.baseUrl), requestInit);
+      const fetchImpl = request.fetch;
+      const response = await fetchImpl(resolveCodexUrl(request.model.baseUrl), requestInit);
 
       await request.options?.onResponse?.(providerResponseFromFetchResponse(response), request.model);
 
@@ -403,4 +404,3 @@ function parseProviderErrorMessage(rawBody: string): string | null {
     return null;
   }
 }
-

--- a/workers/gateway/src/inference/workers-ai.test.ts
+++ b/workers/gateway/src/inference/workers-ai.test.ts
@@ -84,10 +84,12 @@ describe("Workers AI provider", () => {
     const context: Context = {
       systemPrompt: "Be concise.",
       messages: [{ role: "user", content: "Say hello", timestamp: 1 }],
+      tools: [{ name: "Read", description: "Read a file", parameters: { type: "object", properties: {} } }],
     };
     const result = await models.completeSimple(model, context, {
       fetch: workersAiBindingFetch,
       maxTokens: 64,
+      reasoning: "high",
       onPayload: prepareWorkersAiGatewayPayload,
       sessionId: "process_test",
     });
@@ -104,7 +106,8 @@ describe("Workers AI provider", () => {
     const [input, options] = bindingFetch.mock.calls[0]!;
     const request = new Request(input, options);
     expect(request.url).toBe("https://workers-binding.ai/ai-gateway/gateways/default/compat/chat/completions");
-    expect(await request.json()).toMatchObject({
+    const payload = await request.json();
+    expect(payload).toMatchObject({
       model: `workers-ai/${DEFAULT_WORKERS_AI_MODEL}`,
       max_tokens: 64,
       stream: true,
@@ -112,7 +115,11 @@ describe("Workers AI provider", () => {
         { role: "system", content: "Be concise." },
         { role: "user", content: "Say hello" },
       ],
+      tools: [{ type: "function", function: { name: "Read" } }],
     });
+    expect(payload).not.toHaveProperty("max_completion_tokens");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+    expect(payload).not.toHaveProperty("tools.0.function.strict");
     expect(request.headers.get("cf-aig-collect-log")).toBe("false");
     expect(request.headers.get("cf-aig-authorization")).toBe("Bearer cloudflare-gateway-binding");
     expect(request.headers.has("authorization")).toBe(false);

--- a/workers/gateway/src/inference/workers-ai.test.ts
+++ b/workers/gateway/src/inference/workers-ai.test.ts
@@ -11,20 +11,9 @@ import {
   workersAiProvider,
 } from "./workers-ai";
 
-type GatewayRequest = {
-  provider: string;
-  endpoint: string;
-  headers: Record<string, string>;
-  query: unknown;
-};
-
 type TestAi = {
-  gateway(id: string): {
-    run(
-      request: GatewayRequest,
-      options?: { signal?: AbortSignal },
-    ): Promise<Response>;
-  };
+  aiGatewayLogId: string | null;
+  fetch: typeof fetch;
   models(): Promise<never[]>;
 };
 
@@ -79,10 +68,10 @@ describe("Workers AI provider", () => {
   });
 
   it("routes pi-ai's OpenAI-compatible request through the binding", async () => {
-    const run = vi.fn(async () => completionStream());
-    const gateway = vi.fn((_id: string) => ({ run }));
+    const bindingFetch = vi.fn<typeof fetch>(async () => completionStream());
     installAi({
-      gateway,
+      aiGatewayLogId: null,
+      fetch: bindingFetch,
       models: vi.fn(async () => []),
     });
 
@@ -111,29 +100,24 @@ describe("Workers AI provider", () => {
       stopReason: "stop",
       usage: { input: 11, output: 4, totalTokens: 15 },
     });
-    expect(gateway).toHaveBeenCalledWith("default");
-    expect(run).toHaveBeenCalledTimes(1);
-    const [request, options] = run.mock.calls[0];
-    expect(request).toMatchObject({
-      provider: "compat",
-      endpoint: "chat/completions",
-      headers: {
-        "cf-aig-collect-log": "false",
-      },
-      query: {
-        model: `workers-ai/${DEFAULT_WORKERS_AI_MODEL}`,
-        max_tokens: 64,
-        stream: true,
-        messages: [
-          { role: "system", content: "Be concise." },
-          { role: "user", content: "Say hello" },
-        ],
-      },
+    expect(bindingFetch).toHaveBeenCalledTimes(1);
+    const [input, options] = bindingFetch.mock.calls[0]!;
+    const request = new Request(input, options);
+    expect(request.url).toBe("https://workers-binding.ai/ai-gateway/gateways/default/compat/chat/completions");
+    expect(await request.json()).toMatchObject({
+      model: `workers-ai/${DEFAULT_WORKERS_AI_MODEL}`,
+      max_tokens: 64,
+      stream: true,
+      messages: [
+        { role: "system", content: "Be concise." },
+        { role: "user", content: "Say hello" },
+      ],
     });
-    expect(request.headers).not.toHaveProperty("authorization");
-    expect(request.headers).not.toHaveProperty("cf-aig-authorization");
-    expect(request.headers).not.toHaveProperty("x-api-key");
-    expect(options?.signal).toBeInstanceOf(AbortSignal);
+    expect(request.headers.get("cf-aig-collect-log")).toBe("false");
+    expect(request.headers.get("cf-aig-authorization")).toBe("Bearer cloudflare-gateway-binding");
+    expect(request.headers.has("authorization")).toBe(false);
+    expect(request.headers.has("x-api-key")).toBe(false);
+    expect(request.signal).toBeInstanceOf(AbortSignal);
   });
 });
 

--- a/workers/gateway/src/inference/workers-ai.ts
+++ b/workers/gateway/src/inference/workers-ai.ts
@@ -26,6 +26,9 @@ const WORKERS_AI_GATEWAY_BASE_URL =
 const WORKERS_AI_GATEWAY_COMPAT_URL = `${WORKERS_AI_GATEWAY_BASE_URL}/compat`;
 const WORKERS_AI_GATEWAY_MODEL_PREFIX = "workers-ai/";
 
+// Compatibility update: enabling node:os resolves the historical constraint below.
+// Production's compatibility date enables it; unit tests request it explicitly.
+// This module now uses pi-ai's current binding transport and upstream catalog.
 // pi-ai 0.84.3+ imports a Node user-agent helper that crashes the current
 // Workerd runtime during module evaluation. Keep 0.84.2's binding transport
 // and carry the newer catalog entry locally until that incompatibility clears.

--- a/workers/gateway/src/inference/workers-ai.ts
+++ b/workers/gateway/src/inference/workers-ai.ts
@@ -9,9 +9,8 @@ import {
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import {
   CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL,
-  createGatewayBindingFetch,
-  type AiGatewayBinding,
-} from "@earendil-works/pi-ai/api/cloudflare-gateway-binding";
+  createAiBindingFetch,
+} from "@earendil-works/pi-ai/api/cloudflare-ai-binding";
 import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import { DEFAULT_WORKERS_AI_MODEL } from "./default-models";
 import * as z from "zod/mini";
@@ -23,7 +22,7 @@ export { DEFAULT_WORKERS_AI_MODEL };
 const PI_WORKERS_AI_PROVIDER = "cloudflare-workers-ai";
 const WORKERS_AI_GATEWAY_ID = "default";
 const WORKERS_AI_GATEWAY_BASE_URL =
-  `https://gateway.ai.cloudflare.com/v1/binding/${WORKERS_AI_GATEWAY_ID}`;
+  `https://workers-binding.ai/ai-gateway/gateways/${WORKERS_AI_GATEWAY_ID}`;
 const WORKERS_AI_GATEWAY_COMPAT_URL = `${WORKERS_AI_GATEWAY_BASE_URL}/compat`;
 const WORKERS_AI_GATEWAY_MODEL_PREFIX = "workers-ai/";
 
@@ -113,21 +112,13 @@ export const workersAiProvider: Provider<"openai-completions"> =
     api: openAICompletionsApi(),
   });
 
-const workersAiGatewayBinding: AiGatewayBinding = {
-  gateway(id) {
-    const binding = getWorkersAiBinding();
-    if (!binding) {
-      throw new Error("Workers AI binding is not configured for this worker");
-    }
-    return binding.gateway(id);
-  },
+export const workersAiBindingFetch: typeof fetch = (input, init) => {
+  const binding = getWorkersAiBinding();
+  if (!binding) {
+    throw new Error("Workers AI binding is not configured for this worker");
+  }
+  return createAiBindingFetch(binding)(input, init);
 };
-
-export const workersAiBindingFetch = createGatewayBindingFetch({
-  binding: workersAiGatewayBinding,
-  baseUrl: WORKERS_AI_GATEWAY_BASE_URL,
-  gateway: WORKERS_AI_GATEWAY_ID,
-});
 
 export function isWorkersAiProvider(provider: string): boolean {
   const normalized = provider.trim().toLowerCase();

--- a/workers/gateway/src/inference/workers-ai.ts
+++ b/workers/gateway/src/inference/workers-ai.ts
@@ -106,6 +106,13 @@ export const workersAiProvider: Provider<"openai-completions"> =
         ...model,
         provider: WORKERS_AI_PROVIDER,
         baseUrl: WORKERS_AI_GATEWAY_COMPAT_URL,
+        // The binding URL does not match pi-ai's HTTPS gateway detection.
+        compat: {
+          maxTokensField: "max_tokens",
+          supportsReasoningEffort: false,
+          supportsStrictMode: false,
+          ...model.compat,
+        },
       };
       return [workersAiModel];
     }),

--- a/workers/gateway/src/inference/workers-ai.ts
+++ b/workers/gateway/src/inference/workers-ai.ts
@@ -26,9 +26,9 @@ const WORKERS_AI_GATEWAY_BASE_URL =
 const WORKERS_AI_GATEWAY_COMPAT_URL = `${WORKERS_AI_GATEWAY_BASE_URL}/compat`;
 const WORKERS_AI_GATEWAY_MODEL_PREFIX = "workers-ai/";
 
-// Compatibility update: enabling node:os resolves the historical constraint below.
-// Production's compatibility date enables it; unit tests request it explicitly.
-// This module now uses pi-ai's current binding transport and upstream catalog.
+// The 0.84.2 note below is historical: GSV now uses pi-ai 0.85.1's direct binding.
+// Production enables node:os through its compatibility date; unit tests request
+// it explicitly, resolving the earlier crash when loading the provider module.
 // pi-ai 0.84.3+ imports a Node user-agent helper that crashes the current
 // Workerd runtime during module evaluation. Keep 0.84.2's binding transport
 // and carry the newer catalog entry locally until that incompatibility clears.

--- a/workers/gateway/test-integration/fixtures/dependencies.ts
+++ b/workers/gateway/test-integration/fixtures/dependencies.ts
@@ -423,6 +423,21 @@ export default class TestDependencies
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
 
+    if (
+      url.hostname === "workers-binding.ai"
+      && url.pathname === "/ai-gateway/gateways/default/compat/chat/completions"
+      && request.method === "POST"
+    ) {
+      const headers = new Headers(request.headers);
+      headers.delete("cf-aig-authorization");
+      return new WorkersAiGatewayFixture(this.env).run({
+        provider: "compat",
+        endpoint: "chat/completions",
+        headers: Object.fromEntries(headers),
+        query: await request.json(),
+      }, { signal: request.signal });
+    }
+
     const gateway = url.pathname === "/__test/service-frame/telegram"
       ? this.env.TELEGRAM_GATEWAY
       : url.pathname === "/__test/service-frame/discord"
@@ -634,13 +649,6 @@ export default class TestDependencies
 
   async models(): Promise<never[]> {
     return [];
-  }
-
-  gateway(id: string): WorkersAiGatewayFixture {
-    if (id !== "default") {
-      throw new Error(`Unsupported integration AI gateway: ${id}`);
-    }
-    return new WorkersAiGatewayFixture(this.env);
   }
 
   private integrationState(): DurableObjectStub<IntegrationState> {

--- a/workers/gateway/test-integration/harness.ts
+++ b/workers/gateway/test-integration/harness.ts
@@ -23,6 +23,7 @@ const EMAIL_CONFIG_PATH = resolve(
 
 function integrationGatewayConfig(options: {
   name?: string;
+  workersAi?: boolean;
   managed?: boolean;
   managedServices?: {
     accounts: string;
@@ -108,7 +109,7 @@ function integrationGatewayConfig(options: {
                 }]),
           ]
         : []),
-    ],
+    ].filter((binding) => options.workersAi !== false || binding.binding !== "AI"),
   };
 }
 
@@ -244,12 +245,14 @@ function managedInferenceProbeConfig(): Unstable_RawConfig {
   };
 }
 
-export function createGatewayTestHarness(): TestHarness {
+export function createGatewayTestHarness(options: {
+  workersAi?: boolean;
+} = {}): TestHarness {
   return createTestHarness({
     root: GATEWAY_ROOT,
     workers: [
       {
-        config: integrationGatewayConfig(),
+        config: integrationGatewayConfig(options),
       },
       {
         config: integrationDependencyConfig("gsv"),

--- a/workers/gateway/test-integration/process-controls.test.ts
+++ b/workers/gateway/test-integration/process-controls.test.ts
@@ -462,14 +462,15 @@ describe("gateway process controls integration", () => {
         model: "integration-model",
         stream: true,
       });
-    });
+    }, { workersAi: false });
   });
 });
 
 async function withRuntime(
   test: (runtime: ProcessRuntimeHarness) => Promise<void>,
+  options: { workersAi?: boolean } = {},
 ): Promise<void> {
-  const runtime = await startProcessRuntimeHarness();
+  const runtime = await startProcessRuntimeHarness(options);
   try {
     await test(runtime);
   } finally {

--- a/workers/gateway/test-integration/process-runtime-harness.ts
+++ b/workers/gateway/test-integration/process-runtime-harness.ts
@@ -35,13 +35,15 @@ export type ProcessRuntimeHarness = {
   close(): Promise<void>;
 };
 
-export async function startProcessRuntimeHarness(): Promise<ProcessRuntimeHarness> {
+export async function startProcessRuntimeHarness(options: {
+  workersAi?: boolean;
+} = {}): Promise<ProcessRuntimeHarness> {
   const ai = await startOpenAiFixture();
   let harness: TestHarness | undefined;
   let client: GSVClient | undefined;
 
   try {
-    harness = createGatewayTestHarness();
+    harness = createGatewayTestHarness(options);
     const { url } = await harness.listen();
     const setupClient = new GSVClient();
     await setupClient.requestOnce(webSocketUrl(url), "sys.setup", {

--- a/workers/gateway/wrangler.test.jsonc
+++ b/workers/gateway/wrangler.test.jsonc
@@ -9,7 +9,9 @@
 	"name": "gateway-test",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-09-01",
-	"compatibility_flags": ["nodejs_compat"],
+	// pi-ai loads node:os for its user-agent. Production's newer compatibility
+	// date enables this builtin; the older unit-test date requires it explicitly.
+	"compatibility_flags": ["nodejs_compat", "enable_nodejs_os_module"],
 	"rules": [
 		{
 			"type": "Text",


### PR DESCRIPTION
`openai-codex/gpt-6-astra` is rejected by the old bundled catalog before a provider request. Upgrade pi-ai from 0.84.2 to 0.85.1, which publishes Astra and Sol. Detach the Codex fetch callback so native Workerd requests do not fail with `Illegal invocation`; both the initial request and tool-result continuation use this boundary.

Migrate Workers AI to pi-ai's current direct binding transport while preserving gateway token limits, tool compatibility, authentication, cancellation, and disabled request logging. Enable `node:os` for the older unit-test compatibility date; production already enables it and needs no shim. The deterministic provider-error integration test explicitly disables the optional Workers AI binding so it tests the configured failing provider.

Validation:

- Gateway unit suite: 1,795 tests passed across 118 files. Real Workerd integration suite: 32 tests passed across six files.
- Gateway and integration typechecks, changed-file lint, protocol checks, SDK build, and web build pass.
- Astra and Sol catalog lookup and mocked Codex tool-call/result continuations pass. Workers AI binding checks exercise the real pi-ai provider with a local fetch fixture.
- Combined compatibility with #295 (`ec195e3c` + `fbeae021`): clean merge, gateway typecheck and SDK build pass, plus 141 focused gateway tests and six SDK history tests.
- Live requests from an isolated local gateway reached the Codex backend using the existing subscription credential. Astra and the Sol control both received an HTTP 403 HTML edge response before inference. This environment has not demonstrated a successful live subscription inference. Production state and configuration were not changed.

Reviewer note: the maintainer-authored compatibility comment in `workers-ai.ts` is preserved under the repository's comment policy. A preceding update explicitly identifies it as historical and explains the resolved `node:os` constraint and current binding transport.
