### PR TITLE
stream context epoch archives

### DIFF
--- a/workers/gateway/src/process/history-compaction-memory.test.ts
+++ b/workers/gateway/src/process/history-compaction-memory.test.ts
@@ -1,0 +1,42 @@
+import { expect, it } from "vitest";
+import { initProcess, ROOT_IDENTITY, runInProcess, generationRun, processTestConfig, setHistoryPolicy, mockGeneration, terminalTestResponse, messageAction } from "./do-test-harness";
+
+it("compacts history containing retained multi-megabyte fallback metadata", async () => {
+  const pid = "large-fallback-metadata-compaction";
+  const runId = "large-fallback-metadata-run";
+  const stub = await initProcess(pid, ROOT_IDENTITY);
+  const result = await runInProcess(stub, async (process) => {
+    let summaries = 0;
+    process.sendSignal = async () => {};
+    mockGeneration(process, async () => terminalTestResponse([messageAction("done", "large-metadata-done")]), async () => {
+      summaries += 1;
+      return "Synthetic compacted summary.";
+    });
+    for (let index = 0; index < 438; index += 1) {
+      const metadata = index % 16 === 0 && index < 432 ? {
+        fallback: {
+          used: true,
+          from: { provider: "openai-codex", model: "gpt-6-astra" },
+          to: { provider: "gsv", model: "default" },
+          reason: `synthetic ${index}\n` + "x".repeat(734420),
+        },
+      } : undefined;
+      process.store.messages.appendMessage(index % 2 === 0 ? "assistant" : "user", `Synthetic message ${index} ` + "c".repeat(1730), { metadata });
+    }
+    process.store.messages.appendMessage("user", "Current synthetic input", { runId });
+    setHistoryPolicy(process);
+    process.runs.active = generationRun(runId, processTestConfig(pid, {
+      provider: "openai-codex", model: "gpt-6-astra", maxTokens: 8192, contextWindowTokens: 247424,
+    }));
+    await process.run.runTick(runId);
+    const epoch = process.store.epochs.listContextEpochs().find((entry: { state: string }) => entry.state === "closed");
+    if (!epoch?.archivePath) throw new Error("Compaction did not retain its context epoch archive");
+    const archived = await process.storage.head(epoch.archivePath.replace(/^\/+/, ""));
+    return { summaries, segments: process.store.history.listHistorySegments(), active: process.runs.active !== null, epochArchived: archived !== null };
+  });
+  expect(result.summaries).toBe(1);
+  expect(result.segments).toHaveLength(1);
+  expect(result.segments[0].toMessageId).toBeGreaterThan(200);
+  expect(result.active).toBe(false);
+  expect(result.epochArchived).toBe(true);
+});

