### PR TITLE
bound retained fallback diagnostics

### DIFF
--- a/docs/architecture/agent-loop.md
+++ b/docs/architecture/agent-loop.md
@@ -158,6 +158,13 @@ for shell and low-level callers.
 The process calls the configured generation service with `sessionAffinityKey`
 set to the PID.
 
+After classifying a generation failure and selecting a fallback, the Process
+limits the new fallback diagnostic to 4,096 characters (UTF-16 code units),
+including a truncation marker that records the original length. The same preview
+is announced and retained as `metadata.fallback.reason`; provider and model
+identifiers remain separate fields. Classification uses the original error.
+Existing history and imported diagnostics retain their full stored values.
+
 The model response can contain text, thinking blocks, and tool calls:
 
 - Text, reasoning, and tool-call blocks are raw Process activity. They are emitted

--- a/workers/gateway/src/inference/errors.test.ts
+++ b/workers/gateway/src/inference/errors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   errorMessageFromUnknown,
+  formatProviderErrorDiagnostic,
   formatProviderErrorMessage,
   formatProviderContextOverflowMessage,
   isProviderContextOverflow,
@@ -8,6 +9,29 @@ import {
   NON_STANDARD_PROVIDER_ERROR,
 } from "./errors";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
+
+describe("formatProviderErrorDiagnostic", () => {
+  it("preserves diagnostics through the 4096-character limit", () => {
+    for (const message of ["", "HTTP 403: invalid account", "x".repeat(4096)]) {
+      expect(formatProviderErrorDiagnostic(message)).toBe(message);
+    }
+  });
+
+  it("bounds oversized diagnostics while retaining their category and original length", () => {
+    const message = "Provider validation failed: " + "x".repeat(1_200_000);
+    const diagnostic = formatProviderErrorDiagnostic(message);
+    expect(diagnostic.length).toBeLessThanOrEqual(4096);
+    expect(diagnostic.startsWith("Provider validation failed: ")).toBe(true);
+    expect(diagnostic.endsWith(`[truncated; original length ${message.length} characters]`)).toBe(true);
+  });
+
+  it("does not split a Unicode surrogate pair at the preview boundary", () => {
+    const message = "😀".repeat(10_000);
+    const diagnostic = formatProviderErrorDiagnostic(message);
+    expect(diagnostic.length).toBeLessThanOrEqual(4096);
+    expect(diagnostic.isWellFormed()).toBe(true);
+  });
+});
 
 describe("formatProviderErrorMessage", () => {
   it("adds account guidance for billing and credit failures", () => {

--- a/workers/gateway/src/inference/errors.ts
+++ b/workers/gateway/src/inference/errors.ts
@@ -12,6 +12,17 @@ export type ProviderErrorContext = {
 export const NON_STANDARD_PROVIDER_ERROR =
   "Provider returned a non-standard error response.";
 
+/** New retained diagnostics are previews; classification must use the original error. */
+const MAX_PROVIDER_DIAGNOSTIC_CHARS = 4096;
+
+export function formatProviderErrorDiagnostic(message: string): string {
+  if (message.length <= MAX_PROVIDER_DIAGNOSTIC_CHARS) return message;
+  const suffix = `\n[truncated; original length ${message.length} characters]`;
+  const preview = message.slice(0, MAX_PROVIDER_DIAGNOSTIC_CHARS - suffix.length)
+    .replace(/[\uD800-\uDBFF]$/u, "");
+  return preview + suffix;
+}
+
 const BILLING_ERROR_PATTERN =
   /\b(?:http\s*402|error\s*code:\s*402|402|payment[\s_-]+required|insufficient[\s_-]+(?:funds|credits|balance|quota)|out[\s_-]+of[\s_-]+(?:credits?|quota)|no[\s_-]+(?:credits?|quota)|billing|payment|balance(?:[\s_-]+low)?|credits?|quota[\s_-]+exceeded|exceeded[\s_-]+quota)\b/i;
 const RATE_LIMIT_ERROR_PATTERN =

--- a/workers/gateway/src/process/history-fallback-diagnostics.test.ts
+++ b/workers/gateway/src/process/history-fallback-diagnostics.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AiConfigResult } from "@humansandmachines/gsv/protocol";
+import type { Process } from "./do";
+import {
+  assistantResponse, captureSignals, generationRun, initProcess, messageAction,
+  mockGeneration, processTestConfig, ROOT_IDENTITY, runInProcess,
+} from "./do-test-harness";
+import { parseMessageMetadata, stringifyMessageMetadata } from "./storage/metadata-codec";
+import { z } from "zod";
+
+const reason = "Provider validation failed: " + "x".repeat(1_200_000);
+
+describe("retained fallback diagnostics", () => {
+  it.each(["throw", "response"])("bounds a %s failure before announcement and persistence", async (failureMode) => {
+    const pid = `fallback-diagnostic-${failureMode}`;
+    const runId = `${pid}-run`;
+    const stub = await initProcess(pid, ROOT_IDENTITY);
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const observed = await runInProcess(stub, async (process: Process) => {
+        const emitted = captureSignals(process);
+        let calls = 0;
+        mockGeneration(process, async (request: { config: AiConfigResult }) => {
+          calls += 1;
+          if (calls === 1) {
+            if (failureMode === "throw") throw new Error(reason);
+            return assistantResponse([], { stopReason: "error", errorMessage: reason });
+          }
+          return assistantResponse([
+            { type: "text", text: "Fallback completed." },
+            messageAction("Fallback completed.", "fallback-diagnostic-send"),
+          ], { provider: request.config.provider, model: request.config.model });
+        }, async () => "unused");
+        process.store.messages.appendMessage("user", "Synthetic fallback check", { runId });
+        process.runs.active = generationRun(runId, processTestConfig(pid, {
+          provider: "openai-codex", model: "gpt-6-astra", apiKey: "synthetic-primary",
+          fallbacks: [{
+            modelId: "fallback", modelName: "Fallback", provider: "openrouter", model: "test/model",
+            apiKey: "synthetic-fallback", providerStyle: "openai-chat-completions", transportTarget: "gsv",
+            maxTokens: 4096, contextWindowTokens: 128000, contextWindowSource: "config",
+            generationTimeoutMs: 180000, generationStreaming: "auto",
+          }],
+        }));
+        await process.run.runTick(runId);
+        const assistant = process.store.messages.getMessages().find((message) => message.role === "assistant");
+        return {
+          calls, active: process.runs.active !== null,
+          metadata: parseMessageMetadata(assistant?.metadata),
+          retry: emitted.find((entry) => entry.signal === "proc.run.retrying")?.payload,
+        };
+      });
+      const fallback = observed.metadata?.fallback;
+      expect(fallback?.reason?.length).toBeLessThanOrEqual(4096);
+      expect(fallback).toMatchObject({
+        used: true,
+        from: { provider: "openai-codex", model: "gpt-6-astra" },
+        to: { provider: "openrouter", model: "test/model" },
+      });
+      expect(fallback?.reason?.startsWith("Provider validation failed: ")).toBe(true);
+      expect(fallback?.reason?.endsWith(`[truncated; original length ${reason.length} characters]`)).toBe(true);
+      expect(z.object({ reason: z.string() }).parse(observed.retry).reason).toBe(fallback?.reason);
+      expect(observed.calls).toBe(2);
+      expect(observed.active).toBe(false);
+      expect(warning.mock.calls.some((args) => args.some((value) => String(value).length > 4300))).toBe(false);
+    } finally {
+      warning.mockRestore();
+    }
+  });
+
+  it("preserves full existing diagnostics through metadata read and import serialization", () => {
+    const raw = JSON.stringify({ fallback: {
+      used: true, from: { provider: "old-provider", model: "old-model" }, reason,
+    } });
+    expect(parseMessageMetadata(raw)?.fallback?.reason).toBe(reason);
+    expect(parseMessageMetadata(stringifyMessageMetadata(raw))?.fallback?.reason).toBe(reason);
+  });
+});

--- a/workers/gateway/src/process/run/runtime.ts
+++ b/workers/gateway/src/process/run/runtime.ts
@@ -25,7 +25,7 @@ import { readPathKey } from "../tools/runtime";
 import type { FileResourceReference, FsReadArgs, FsReadResult, ResourceBlock } from "@humansandmachines/gsv/protocol";
 import type { RunOutputMedia, RunState } from "./state";
 import {
-  errorMessageFromUnknown, isProviderContextOverflow, isProviderContextOverflowErrorMessage,
+  errorMessageFromUnknown, formatProviderErrorDiagnostic, isProviderContextOverflow, isProviderContextOverflowErrorMessage,
 } from "../../inference/errors";
 import { sendFrameToKernel, cancelProcessRequests } from "../../shared/utils";
 import {
@@ -1259,9 +1259,10 @@ export class ProcessRun {
     if (!fallback) return "none";
     control.fallbackIndex = fallback.nextIndex;
     if (failedResponse) this.recordUnpersistedAssistantUsage(failedResponse, current);
+    const diagnosticReason = formatProviderErrorDiagnostic(reason);
     const fallbackState = await this.beginGenerationFallback({
       runId,
-      reason,
+      reason: diagnosticReason,
       from: current,
       to: fallback.config,
       fallbackIndex: control.fallbackIndex,
@@ -1272,7 +1273,7 @@ export class ProcessRun {
       used: true,
       from: modelMetadataFromAiConfig(current),
       to: modelMetadataFromAiConfig(fallback.config),
-      reason,
+      reason: diagnosticReason,
     };
     control.prepared.activeConfig = fallback.config;
     const run = this.host.mutateActiveRun(runId, (active) => ({


### PR DESCRIPTION
Oversized provider errors were copied in full into fallback announcements and assistant history metadata. Repeated failures could inflate retained Process history and its archive working set.

Bound each new fallback diagnostic to 4,096 characters, including an explicit original-length truncation marker. Apply the bound after classification and fallback selection, then reuse that value for the warning, retry signal, and `metadata.fallback.reason`. Keep provider/model identifiers separate and preserve existing history and imported diagnostics unchanged.

Validation: both real Process regressions failed before the fix with oversized thrown/returned errors; all 296 focused provider-error and Process tests now pass. Coverage includes short diagnostics, Unicode boundaries, announcement/persistence parity, unchanged fallback completion, and full legacy metadata round trips. Gateway typecheck, targeted lint, and diff checks pass. Independent source review found no issues.
