### PR TITLE
show the model that answered in zen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, feat/zen-fleet]
 
 permissions:
   contents: read

--- a/web/src/app/features/instrument/zen/Zen.tsx
+++ b/web/src/app/features/instrument/zen/Zen.tsx
@@ -27,6 +27,7 @@ import { PromptLine, type PromptPlace } from "../shared/PromptLine";
 import { Wordmark } from "../shared/Wordmark";
 import {
   activityDuration,
+  answerAttribution,
   countLabel,
   defaultPlace,
   formatSeconds,
@@ -48,6 +49,7 @@ import {
   CLOUD_PLACE_ID,
   RESOLVE_TAIL,
   type Activity,
+  type AnswerHistoryEntry,
   type Moment,
   type Place,
   type ReceiptPhrase,
@@ -300,6 +302,7 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
 
   const [pid, setPid] = useState<string | null>(null);
   const [runtime, setRuntime] = useState<ChatRuntimeState>(() => emptyChatRuntimeState());
+  const [answerHistory, setAnswerHistory] = useState<{ pid: string; entries: AnswerHistoryEntry[]; through: number } | null>(null);
   /* the conversation is what was actually said, both ways; the process transcript is what the ship did */
   const conversation = useChatConversation({ processId: pid ?? "", enabled: pid !== null });
   const runtimeRef = useRef(runtime);
@@ -432,6 +435,12 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
     if (!pid) return;
     try {
       const history = await getChatHistory(client, { pid, tail: true, limit: HISTORY_LIMIT });
+      setAnswerHistory({
+        pid,
+        entries: history.messages.filter((message) => message.role === "assistant")
+          .map(({ runId, timestamp, metadata }) => ({ runId, timestamp, metadata })),
+        through: Math.max(0, ...history.messages.map((message) => message.timestamp ?? 0)),
+      });
       const next = chatRuntimeStateFromHistory(history);
       runtimeRef.current = next;
       setRuntime(next);
@@ -494,7 +503,9 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
 
   /* moments: the runtime's, plus the commands run by hand */
   const moments = useMemo(() => {
-    const fromRuntime = momentsFromConversation(conversation.rows, runtime.rows, runtime.activeRunId);
+    const retained = answerHistory?.pid === pid ? answerHistory : null;
+    const fromRuntime = momentsFromConversation(conversation.rows, runtime.rows, runtime.activeRunId)
+      .map((moment) => ({ ...moment, attribution: answerAttribution(moment, retained?.entries ?? [], retained?.through ?? 0) }));
     const fromLocal: Moment[] = localRuns.map((run) => ({
       id: run.id,
       role: "ship",
@@ -526,7 +537,7 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
       ],
     }));
     return [...fromRuntime, ...fromLocal].sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
-  }, [conversation.rows, localRuns, runtime.activeRunId, runtime.rows]);
+  }, [answerHistory, conversation.rows, localRuns, pid, runtime.activeRunId, runtime.rows]);
 
   const seenMomentsRef = useRef<Set<string> | null>(null);
   const streamedMomentsRef = useRef<Set<string>>(new Set());
@@ -591,6 +602,7 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
   }, [moments, tick]);
 
   const latest = moments[moments.length - 1];
+  const lastAnswer = [...moments].reverse().find((moment) => moment.role === "ship" && moment.text.trim() && !moment.streaming && !moment.thinking);
   const pendingHil: ProcHilRequest | null = runtime.pendingHil;
 
   const toggleActivity = useCallback((key: string) => {
@@ -808,7 +820,7 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
       return [
         part("is-live", "thinking"),
         part("", formatSeconds(elapsed)),
-        part("", runtime.context?.model ?? ""),
+        part("", runtime.context?.model ? `attempting ${runtime.context.model}` : ""),
         part("", `${placeLabel(where ?? "gsv", places)} ready`),
       ].filter((entry) => entry.text);
     }
@@ -828,7 +840,9 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
       ];
     }
     const parts: StatusPart[] = [];
-    if (runtime.context?.model) parts.push(part("is-on", `answered by ${runtime.context.model}`));
+    if (lastAnswer?.attribution?.model) parts.push(part("is-on", `answered by ${lastAnswer.attribution.model}`));
+    const fallback = lastAnswer?.attribution?.fallbacks.at(-1);
+    if (fallback) parts.push(part("is-warn", `fallback from ${fallback.from}`));
     if (lastRun && lastRun.endedAt !== null) parts.push(part("", formatSeconds(lastRun.endedAt - lastRun.startedAt)));
     const usage = runtime.context?.usage;
     if (usage?.cost) parts.push(part("", `$${usage.cost.total.toFixed(2)} so far`));