--- a/workers/gateway/src/process/history-epoch-stream.test.ts
+++ b/workers/gateway/src/process/history-epoch-stream.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { JsonObject } from "@humansandmachines/gsv/protocol";
+import { gzipContextEpochArchive, serializeArchivedMessage } from "./history/helpers";
+import type { MessageRecord } from "./store";
+import type { ArchivedMediaRewrite } from "./internal/lifecycle";
+
+const header = { schemaVersion: 1, installationId: "synthetic", process: { pid: "process", uid: 0 } };
+const epoch = { id: "epoch", systemPrompt: "Synthetic \"quoted\" context\nline", observedProjection: null };
+const message: MessageRecord = {
+  id: 1, generation: 1, runId: "run", role: "assistant", content: "Original text \"quoted\"\nline",
+  toolCalls: null, toolCallId: null, media: null, origin: null, createdAt: 1,
+  metadata: JSON.stringify({ fallback: { used: true, from: { provider: "openai-codex", model: "gpt-6-astra" }, to: { provider: "gsv", model: "default" }, reason: "synthetic error\n".repeat(80000) } }),
+  records: [{ kind: "note", payload: { text: "Original text", thinking: [] } }],
+};
+
+async function decompress(stream: ReadableStream<Uint8Array>): Promise<string> {
+  return await new Response(stream.pipeThrough(new DecompressionStream("gzip"))).text();
+}
+
+describe("context epoch archive streaming", () => {
+  it.each([false, true])("preserves exact uncompressed archive bytes with records=%s", async (includeRecords) => {
+    const messages = includeRecords ? [message, { ...message, id: 2 }] : [];
+    const runBoundaries: JsonObject[] = includeRecords ? [{ runId: "run", status: "completed" }] : [];
+    const expected = JSON.stringify({ ...header, epoch: { ...epoch, processActivity: messages.map(item => serializeArchivedMessage(item)), runBoundaries } });
+    const actual = await decompress(gzipContextEpochArchive({ header, epoch, messages, runBoundaries, mediaRewrites: new Map() }));
+    expect(actual).toBe(expected);
+  });
+
+  it("propagates cancellation before serializing retained metadata", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("synthetic cancellation"));
+    const stream = gzipContextEpochArchive({ header, epoch, messages: [message], runBoundaries: [], mediaRewrites: new Map(), signal: controller.signal });
+    await expect(decompress(stream)).rejects.toThrow("synthetic cancellation");
+  });
+
+  it("preserves media rewrites in compatibility and typed archive records", async () => {
+    const media = { type: "image" as const, mimeType: "image/png", key: "original", path: "/original" };
+    const withMedia: MessageRecord = {
+      ...message,
+      metadata: null,
+      media: JSON.stringify([media]),
+      records: [{ kind: "note", payload: { text: "Image", thinking: [], media: [media] } }],
+    };
+    const mediaRewrites = new Map<string, ArchivedMediaRewrite>([
+      ["original", { key: "archive/image", path: "/archive/image", revision: "immutable-revision" }],
+    ]);
+    const expected = JSON.stringify({ ...header, epoch: { ...epoch, processActivity: [serializeArchivedMessage(withMedia, mediaRewrites)], runBoundaries: [] } });
+    const actual = await decompress(gzipContextEpochArchive({ header, epoch, messages: [withMedia], runBoundaries: [], mediaRewrites }));
+    expect(actual).toBe(expected);
+  });
+
+});

--- a/workers/gateway/src/process/history/helpers.ts
+++ b/workers/gateway/src/process/history/helpers.ts
@@ -363,6 +363,44 @@ export function gzipMessageRecords(
   }).pipeThrough(new CompressionStream("gzip"));
 }
 
