### PR TITLE
fix codex history serialization

### DIFF
--- a/workers/gateway/src/inference/openai-codex.test.ts
+++ b/workers/gateway/src/inference/openai-codex.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
+import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
 import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
+import { jsonObjectSchema } from "@humansandmachines/gsv/protocol";
+import * as z from "zod/mini";
 import { createGenerationService } from "./service";
 import {
   completeWithOpenAiCodexFetch,
@@ -44,6 +47,7 @@ function codexTextEvents(text = "ok", modelName = "gpt-5.4-mini"): JsonObject[] 
     },
     {
       type: "response.output_item.added",
+      output_index: 0,
       item: { id: "msg_1", type: "message", role: "assistant", status: "in_progress", content: [] },
     },
     {
@@ -97,8 +101,12 @@ function sseResponse(events: JsonObject[], separator = "\n\n"): Response {
   });
 }
 
+function requestInput(request: JsonObject | undefined): JsonObject[] {
+  return z.array(jsonObjectSchema).parse(request?.input);
+}
+
 describe("OpenAI Codex routed fetch transport", () => {
-  it.each(["gpt-6-astra", "gpt-5.6-sol"])("runs a %s tool turn through model resolution and routed fetch", async (modelName) => {
+  it.each(["gpt-6-astra", "gpt-5.6-sol"])("replays a completed %s tool turn through model resolution and routed fetch", async (modelName) => {
     const requests: JsonObject[] = [];
     const toolCall = {
       id: "fc_read", type: "function_call", call_id: "call_read", name: "Read",
@@ -128,9 +136,9 @@ describe("OpenAI Codex routed fetch transport", () => {
       executor: { kind: "kernel" as const }, provider: "openai-codex", model: modelName,
       apiKey: codexToken(), reasoning: "high", maxTokens: 4096, maxContextBytes: 32768,
     };
-    const context = {
+    const context: Context = {
       systemPrompt: "Inspect a file, then report the result.",
-      messages: [{ role: "user" as const, content: "Inspect example.txt" }],
+      messages: [{ role: "user", content: "Inspect example.txt", timestamp: 0 }],
       tools: [{ name: "Read", description: "Read a file", parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] } }],
     };
     const call = await generation.generate({ config, context, sessionAffinityKey: "process:codex" });
@@ -138,19 +146,19 @@ describe("OpenAI Codex routed fetch transport", () => {
     const requestedTool = call.content.find((content) => content.type === "toolCall");
     expect(requestedTool).toMatchObject({ name: "Read", arguments: { path: "/root/example.txt" } });
     if (!requestedTool || requestedTool.type !== "toolCall") throw new Error("Expected a Read tool call");
+    const afterTool: Context = {
+      ...context,
+      messages: [
+        ...context.messages,
+        call,
+        {
+          role: "toolResult", toolCallId: requestedTool.id, toolName: "Read",
+          content: [{ type: "text", text: "File contents" }], isError: false, timestamp: 1,
+        },
+      ],
+    };
     const completed = await generation.generate({
-      config,
-      context: {
-        ...context,
-        messages: [
-          ...context.messages,
-          call,
-          {
-            role: "toolResult", toolCallId: requestedTool.id, toolName: "Read",
-            content: [{ type: "text", text: "File contents" }], isError: false, timestamp: 1,
-          },
-        ],
-      },
+      config, context: afterTool,
       sessionAffinityKey: "process:codex",
     });
     expect(completed.stopReason).toBe("stop");
@@ -164,6 +172,87 @@ describe("OpenAI Codex routed fetch transport", () => {
       expect.objectContaining({ type: "function_call", call_id: "call_read", name: "Read" }),
       expect.objectContaining({ type: "function_call_output", call_id: "call_read", output: "File contents" }),
     ]));
+
+    const followup = await generation.generate({
+      config,
+      context: {
+        ...afterTool,
+        messages: [
+          ...afterTool.messages, completed,
+          { role: "user", content: "Confirm the result briefly.", timestamp: 2 },
+        ],
+      },
+      sessionAffinityKey: "process:codex",
+    });
+    expect(followup.stopReason).toBe("stop");
+    expect(requests).toHaveLength(3);
+    const replay = requestInput(requests[2]).find((item) => item.role === "assistant");
+    expect(replay).toMatchObject({
+      type: "message", id: "msg_1", status: "completed",
+      content: [{ type: "output_text", text: "File inspected." }],
+    });
+    expect(replay).not.toHaveProperty("phase");
+  });
+
+  it("serializes mixed-provider history without losing signatures or JSON values", async () => {
+    const model = codexModel();
+    const requests: JsonObject[] = [];
+    const fetchMock: typeof fetch = async (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return sseResponse(codexTextEvents());
+    };
+    const prior = await completeWithOpenAiCodexFetch({
+      model, fetch: fetchMock, options: { apiKey: codexToken() },
+      context: { messages: [{ role: "user", content: "Begin.", timestamp: 0 }] },
+    });
+    expect(prior.stopReason).toBe("stop");
+    const argumentsValue = { path: "/example.txt", offset: 0, follow: false, cursor: null };
+    const output = JSON.stringify({ text: "A quoted \"result\" — λ", count: 0, truncated: false, next: null });
+    const foreign: AssistantMessage = {
+      ...prior, provider: "deepseek", api: "openai-completions", model: "deepseek-chat", stopReason: "toolUse",
+      content: [
+        { type: "text", text: "Checking the file." },
+        { type: "toolCall", id: "call_legacy", name: "Read", arguments: argumentsValue },
+      ],
+    };
+    const reasoning = { type: "reasoning", id: "rs_saved", encrypted_content: "synthetic-ciphertext", summary: [] };
+    const signed: AssistantMessage = {
+      ...prior,
+      content: [
+        { type: "thinking", thinking: "", thinkingSignature: JSON.stringify(reasoning) },
+        { type: "text", text: "File checked.", textSignature: JSON.stringify({ v: 1, id: "msg_saved", phase: "final_answer" }) },
+      ],
+    };
+    const parameters = {
+      type: "object", additionalProperties: false,
+      properties: { offset: { type: "integer", minimum: 0, default: 0 }, cursor: { type: ["string", "null"], default: null } },
+    };
+    const result = await completeWithOpenAiCodexFetch({
+      model, fetch: fetchMock,
+      options: { apiKey: codexToken(), temperature: 0 },
+      context: {
+        messages: [
+          { role: "user", content: "Read the file.", timestamp: 0 }, foreign,
+          { role: "toolResult", toolCallId: "call_legacy", toolName: "Read", content: [{ type: "text", text: output }], isError: false, timestamp: 1 },
+          signed, { role: "user", content: "Continue.", timestamp: 2 },
+        ],
+        tools: [{ name: "Read", description: "Read a file", parameters }],
+      },
+    });
+    expect(result.stopReason).toBe("stop");
+    expect(requests).toHaveLength(2);
+    const request = requests[1]!;
+    const input = requestInput(request);
+    const call = input.find((item) => item.type === "function_call");
+    expect(call).toEqual({ type: "function_call", call_id: "call_legacy", name: "Read", arguments: JSON.stringify(argumentsValue) });
+    expect(input).toContainEqual({ type: "function_call_output", call_id: "call_legacy", output });
+    expect(input).toContainEqual(reasoning);
+    expect(input.find((item) => item.id === "msg_saved")).toMatchObject({ phase: "final_answer", content: [{ type: "output_text", text: "File checked." }] });
+    expect(input.find((item) => item.role === "assistant")).not.toHaveProperty("phase");
+    expect(request).toMatchObject({
+      store: false, temperature: 0,
+      tools: [{ type: "function", name: "Read", description: "Read a file", parameters, strict: null }],
+    });
   });
 
   it("streams Codex SSE through the supplied fetch implementation", async () => {

--- a/workers/gateway/src/inference/openai-codex.ts
+++ b/workers/gateway/src/inference/openai-codex.ts
@@ -20,10 +20,7 @@ import type {
   JsonObject,
   JsonValue,
 } from "@humansandmachines/gsv/protocol";
-import {
-  jsonObjectSchema,
-  jsonValueSchema,
-} from "@humansandmachines/gsv/protocol";
+import { jsonObjectSchema } from "@humansandmachines/gsv/protocol";
 import { z } from "zod";
 
 type OpenAiCodexFetchRequest = {
@@ -38,6 +35,23 @@ type OpenAiCodexFetchOptions = SimpleStreamOptions & {
   reasoningSummary?: "auto" | "concise" | "detailed";
   serviceTier?: "auto" | "default" | "flex" | "scale" | "priority";
   textVerbosity?: "low" | "medium" | "high";
+};
+
+type OpenAiCodexRequestBody = {
+  model: string;
+  store: boolean;
+  stream: boolean;
+  instructions: string;
+  input: ReturnType<typeof convertResponsesMessages>;
+  text: { verbosity: NonNullable<OpenAiCodexFetchOptions["textVerbosity"]> };
+  include: string[];
+  tool_choice: "auto";
+  parallel_tool_calls: boolean;
+  prompt_cache_key?: string;
+  temperature?: number;
+  service_tier?: OpenAiCodexFetchOptions["serviceTier"];
+  tools?: ReturnType<typeof convertResponsesTools>;
+  reasoning?: { effort: string; summary: NonNullable<OpenAiCodexFetchOptions["reasoningSummary"]> };
 };
 
 type RoutedRequestInit = RequestInit & { timeoutMs?: number };
@@ -176,15 +190,16 @@ function buildRequestBody(
   model: Model<Api>,
   context: Context,
   options: OpenAiCodexFetchOptions | undefined,
-): JsonObject {
-  const body: JsonObject = {
+): OpenAiCodexRequestBody {
+  // Provider converters retain optional undefined fields until HTTP JSON serialization.
+  const body: OpenAiCodexRequestBody = {
     model: model.id,
     store: false,
     stream: true,
     instructions: context.systemPrompt || "You are a helpful assistant.",
-    input: jsonValueSchema.parse(convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS, {
+    input: convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS, {
       includeSystemPrompt: false,
-    })),
+    }),
     text: { verbosity: options?.textVerbosity ?? "low" },
     include: ["reasoning.encrypted_content"],
     tool_choice: "auto",
@@ -204,7 +219,7 @@ function buildRequestBody(
     body.service_tier = serviceTier;
   }
   if (context.tools && context.tools.length > 0) {
-    body.tools = jsonValueSchema.parse(convertResponsesTools(context.tools, { strict: null }));
+    body.tools = convertResponsesTools(context.tools, { strict: null });
   }
 
   const clampedReasoning = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;


### PR DESCRIPTION
Codex requests with prior assistant text or tool calls could fail before HTTP dispatch: the provider converter emits optional `phase` and `id` fields as `undefined`, and strict JSON validation rejected those intermediate objects. This could trigger an unintended provider fallback on a later conversation turn.

Keep the converter's typed request values until the existing HTTP JSON serialization boundary, which omits optional undefined properties. Apply the same boundary to tool definitions while preserving defined phases, signatures, and JSON values.

Validation: three new replay cases failed before the fix; all 42 focused inference tests now pass, including Astra/Sol third-turn replay and mixed-provider history. Gateway typecheck, targeted lint, and diff checks pass. Tests use synthetic history and a routed fetch fixture; no live inference claim.
