### PR TITLE
preserve both ai binding fixture transports

### DIFF
--- a/workers/gateway/test-integration/fixtures/dependencies.ts
+++ b/workers/gateway/test-integration/fixtures/dependencies.ts
@@ -651,6 +651,13 @@ export default class TestDependencies
     return [];
   }
 
+  gateway(id: string): WorkersAiGatewayFixture {
+    if (id !== "default") {
+      throw new Error(`Unsupported integration AI gateway: ${id}`);
+    }
+    return new WorkersAiGatewayFixture(this.env);
+  }
+
   private integrationState(): DurableObjectStub<IntegrationState> {
     const id = this.env.INTEGRATION_STATE.idFromName(SINGLETON_INSTALLATION_ID);
     return this.env.INTEGRATION_STATE.get(id);


### PR DESCRIPTION
Managed deployment checks call `AI.gateway().run()` through the private inference service, while the updated Gateway calls `AI.fetch()`. The shared fixture must support both Cloudflare binding APIs. Restore its `gateway()` entrypoint and reuse the existing response implementation.

Validation: the previously failing infrastructure managed-inference stack test passes, all 32 public Gateway integration tests pass, and gateway integration types and fixture lint pass.