+export function gzipContextEpochArchive(input: {
+  header: JsonObject;
+  epoch: JsonObject;
+  messages: MessageRecord[];
+  runBoundaries: JsonObject[];
+  signal?: AbortSignal;
+  mediaRewrites: ReadonlyMap<string, ArchivedMediaRewrite>;
+}): ReadableStream<Uint8Array> {
+  function* chunks(): Generator<string, void> {
+    yield `${JSON.stringify(input.header).slice(0, -1)},"epoch":${JSON.stringify(input.epoch).slice(0, -1)},"processActivity":[`;
+    for (let index = 0; index < input.messages.length; index += 1) {
+      yield `${index > 0 ? "," : ""}${JSON.stringify(serializeArchivedMessage(input.messages[index]!, input.mediaRewrites))}`;
+    }
+    yield '],"runBoundaries":[';
+    for (let index = 0; index < input.runBoundaries.length; index += 1) {
+      yield `${index > 0 ? "," : ""}${JSON.stringify(input.runBoundaries[index])}`;
+    }
+    yield "]}}";
+  }
+  const parts = chunks();
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (input.signal?.aborted) {
+        parts.return();
+        controller.error(input.signal.reason ?? new Error("Context epoch archive cancelled"));
+        return;
+      }
+      const next = parts.next();
+      if (next.done) controller.close();
+      else controller.enqueue(encoder.encode(next.value));
+    },
+    cancel() {
+      parts.return();
+    },
+  }).pipeThrough(new CompressionStream("gzip"));
+}
+
 export async function gunzip(input: ArrayBuffer): Promise<string> {
   const stream = new Blob([input])
     .stream()

--- a/workers/gateway/src/process/history/runtime.ts
+++ b/workers/gateway/src/process/history/runtime.ts
@@ -12,8 +12,8 @@ import {
 } from "@humansandmachines/gsv/protocol";
 import type { Process } from "../do";
 import {
-  defaultHistoryPolicy, serializeInteractionOrigin, emptyProcessArchive, gunzip, gzipMessageRecords,
-  historyArchiveFilename, parseArchivedMessageRecord, serializeArchivedMessage, buildCompactionSummaryContext,
+  defaultHistoryPolicy, serializeInteractionOrigin, emptyProcessArchive, gunzip, gzipMessageRecords, gzipContextEpochArchive,
+  historyArchiveFilename, parseArchivedMessageRecord, buildCompactionSummaryContext,
   formatCompactionSummaryMessage, contextBoundaryRemainingTokens, contextRunwayAlertThreshold,
   isCompactionSummaryMessage, messageSnapshotsMatch, parseInteractionOrigin,
 } from "./helpers";
@@ -843,7 +843,7 @@ export class ProcessHistory {
       ? [...snapshot.runBoundaries]
       : this.host.store.epochs.listContextEpochRuns(epoch.id);
     if (snapshot?.closingBoundary) runBoundaries.push(snapshot.closingBoundary);
-    const manifest = jsonObjectSchema.parse({
+    const header = jsonObjectSchema.parse({
       schemaVersion: 1,
       installationId: this.host.installationId,
       process: {
@@ -852,31 +852,29 @@ export class ProcessHistory {
         gid: this.host.identity.gid,
         username: this.host.identity.username,
       },
-      epoch: {
-        id: epoch.id,
-        generation: epoch.generation,
-        state: "closed",
-        createdAt: epoch.createdAt,
-        closedAt,
-        closeReason: reason,
-        systemPrompt: epoch.systemPrompt,
-        r12yRevision: epoch.r12yRevision,
-        r12yCount: epoch.r12yCount,
-        observedR12yRevision: epoch.observedR12yRevision,
-        r12yBaseline: epoch.r12yBaseline,
-        r12yTransitions:
-          snapshot?.transitions ?? this.host.store.epochs.listContextEpochTransitions(epoch.id),
-        sourceManifest: epoch.sourceManifest,
-        observedProjection: epoch.observedProjection,
-        processActivity: messages.map((message) =>
-          serializeArchivedMessage(message, mediaRewrites),
-        ),
-        runBoundaries,
-      },
+    });
+    const epochHeader = jsonObjectSchema.parse({
+      id: epoch.id,
+      generation: epoch.generation,
+      state: "closed",
+      createdAt: epoch.createdAt,
+      closedAt,
+      closeReason: reason,
+      systemPrompt: epoch.systemPrompt,
+      r12yRevision: epoch.r12yRevision,
+      r12yCount: epoch.r12yCount,
+      observedR12yRevision: epoch.observedR12yRevision,
+      r12yBaseline: epoch.r12yBaseline,
+      r12yTransitions:
+        snapshot?.transitions ?? this.host.store.epochs.listContextEpochTransitions(epoch.id),
+      sourceManifest: epoch.sourceManifest,
+      observedProjection: epoch.observedProjection,
     });
     const compressed = await raceWithAbort(
       new Response(
-        new Blob([JSON.stringify(manifest)]).stream().pipeThrough(new CompressionStream("gzip")),
+        gzipContextEpochArchive({
+          header, epoch: epochHeader, messages, runBoundaries, signal, mediaRewrites,
+        }),
       ).arrayBuffer(),
       signal,
     );


### PR DESCRIPTION
Automatic compaction can exhaust a Durable Object isolate when retained provider-error metadata makes history much larger than its model-visible text. Context-epoch archival currently builds the complete activity array, clones its manifest, serializes the whole document, and then copies it into a Blob before compression.

Stream the same epoch JSON into gzip one activity record and run boundary at a time. Preserve exact uncompressed archive bytes, historical metadata, media rewrites, snapshot checks, and storage cleanup. No stored history migration or deletion is required.

Validation:
- 54 focused tests across six files passed, including automatic compaction of 439 rows with about 19.8 MB of fallback metadata, exact archive-byte equality, empty activity/boundary arrays, media rewrites, pre-aborted streams, and existing epoch/compaction/kill lifecycle cases.
- Gateway TypeScript and focused lint passed.
- With the same synthetic fixture, local Workerd inspector peak heap decreased from 303,145,208 to 268,812,272 bytes. Growth above the matched seeded-history plateau decreased from 117,098,720 to 82,792,168 bytes. These figures include Vitest overhead and are comparative measurements, not a production memory-cap guarantee.

A separate mid-stream-abort diagnostic observed correctly handled reader rejection plus extra runtime unhandled-rejection reports with both this helper and the existing shipped gzipMessageRecords pipeline. It is not included in the passing test count; this change preserves the existing compression pipeline and does not suppress runtime errors.