@@ -836,7 +850,7 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
     if (latest && latest.role === "ship") parts.push(part("", `${countLabel(placesUsed(latest), "place")} used`));
     if (parts.length === 0) parts.push(part("", "nothing yet"));
     return parts;
-  }, [browse, connected, lastRun, latest, localRuns, moments.length, now, pendingHil, pid, places, runtime.context, thinking, where]);
+  }, [browse, connected, lastAnswer, lastRun, latest, localRuns, moments.length, now, pendingHil, pid, places, runtime.context, thinking, where]);
 
   const onlinePlaces = places.filter((place) => place.online);
   const empty = ready && moments.length === 0 && pid !== null;
@@ -929,7 +943,20 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
               }
               return (
                 <div key={moment.id} data-index={index} class={`zen-moment ${moment.role === "human" ? "is-human" : "is-ship"}${pending ? " is-pending" : ""}${materialising ? " is-materialising" : ""}${isLatest ? "" : " is-older"}${browse === index ? " is-focus" : ""}`}>
-                  <div class="who">{moment.role === "human" ? who : "ship"}</div>
+                  <div class="who">
+                    {moment.role === "human" ? who : "ship"}
+                    {moment.attribution?.model ? <span class="answer-model" title={moment.attribution.provider ?? undefined}> · {moment.attribution.model}</span> : null}
+                  </div>
+                  {moment.attribution?.fallbacks.length ? (
+                    <div class="zen-model-fallback">
+                      {moment.attribution.fallbacks.map((fallback, index) => (
+                        <span key={`${fallback.from}:${fallback.to}`} title={fallback.reason ?? undefined}>
+                          {index ? " · " : "fallback: "}{fallback.from} → {fallback.to}
+                        </span>
+                      ))}
+                      {moment.attribution.omittedFallbacks ? ` · ${moment.attribution.omittedFallbacks} earlier` : null}
+                    </div>
+                  ) : null}
                   {moment.activities
                     .filter((activity) => activity.you)
                     .map((activity) => (

--- a/web/src/app/features/instrument/zen/zen.css
+++ b/web/src/app/features/instrument/zen/zen.css
@@ -64,6 +64,17 @@
   color: var(--text-dim);
   margin-bottom: 8px;
 }
+.zen-moment .answer-model {
+  letter-spacing: normal;
+  text-transform: none;
+}
+.zen-model-fallback {
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.5;
+  margin-bottom: 8px;
+  overflow-wrap: anywhere;
+}
 .zen-moment.is-human .text {
   font-family: var(--gsv-font-prose);
   font-weight: 500;

--- a/web/src/app/features/instrument/zen/zenModel.test.ts
+++ b/web/src/app/features/instrument/zen/zenModel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ChatTranscriptRow } from "../../chat/domain/transcript";
 import {
   activitiesForRows,
+  answerAttribution,
   argumentThatMatters,
   defaultPlace,
   formatSeconds,
@@ -20,6 +21,8 @@ import {
   resolveTail,
   trimOutput,
   noteSummary,
+  type AnswerHistoryEntry,
+  type Moment,
 } from "./zenModel";
 
 const places = [
@@ -30,6 +33,103 @@ const places = [
 function row(partial: Partial<ChatTranscriptRow> & { id: string }): ChatTranscriptRow {
   return { text: "", time: "", timestamp: null, ...partial };
 }
+
+describe("answerAttribution", () => {
+  const answer: Pick<Moment, "role" | "text" | "runId" | "timestamp" | "streaming"> = {
+    role: "ship", text: "Done.", runId: "r1", timestamp: 200, streaming: false,
+  };
+  const generation = (timestamp: number, model: string, runId = "r1"): AnswerHistoryEntry => ({
+    runId, timestamp, metadata: { provider: { provider: "openai-codex", model } },
+  });
+  const fallback: AnswerHistoryEntry = {
+    runId: "r1", timestamp: 150,
+    metadata: {
+      provider: { provider: "deepseek", model: "deepseek-chat", responseModel: "deepseek-v3.2" },
+      fallback: {
+        used: true,
+        from: { provider: "openai-codex", model: "gpt-6-astra" },
+        to: { provider: "deepseek", model: "deepseek-chat" },
+        reason: "Upstream unavailable",
+      },
+    },
+  };
+
+  it("labels the actual response model and evidenced fallback instead of the requested Astra", () => {
+    expect(answerAttribution(answer, [generation(100, "gpt-6-astra"), fallback], 200)).toEqual({
+      model: "deepseek-v3.2", provider: "deepseek",
+      fallbacks: [{ from: "gpt-6-astra", to: "deepseek-chat", reason: "Upstream unavailable" }],
+      omittedFallbacks: 0,
+    });
+  });
+
+  it("prefers responseModel and uses the recorded request model only when absent", () => {
+    const request = generation(100, "gpt-6-astra");
+    expect(answerAttribution(answer, [request], 200)?.model).toBe("gpt-6-astra");
+    expect(answerAttribution(answer, [{ ...request, metadata: {
+      provider: { provider: "openai-codex", model: "gpt-6-astra", responseModel: "gpt-6-astra-2026-09" },
+    } }], 200)?.model).toBe("gpt-6-astra-2026-09");
+  });
+
+  it("keeps each reply in a mixed-model run tied to its own commit cutoff", () => {
+    const history = [fallback, generation(100, "gpt-6-astra")];
+    const early = answerAttribution({ ...answer, timestamp: 125 }, history, 200);
+    expect(early?.model).toBe("gpt-6-astra");
+    expect(early?.fallbacks).toEqual([]);
+    expect(answerAttribution(answer, history, 200)?.model).toBe("deepseek-v3.2");
+    expect(history[0]).toBe(fallback);
+  });
+
+  it("does not retag old replies after later generations or another run change model", () => {
+    expect(answerAttribution(answer, [
+      generation(100, "gpt-6-astra"),
+      generation(200, "gpt-5.6-sol", "r2"),
+      { ...fallback, timestamp: 300 },
+    ], 300)).toMatchObject({ model: "gpt-6-astra", fallbacks: [] });
+  });
+
+  it("does not borrow an older model when the latest generation lacks metadata", () => {
+    expect(answerAttribution(answer, [
+      generation(100, "gpt-6-astra"), { runId: "r1", timestamp: 150 },
+    ], 200)).toBeNull();
+    expect(answerAttribution(answer, [], 200)).toBeNull();
+  });
+
+  it("does not infer an answer model from fallback targets alone", () => {
+    expect(answerAttribution(answer, [{ ...fallback, metadata: { fallback: fallback.metadata?.fallback } }], 200))
+      .toMatchObject({ model: null, provider: null, fallbacks: [{ from: "gpt-6-astra", to: "deepseek-chat" }] });
+  });
+
+  it("requires a committed Ship reply with an attributable run and timestamp", () => {
+    for (const change of [
+      { role: "human" as const }, { role: "note" as const }, { text: " " },
+      { streaming: true }, { runId: null }, { timestamp: null },
+    ]) expect(answerAttribution({ ...answer, ...change }, [fallback], 200)).toBeNull();
+    expect(answerAttribution(answer, [{ ...fallback, timestamp: null }], 200)).toBeNull();
+  });
+
+  it("waits for a history snapshot covering the committed reply before using same-run metadata", () => {
+    const previous = generation(100, "gpt-6-astra");
+    expect(answerAttribution(answer, [previous], 125)).toBeNull();
+    expect(answerAttribution(answer, [previous, fallback], 200)?.model).toBe("deepseek-v3.2");
+  });
+
+  it("bounds fallback diagnostics and deduplicates repeated typed generation metadata", () => {
+    const history: AnswerHistoryEntry[] = Array.from({ length: 5 }, (_, index) => ({
+      runId: "r1", timestamp: 100 + index,
+      metadata: {
+        provider: { model: `model-${index + 1}` },
+        fallback: { used: true, from: { model: `model-${index}` }, to: { model: `model-${index + 1}` }, reason: "x".repeat(1_000_000) },
+      },
+    }));
+    history.push(history[4]);
+    const result = answerAttribution(answer, history, 200);
+    expect(result?.fallbacks.map(({ from, to }) => [from, to])).toEqual([
+      ["model-2", "model-3"], ["model-3", "model-4"], ["model-4", "model-5"],
+    ]);
+    expect(result?.omittedFallbacks).toBe(2);
+    expect(result?.fallbacks.every(({ reason }) => reason?.length === 240 && reason.endsWith("…"))).toBe(true);
+  });
+});
 
 describe("parsePromptInput", () => {
   it("sends a sentence to the ship", () => {

--- a/web/src/app/features/instrument/zen/zenModel.ts
+++ b/web/src/app/features/instrument/zen/zenModel.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ProcMessageMetadata } from "@humansandmachines/gsv/protocol";
 import type { ChatTranscriptRow, ChatTranscriptValue } from "../../chat/domain/transcript";
 
 /* ---------- the prompt line ---------- */
@@ -88,7 +89,52 @@ export type Moment = {
   activities: Activity[];
   /** The ship's working narration for this run: what it told itself, not what it sent. Folded by default. */
   narration: string;
+  attribution?: AnswerAttribution | null;
 };
+
+export type AnswerHistoryEntry = {
+  runId: string | null;
+  timestamp: number | null;
+  metadata?: ProcMessageMetadata;
+};
+
+export type AnswerAttribution = {
+  model: string | null;
+  provider: string | null;
+  fallbacks: Array<{ from: string; to: string; reason: string | null }>;
+  omittedFallbacks: number;
+};
+
+/** Attribute a committed answer to its generation, never to the process's current model setting. */
+export function answerAttribution(
+  moment: Pick<Moment, "role" | "text" | "runId" | "timestamp" | "streaming">,
+  history: readonly AnswerHistoryEntry[],
+  historyThrough: number,
+): AnswerAttribution | null {
+  if (moment.role !== "ship" || !moment.text.trim() || moment.streaming || !moment.runId || moment.timestamp === null) return null;
+  // Delivery can arrive before the refreshed Process history; an older generation is not evidence for that reply.
+  if (historyThrough < moment.timestamp) return null;
+  const cutoff = moment.timestamp;
+  const candidates = history.filter((entry): entry is AnswerHistoryEntry & { timestamp: number } => entry.runId === moment.runId
+    && entry.timestamp !== null && entry.timestamp <= cutoff)
+    .sort((left, right) => left.timestamp - right.timestamp);
+  const metadata = candidates.at(-1)?.metadata;
+  const model = metadata?.provider?.responseModel?.trim() || metadata?.provider?.model?.trim() || null;
+  const provider = metadata?.provider?.provider?.trim() || null;
+  const fallbacks = new Map<string, AnswerAttribution["fallbacks"][number]>();
+  for (const entry of candidates) {
+    const fallback = entry.metadata?.fallback;
+    if (!fallback?.used) continue;
+    const from = fallback.from?.model?.trim() || fallback.from?.provider?.trim() || "unknown model";
+    const to = fallback.to?.model?.trim() || fallback.to?.provider?.trim() || "unknown model";
+    const reason = fallback.reason?.slice(0, 241).replace(/\s+/g, " ").trim() || null;
+    const key = JSON.stringify([from, to]);
+    fallbacks.delete(key);
+    fallbacks.set(key, { from, to, reason: reason && reason.length > 240 ? `${reason.slice(0, 239)}…` : reason });
+  }
+  if (!model && fallbacks.size === 0) return null;
+  return { model, provider, fallbacks: [...fallbacks.values()].slice(-3), omittedFallbacks: Math.max(0, fallbacks.size - 3) };
+}
 
 const OUTPUT_LIMIT = 600;
 


### PR DESCRIPTION
Zen could say “answered by gpt-6-astra” when the completed reply actually came from a fallback provider, because its status used the process's configured model. Replies and the idle status now use retained provider metadata for the matching run and reply timestamp, preferring the actual response model. Evidenced fallback transitions appear beside the reply, with bounded diagnostic reasons.

Attribution waits until the loaded Process history covers the committed reply. Missing metadata leaves the model unspecified, and later generations or configuration changes cannot relabel an earlier answer. Existing fallback policy is unchanged.

This targets `feat/zen-fleet`, the branch serving the local Zen UI, and enables CI for PRs targeting that branch. The typed-history adaptation will also be applied to PR #298.

Validation: web typecheck, all 470 web tests (including nine new attribution regressions), production web build, repository lint, and `git diff --check` passed. The build retains the existing large-chunk advisory.
