### PR TITLE
connect memory and restore chronological working

### DIFF
--- a/web/src/app/features/chat/domain/transcript.test.ts
+++ b/web/src/app/features/chat/domain/transcript.test.ts
@@ -63,6 +63,19 @@ function history(messages: HistoryFixture[]): ChatHistory {
 }
 
 describe("chat transcript rows", () => {
+  it("retains the owning process for work before a canonical reply exists", () => {
+    const record = procHistoryRecordSchema.parse({
+      kind: "call", payload: { runId: "run-working", callId: "read", tool: "Read", syscall: "fs.read", target: "gsv", args: { path: "/note.md" } },
+      id: 1, messageId: 1, index: 0, runId: "run-working", generation: 1, createdAt: 1, source: "typed",
+    });
+    const original = { ...history([]), pid: "original-process", records: [record] };
+    const replacement = { ...original, pid: "replacement-process" };
+
+    expect(transcriptRowsFromHistory(original)[0]).toMatchObject({ processId: "original-process", toolCallId: "read" });
+    expect(transcriptRowsFromHistory(replacement)[0]).toMatchObject({ processId: "replacement-process", toolCallId: "read" });
+    expect(transcriptRowsFromHistory(original)[0].processId).toBe("original-process");
+  });
+
   it("does not downgrade a live directed Message during history synchronization", () => {
     const current = {
       id: "conversation:msg-one",

--- a/web/src/app/features/chat/domain/transcript.ts
+++ b/web/src/app/features/chat/domain/transcript.ts
@@ -102,9 +102,12 @@ export type ChatTranscriptRow = {
   processId?: string;
   delivery?: "directed" | "sync";
   conversationSequence?: number;
+  conversationMessageId?: string;
   origin?: InteractionOrigin;
   toolArgs?: ChatTranscriptValue;
   toolCallId?: string;
+  toolStartedAt?: number | null;
+  toolCallRecordKey?: string;
   toolName?: string;
   toolOutcome?: ChatToolOutcome;
   toolOutput?: ChatTranscriptValue;

--- a/web/src/app/features/chat/domain/transcript.ts
+++ b/web/src/app/features/chat/domain/transcript.ts
@@ -398,7 +398,7 @@ export function applyChatSignal(
  *  Fail-safe: anything unmatched renders as a neutral informational row —
  *  a new gateway error format degrades to neutral, never to a false red. */
 export function transcriptRowsFromHistory(history: ChatHistory): ChatTranscriptRow[] {
-  return transcriptRowsFromRecords(history.records);
+  return transcriptRowsFromRecords(history.records).map((row) => ({ ...row, processId: history.pid }));
 }
 
 function isToolActivityRow(row: Pick<ChatTranscriptRow, "role">): boolean {

--- a/web/src/app/features/chat/domain/transcriptMerge.ts
+++ b/web/src/app/features/chat/domain/transcriptMerge.ts
@@ -204,7 +204,22 @@ export function mergeTranscriptRows(
     }
     const current = merged.get(key);
     if (current && shouldKeepCurrentToolRow(current, row)) {
-      merged.set(key, { ...current, toolArgs: row.toolArgs ?? current.toolArgs, toolSyscall: row.toolSyscall ?? current.toolSyscall, toolTarget: row.toolTarget ?? current.toolTarget, toolRunControl: row.toolRunControl ?? current.toolRunControl });
+      merged.set(key, { ...current, toolArgs: row.toolArgs ?? current.toolArgs, toolSyscall: row.toolSyscall ?? current.toolSyscall, toolTarget: row.toolTarget ?? current.toolTarget, toolRunControl: row.toolRunControl ?? current.toolRunControl,
+        toolStartedAt: row.toolStartedAt ?? current.toolStartedAt,
+        toolCallRecordKey: row.toolCallRecordKey ?? current.toolCallRecordKey,
+      });
+      continue;
+    }
+    if (current && isToolActivityRow(current) && isToolActivityRow(row)) {
+      merged.set(key, { ...row,
+        processId: row.processId ?? current.processId,
+        toolArgs: row.toolArgs ?? current.toolArgs,
+        toolSyscall: row.toolSyscall ?? current.toolSyscall,
+        toolTarget: row.toolTarget ?? current.toolTarget,
+        toolRunControl: row.toolRunControl || current.toolRunControl,
+        toolStartedAt: row.toolStartedAt ?? current.toolStartedAt ?? (current.role === "tool" ? current.timestamp : undefined),
+        toolCallRecordKey: row.toolCallRecordKey ?? current.toolCallRecordKey,
+      });
       continue;
     }
     merged.set(key, row);

--- a/web/src/app/features/chat/domain/typedHistory.test.ts
+++ b/web/src/app/features/chat/domain/typedHistory.test.ts
@@ -2,10 +2,56 @@ import { describe, expect, it } from "vitest";
 import { procHistoryRecordSchema, procHistoryArchivedRecordSchema } from "@humansandmachines/gsv/protocol";
 import { mergeTranscriptRows } from "./transcriptMerge";
 import { transcriptRowsFromRecords } from "./typedHistory";
-import { momentsFromConversation, activitiesForRows, receiptTargets } from "../../instrument/zen/zenModel";
+import { momentsFromConversation, activitiesForRows, receiptTargets, placesUsed } from "../../instrument/zen/zenModel";
 
 const identity = { id: 1, messageId: 1, index: 0, runId: "r", generation: 1, createdAt: 1, source: "typed" };
 describe("typed history projection", () => {
+  it.each(["completed", "failed"] as const)("retains %s CodeMode output without inventing a target", (outcome) => {
+    const code = 'console.log("started"); return 0;';
+    const output = outcome === "completed"
+      ? { status: "completed", result: 0, logs: ["started"] }
+      : { status: "failed", error: "script failed", logs: ["started"] };
+    const call = procHistoryRecordSchema.parse({ ...identity, kind: "call", payload: {
+      runId: "r", callId: "code", tool: "CodeMode", syscall: "codemode.exec", target: null,
+      args: { code, target: "laptop" },
+    } });
+    const result = procHistoryRecordSchema.parse({ ...identity, id: 2, messageId: 2, createdAt: 2, kind: "result", payload: {
+      callId: "code", tool: "CodeMode", outcome, output, media: [], resources: [],
+    } });
+    const running = transcriptRowsFromRecords([call]);
+    const delta = mergeTranscriptRows(running, transcriptRowsFromRecords([result]));
+    const reload = transcriptRowsFromRecords([call, result]);
+    const unlinked = transcriptRowsFromRecords([result]);
+    for (const rows of [delta, reload, unlinked]) {
+      const moment = momentsFromConversation([], rows, null)[0];
+      expect(moment.activities).toEqual([expect.objectContaining({ target: null })]);
+      expect(moment.activities[0].calls[0]).toMatchObject({
+        syscall: "codemode.exec", finished: true, failed: outcome === "failed",
+        output: outcome === "completed" ? "started\n0" : "started\nscript failed",
+        summary: rows === unlinked ? "" : code,
+      });
+      expect(receiptTargets(moment)).toEqual([]);
+      expect(placesUsed(moment)).toBe(0);
+    }
+    expect(activitiesForRows(running, "r", true)[0]).toMatchObject({ target: null, live: true });
+  });
+
+  it("keeps process working separate from a real target named null", () => {
+    const rows = transcriptRowsFromRecords([
+      procHistoryRecordSchema.parse({ ...identity, kind: "call", payload: {
+        runId: "r", callId: "code", tool: "CodeMode", syscall: "codemode.run", target: null, args: { code: "return 1;", target: "null" },
+      } }),
+      procHistoryRecordSchema.parse({ ...identity, id: 2, messageId: 2, kind: "call", payload: {
+        runId: "r", callId: "read", tool: "Read", syscall: "fs.read", target: "null", args: { path: "/x" },
+      } }),
+    ]);
+    const moment = momentsFromConversation([], rows, "r")[0];
+    expect(moment.activities.map((activity) => activity.target)).toEqual([null, "null"]);
+    expect(new Set(moment.activities.map((activity) => activity.key)).size).toBe(2);
+    expect(receiptTargets(moment)).toEqual([{ target: "null", live: true, failed: false }]);
+    expect(placesUsed(moment)).toBe(1);
+  });
+
   it("retains a call's start and a sent message's identity when the result arrives after sending", () => {
     const call = procHistoryRecordSchema.parse({ ...identity, createdAt: 10, kind: "call", payload: {
       runId: "r", callId: "read", tool: "Read", syscall: "fs.read", target: "gsv", args: { path: "/note.md" },

--- a/web/src/app/features/chat/domain/typedHistory.test.ts
+++ b/web/src/app/features/chat/domain/typedHistory.test.ts
@@ -2,10 +2,36 @@ import { describe, expect, it } from "vitest";
 import { procHistoryRecordSchema, procHistoryArchivedRecordSchema } from "@humansandmachines/gsv/protocol";
 import { mergeTranscriptRows } from "./transcriptMerge";
 import { transcriptRowsFromRecords } from "./typedHistory";
-import { momentsFromConversation, activitiesForRows, receiptPhrases } from "../../instrument/zen/zenModel";
+import { momentsFromConversation, activitiesForRows, receiptTargets } from "../../instrument/zen/zenModel";
 
 const identity = { id: 1, messageId: 1, index: 0, runId: "r", generation: 1, createdAt: 1, source: "typed" };
 describe("typed history projection", () => {
+  it("retains a call's start and a sent message's identity when the result arrives after sending", () => {
+    const call = procHistoryRecordSchema.parse({ ...identity, createdAt: 10, kind: "call", payload: {
+      runId: "r", callId: "read", tool: "Read", syscall: "fs.read", target: "gsv", args: { path: "/note.md" },
+    } });
+    const sent = procHistoryRecordSchema.parse({ ...identity, id: 2, messageId: 2, createdAt: 10, kind: "message", payload: {
+      direction: "out", conversationMessageId: "sent-one", text: "An update", media: [], origin: {},
+    } });
+    const result = procHistoryRecordSchema.parse({ ...identity, id: 3, messageId: 3, createdAt: 20, kind: "result", payload: {
+      callId: "read", tool: "Read", outcome: "completed", output: "Read output", media: [], resources: [],
+    } });
+    const started = transcriptRowsFromRecords([call]).map((row) => ({ ...row, processId: "original", status: "running" as const }));
+    const delta = mergeTranscriptRows(started, transcriptRowsFromRecords([sent, result]));
+    const reloaded = transcriptRowsFromRecords([call, sent, result]);
+
+    for (const rows of [delta, reloaded]) {
+      expect(rows.find((row) => row.role === "toolResult")).toMatchObject({
+        toolStartedAt: 10, toolCallRecordKey: "1:0", timestamp: 20,
+        toolSyscall: "fs.read", toolTarget: "gsv", toolArgs: { path: "/note.md" },
+      });
+      expect(rows.find((row) => row.messageDirection === "out")).toMatchObject({
+        conversationMessageId: "sent-one", historyRecordKey: "2:0", timestamp: 10,
+      });
+    }
+    expect(delta.find((row) => row.role === "toolResult")?.processId).toBe("original");
+  });
+
   it.each(["live", "archive"])("hides redacted thinking in %s notes without changing retained content", (source) => {
     const schema = source === "live" ? procHistoryRecordSchema : procHistoryArchivedRecordSchema;
     const hidden = { type: "thinking", thinking: "opaque provider redaction", redacted: true, thinkingSignature: "hidden-signature" };
@@ -104,7 +130,7 @@ describe("typed history projection", () => {
       const moments = momentsFromConversation([], rows, null);
       expect(moments).toHaveLength(1);
       expect(moments[0].activities[0].calls).toEqual([expect.objectContaining({ output: output.error, finished: true, failed: true })]);
-      expect(receiptPhrases(moments[0])).toEqual([{ verb: "read", what: path, count: 1, noun: "files", failed: true }]);
+      expect(receiptTargets(moments[0])).toEqual([{ target: "gsv", live: false, failed: true }]);
     }
   });
 
@@ -127,7 +153,7 @@ describe("typed history projection", () => {
       const moments = momentsFromConversation([], rows, null);
       expect(moments).toHaveLength(1);
       expect(moments[0].activities[0].calls).toEqual([expect.objectContaining({ output: content, finished: true, failed: false })]);
-      expect(receiptPhrases(moments[0])).toEqual([{ verb: "read", what: path, count: 1, noun: "files", failed: false }]);
+      expect(receiptTargets(moments[0])).toEqual([{ target: "gsv", live: false, failed: false }]);
     }
   });
 

--- a/web/src/app/features/chat/domain/typedHistory.ts
+++ b/web/src/app/features/chat/domain/typedHistory.ts
@@ -74,6 +74,7 @@ export function transcriptRowsFromRecords(records: readonly (ProcHistoryRecord |
           text: record.payload.text, media: record.payload.media,
           origin: record.payload.origin.interaction,
           messageDirection: record.payload.direction,
+          conversationMessageId: record.payload.conversationMessageId,
         });
         break;
       case "note": {
@@ -90,6 +91,7 @@ export function transcriptRowsFromRecords(records: readonly (ProcHistoryRecord |
           ...base, id: `tool:${record.runId ?? ""}:${record.payload.callId}`, role: "tool",
           text: displayValue(record.payload.args), toolArgs: record.payload.args,
           toolCallId: record.payload.callId, toolName: record.payload.tool,
+          toolStartedAt: record.createdAt ?? null, toolCallRecordKey: historyRecordKey(record),
           toolSyscall: record.payload.syscall, toolTarget: record.payload.target,
           toolRunControl: isRunControlCall(record.payload),
           status: "planning", meta: record.payload.syscall ?? undefined,
@@ -102,6 +104,8 @@ export function transcriptRowsFromRecords(records: readonly (ProcHistoryRecord |
           ...base, id: record.payload.callId === null ? base.id : `tool:${record.runId ?? ""}:${record.payload.callId}`, role: "toolResult",
           text: record.payload.error?.message ?? displayValue(record.payload.output),
           toolCallId: record.payload.callId ?? undefined, toolName: record.payload.tool,
+          toolStartedAt: call ? call.createdAt ?? null : undefined,
+          toolCallRecordKey: call ? historyRecordKey(call) : undefined,
           toolOutput: record.payload.output, toolOutcome: record.payload.outcome,
           toolArgs: call?.payload.args, toolSyscall: call?.payload.syscall ?? null,
           toolTarget: call?.payload.target ?? null,

--- a/web/src/app/features/gsv-console/library/libraryService.test.ts
+++ b/web/src/app/features/gsv-console/library/libraryService.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GSVClient } from "@humansandmachines/gsv/client";
+import type { RepoReadResult } from "@humansandmachines/gsv/protocol";
+import { saveLibraryPage } from "./libraryService";
+
+function file(path: string, content: string | null, isBinary = false): RepoReadResult {
+  return { repo: "agent/knowledge", ref: "HEAD", path, kind: "file", size: content?.length ?? 4, content, isBinary };
+}
+
+function saveClient(index: RepoReadResult | Error) {
+  const client = { call: vi.fn<GSVClient["call"]>(), request: vi.fn<GSVClient["request"]>() };
+  client.call.mockResolvedValueOnce({ repos: [
+    { repo: "agent/knowledge", owner: "agent", name: "knowledge", kind: "user", writable: true, public: false },
+  ] });
+  client.call.mockResolvedValueOnce(file("wiki.json", JSON.stringify({ kind: "gsv.wiki", id: "personal", title: "Personal" })));
+  if (index instanceof Error) client.call.mockRejectedValueOnce(index);
+  else client.call.mockResolvedValueOnce(index);
+  return client;
+}
+
+describe("library page saving", () => {
+  it("saves an explicit overview edit without automatic index changes", async () => {
+    const client = saveClient(file("index.md", "Unused"));
+    const markdown = "# Updated overview\n\nAuthored text.\n";
+
+    await saveLibraryPage(client, { db: "personal", path: "index.md", markdown });
+
+    expect(client.call.mock.calls.map(([call]) => call)).toEqual(["repo.list", "repo.read", "repo.apply"]);
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", {
+      repo: "agent/knowledge",
+      message: "wiki: update personal/index.md",
+      ops: [{ type: "put", path: "index.md", content: markdown }],
+    });
+  });
+
+  it("edits the selected repository page without rewriting its authored overview", async () => {
+    const index = "---\nowner: person\n---\n# My memory\n\nAn authored introduction.\n\n## Pages\n\n- pages/example.md\n\n## Decisions\n\nKeep this paragraph and [link](https://example.test).\n\n### Detail\n\n| One | Two |\n| --- | --- |\n| a | b |\n";
+    const client = saveClient(file("index.md", index));
+
+    expect(await saveLibraryPage(client, {
+      db: "personal", path: "personal/pages/example.md", markdown: "# Corrected\n\nUpdated page.\n",
+    })).toEqual({ db: "personal", openPath: "personal/pages/example.md", statusText: "Saved personal/pages/example.md" });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", {
+      repo: "agent/knowledge",
+      message: "wiki: update personal/pages/example.md",
+      ops: [{ type: "put", path: "pages/example.md", content: "# Corrected\n\nUpdated page.\n" }],
+    });
+  });
+
+  it("adds a missing page entry while retaining every authored byte and CRLF", async () => {
+    const before = "---\r\nowner: person\r\n---\r\n# Memory\r\n\r\n## Pages\r\n\r\n- pages/old.md\r\n\r\n";
+    const after = "## Decisions\r\n\r\nKeep this.\r\n";
+    const client = saveClient(file("index.md", before + after));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/new.md", content: "New page." },
+        { type: "put", path: "index.md", content: `${before}- pages/new.md\r\n\r\n${after}` },
+      ],
+    }));
+  });
+
+  it("adds a Pages section to an authored overview that has none", async () => {
+    const index = "# Memory\n\n## Decisions\n\nKeep this verbatim.";
+    const client = saveClient(file("index.md", index));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/new.md", content: "New page." },
+        { type: "put", path: "index.md", content: `${index}\n\n## Pages\n\n- pages/new.md\n` },
+      ],
+    }));
+  });
+
+  it("creates an absent index with its first page instead of retaining the empty placeholder", async () => {
+    const client = saveClient(new Error("Path not found: index.md"));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/new.md", content: "New page." },
+        { type: "put", path: "index.md", content: "# Personal\n\n## Pages\n\n- pages/new.md\n" },
+      ],
+    }));
+  });
+
+  it("replaces only the generated empty placeholder inside an authored overview", async () => {
+    const before = "# Memory\r\n\r\nAn introduction.\r\n\r\n## Pages\r\n\r\n";
+    const after = "\r\n\r\n## Decisions\r\n\r\nKeep this.\r\n";
+    const client = saveClient(file("index.md", before + "- _No pages yet._" + after));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/first.md", markdown: "First page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/first.md", content: "First page." },
+        { type: "put", path: "index.md", content: before + "- pages/first.md" + after },
+      ],
+    }));
+  });
+
+  it.each(["```", "~~~~"])("preserves an authored %s code example containing Pages and the empty placeholder", async (fence) => {
+    const example = `# Reference\n\nExample template:\n\n${fence}md\n## Pages\n\n- _No pages yet._\n${fence}\n`;
+    const client = saveClient(file("index.md", example));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/new.md", content: "New page." },
+        { type: "put", path: "index.md", content: `${example}\n## Pages\n\n- pages/new.md\n` },
+      ],
+    }));
+  });
+
+  it("ignores frontmatter and code placeholders while selecting the real Pages section", async () => {
+    const prefix = "---\n## Pages\n- _No pages yet._\n---\n# Memory\n\n## Pages\n\n```md\n- _No pages yet._\n```\n\n";
+    const suffix = "## Decisions\n\nKeep this.\n";
+    const client = saveClient(file("index.md", prefix + suffix));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/new.md", content: "New page." },
+        { type: "put", path: "index.md", content: `${prefix}- pages/new.md\n\n${suffix}` },
+      ],
+    }));
+  });
+
+  it("does not mistake an indented or fenced example for an existing page entry", async () => {
+    const index = "# Memory\n\n    - pages/new.md\n\n```md\n- pages/new.md\n```\n";
+    const client = saveClient(file("index.md", index));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/new.md", content: "New page." },
+        { type: "put", path: "index.md", content: `${index}\n## Pages\n\n- pages/new.md\n` },
+      ],
+    }));
+  });
+
+  it.each([
+    "<!-- Hidden example\r\n## Pages\r\n\r\n- _No pages yet._\r\n-->\r\n",
+    "<pre>\r\n## Pages\r\n\r\n- _No pages yet._\r\n</pre>\r\n",
+    "<script>\r\n## Pages\r\n\r\n- _No pages yet._\r\n</script>\r\n",
+  ])("preserves raw HTML example bytes while appending a real index", async (example) => {
+    const index = `# Reference\r\n\r\n${example}`;
+    const client = saveClient(file("index.md", index));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/new.md", content: "New page." },
+        { type: "put", path: "index.md", content: `${index}\r\n## Pages\r\n\r\n- pages/new.md\r\n` },
+      ],
+    }));
+  });
+
+  it("keeps original offsets after tab-indented code and mixed line endings", async () => {
+    const prefix = "# Reference\r\n\r\n\t## Pages\r\n\t- _No pages yet._\r\n\r\n## Pages\n\n";
+    const suffix = "\r\n\r\n## Decisions\r\n\r\nKeep this.\r\n";
+    const client = saveClient(file("index.md", prefix + "- _No pages yet._" + suffix));
+
+    await saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." });
+
+    expect(client.call).toHaveBeenLastCalledWith("repo.apply", expect.objectContaining({
+      ops: [
+        { type: "put", path: "pages/new.md", content: "New page." },
+        { type: "put", path: "index.md", content: prefix + "- pages/new.md" + suffix },
+      ],
+    }));
+  });
+
+  it.each([
+    file("index.md", null, true),
+    { repo: "agent/knowledge", ref: "HEAD", path: "index.md", kind: "tree", entries: [] } satisfies RepoReadResult,
+  ])("does not overwrite a non-text overview while saving another page", async (index) => {
+    const client = saveClient(index);
+
+    await expect(saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." }))
+      .rejects.toThrow("The collection overview is not a readable text file.");
+    expect(client.call.mock.calls.some(([call]) => call === "repo.apply")).toBe(false);
+  });
+
+  it("does not treat a repository failure as a missing overview", async () => {
+    const error = new Error("Repository not found: agent/knowledge");
+    const client = saveClient(error);
+
+    await expect(saveLibraryPage(client, { db: "personal", path: "pages/new.md", markdown: "New page." }))
+      .rejects.toBe(error);
+    expect(client.call.mock.calls.some(([call]) => call === "repo.apply")).toBe(false);
+  });
+
+  it.each(["shared/pages/example.md", "personal/pages/../../other.md"])(
+    "rejects a wrong-collection or invalid page path before making requests: %s", async (path) => {
+      const client = saveClient(file("index.md", ""));
+
+      await expect(saveLibraryPage(client, { db: "personal", path, markdown: "Changed" })).rejects.toThrow();
+      expect(client.call).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/web/src/app/features/gsv-console/library/libraryService.ts
+++ b/web/src/app/features/gsv-console/library/libraryService.ts
@@ -1,5 +1,6 @@
 import type { GSVClient } from "@humansandmachines/gsv/client";
 import { z } from "zod";
+import { lexer } from "marked";
 import type {
   RepoApplyOp,
   RepoReadResult,
@@ -156,6 +157,9 @@ export async function saveLibraryPage(
   const path = normalizeDbScopedLibraryPath(input.path, db);
   if (!path) {
     throw new Error("page path is required");
+  }
+  if (!path.startsWith(`${db}/`)) {
+    throw new Error("This page does not belong to the selected collection.");
   }
   const collection = await requireCollection(client, db);
   const localPath = libraryPathInDb(path, db);
@@ -365,7 +369,7 @@ export async function previewLibraryContent(
   }
 }
 
-async function listLibraryCollections(client: LibraryClient): Promise<LibraryCollection[]> {
+export async function listLibraryCollections(client: LibraryClient): Promise<LibraryCollection[]> {
   const result = await client.call("repo.list", {});
   const parsed = z.object({
     repos: z.array(z.object({
@@ -552,8 +556,7 @@ async function readRepoPath(client: LibraryClient, repo: string, path: string): 
       size: result.size,
     };
   } catch (error) {
-    const message = formatError(error).toLowerCase();
-    if (message.includes("not found") || message.includes("enoent")) {
+    if (formatError(error).startsWith("Path not found:")) {
       return { kind: "missing" };
     }
     throw error;
@@ -578,7 +581,14 @@ async function indexUpdateOp(
     return null;
   }
   const existing = await readRepoPath(client, collection.repo, "index.md");
-  const current = existing.kind === "file" ? existing.content ?? "" : renderLibraryIndex(collection.title, undefined, []);
+  let current: string;
+  if (existing.kind === "missing") {
+    current = renderLibraryIndex(collection.title, undefined, []);
+  } else if (existing.kind === "file" && !existing.isBinary && existing.content !== null) {
+    current = existing.content;
+  } else {
+    throw new Error("The collection overview is not a readable text file.");
+  }
   const updated = mergeLibraryIndexPage(current, pageEntry);
   return updated === current ? null : { type: "put", path: "index.md", content: updated };
 }
@@ -595,28 +605,61 @@ function renderLibraryIndex(title: string, description: string | undefined, page
 }
 
 function mergeLibraryIndexPage(markdown: string, pageEntry: string): string {
-  const normalized = markdown.replace(/\r\n/g, "\n");
-  const lines = normalized.split("\n");
-  const title = lines.find((line) => line.startsWith("# "))?.slice(2).trim() || "Library";
-  const headerIndex = lines.findIndex((line) => line.trim() === "## Pages");
-  const description = headerIndex > 1 ? trimEmptyLines(lines.slice(1, headerIndex)).join("\n") : undefined;
-  const pages = lines
-    .slice(headerIndex >= 0 ? headerIndex + 1 : 0)
-    .map((line) => line.match(/^\s*-\s+(.*)$/)?.[1] ?? "")
-    .filter((line) => line && line !== "_No pages yet._");
-  return renderLibraryIndex(title, description, [...pages, pageEntry]);
+  const pageLine = `- ${pageEntry}`;
+  const lines = libraryIndexTextLines(markdown);
+  if (lines.some((line) => line.text.trim() === pageLine)) {
+    return markdown;
+  }
+  const newline = markdown.includes("\r\n") ? "\r\n" : "\n";
+  const heading = lines.find((line) => /^## Pages[ \t]*$/.test(line.text));
+  if (!heading) {
+    const separator = markdown ? (markdown.endsWith(newline) ? newline : newline + newline) : "";
+    return `${markdown}${separator}## Pages${newline}${newline}${pageLine}${newline}`;
+  }
+
+  const start = heading.end;
+  const nextHeading = lines.find((line) => line.start >= start && /^#{1,2}(?:[ \t]|$)/.test(line.text));
+  const end = nextHeading?.start ?? markdown.length;
+  const placeholder = lines.find((line) => line.start >= start && line.start < end && /^- _No pages yet\._[ \t]*$/.test(line.text));
+  if (placeholder) {
+    return markdown.slice(0, placeholder.start) + pageLine + markdown.slice(placeholder.start + placeholder.text.length);
+  }
+  const before = markdown.slice(0, end);
+  const after = markdown.slice(end);
+  return `${before}${before.endsWith(newline) ? "" : newline}${pageLine}${newline}${after ? newline : ""}${after}`;
+}
+
+function libraryIndexTextLines(markdown: string): Array<{ text: string; start: number; end: number }> {
+  const lines = [...markdown.matchAll(/[^\r\n]*(?:\r\n|\r|\n|$)/g)]
+    .filter((match) => match[0] !== "")
+    .map((match) => ({ text: match[0].replace(/\r?\n$|\r$/, ""), start: match.index, end: match.index + match[0].length }));
+  const frontmatterEnd = lines[0]?.text === "---"
+    ? lines.findIndex((line, index) => index > 0 && line.text === "---")
+    : -1;
+  const bodyStart = frontmatterEnd >= 0 ? lines[frontmatterEnd].end : 0;
+  const examples: Array<{ start: number; end: number }> = [];
+  let tokenOffset = 0;
+  for (const token of lexer(markdown.slice(bodyStart))) {
+    const end = tokenOffset + token.raw.length;
+    if (token.type === "code" || token.type === "html") {
+      examples.push({ start: tokenOffset, end });
+    }
+    tokenOffset = end;
+  }
+  // Keep source offsets so index edits never reconstruct authored Markdown.
+  // The lexer normalizes every line ending to one character but retains tabs.
+  let normalizedOffset = 0;
+  return lines.filter((line, index) => {
+    if (index <= frontmatterEnd) return false;
+    const start = normalizedOffset;
+    normalizedOffset += line.text.length + (line.end > line.start + line.text.length ? 1 : 0);
+    return !examples.some((block) => start >= block.start && start < block.end);
+  });
 }
 
 function pageEntryForLocalPath(path: string): string | null {
   const normalized = normalizeLibraryPath(path);
   return normalized.startsWith("pages/") && normalized !== "pages/.dir" ? normalized : null;
-}
-
-function trimEmptyLines(lines: string[]): string[] {
-  const copy = [...lines];
-  while (copy.length > 0 && !copy[0].trim()) copy.shift();
-  while (copy.length > 0 && !copy[copy.length - 1].trim()) copy.pop();
-  return copy;
 }
 
 function joinPath(left: string, right: string): string {

--- a/web/src/app/features/instrument/Instrument.tsx
+++ b/web/src/app/features/instrument/Instrument.tsx
@@ -7,6 +7,7 @@ import { FirstDay } from "./firstday/FirstDay";
 import { Fleet } from "./fleet/Fleet";
 import { Memory } from "./memory/Memory";
 import { WireSync } from "./wire/WireSync";
+import type { MemoryPageRef } from "./shared/navigation";
 import "./instrument.css";
 
 /** The three distances of the instrument. Zen is near, Fleet is far, the first day is Zen's empty state. */
@@ -77,6 +78,7 @@ function InstrumentReady({ initialPath }: { initialPath: string }) {
   const [phase, setPhase] = useState<"still" | "leaving" | "arriving">("still");
   const [fleetRow, setFleetRow] = useState<FleetRow | null>(null);
   const [zenPrefill, setZenPrefill] = useState<string | null>(null);
+  const [selectedMemoryPage, setSelectedMemoryPage] = useState<MemoryPageRef | null>(null);
   /* the theme follows the system until the person picks one with the l key; the choice is remembered on this device */
   const [theme, setTheme] = useState<Theme>(() => storedTheme() ?? systemTheme());
   useEffect(() => {
@@ -230,11 +232,19 @@ function InstrumentReady({ initialPath }: { initialPath: string }) {
       ) : null}
       <div class={`distance${phaseClass}`}>
         {distance === "zen" ? (
-          <Zen onFleet={(row) => move("fleet", row ?? null)} onFirstDay={() => move("firstday")} onMemory={() => move("memory")} prefill={zenPrefill} onPrefillUsed={() => setZenPrefill(null)} pid={zenPid} onShip={() => setZenPid(null)} />
+          <Zen onFleet={(row) => move("fleet", row ?? null)} onFirstDay={() => move("firstday")} onMemory={(page) => {
+            if (page) setSelectedMemoryPage(page);
+            move("memory");
+          }} prefill={zenPrefill} onPrefillUsed={() => setZenPrefill(null)} pid={zenPid} onShip={() => setZenPid(null)} />
         ) : distance === "firstday" ? (
           <FirstDay onZen={() => move("zen")} />
         ) : distance === "memory" ? (
-          <Memory onZen={() => move("zen")} onFleet={() => move("fleet")} />
+          <Memory initialPage={selectedMemoryPage} onZen={() => move("zen")} onFleet={() => move("fleet")} onAsk={(page, prompt) => {
+            setSelectedMemoryPage(page);
+            setZenPid(null);
+            setZenPrefill(prompt);
+            move("zen");
+          }} />
         ) : (
           <Fleet
             initialRow={fleetRow}

--- a/web/src/app/features/instrument/Instrument.tsx
+++ b/web/src/app/features/instrument/Instrument.tsx
@@ -160,7 +160,7 @@ function InstrumentReady({ initialPath }: { initialPath: string }) {
         event.preventDefault();
         move(distance === "firstday" ? "zen" : "firstday");
       }
-      if (event.key === "m" && distance !== "fleet") {
+      if (event.key === "m") {
         event.preventDefault();
         move(distance === "memory" ? "zen" : "memory");
       }
@@ -247,6 +247,7 @@ function InstrumentReady({ initialPath }: { initialPath: string }) {
           }} />
         ) : (
           <Fleet
+            onMemory={() => move("memory")}
             initialRow={fleetRow}
             onZen={(prefill, pid) => {
               if (prefill) setZenPrefill(prefill);

--- a/web/src/app/features/instrument/fleet/Fleet.tsx
+++ b/web/src/app/features/instrument/fleet/Fleet.tsx
@@ -38,6 +38,8 @@ import {
   relativeTime,
   runsTodayByPlace,
   targetRow,
+  visibleProcesses,
+  reconcileFleetSelection,
   type LedgerLine,
   type Place,
   shortPid,
@@ -87,11 +89,15 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
   const targetsQuery = useQuery({
     queryKey: INSTRUMENT_TARGETS_KEY,
     queryFn: () => loadConsoleTargets(client),
+    refetchOnMount: (query) => initialRow?.startsWith("target:") && initialRow !== targetRow(CLOUD_TARGET_ID)
+      && !query.state.data?.some((target) => targetRow(target.deviceId) === initialRow) ? "always" : true,
     enabled: connected,
   });
   const processesQuery = useQuery({
     queryKey: INSTRUMENT_PROCESSES_KEY,
     queryFn: () => loadConsoleProcesses(client),
+    refetchOnMount: (query) => initialRow?.startsWith("proc:")
+      && !query.state.data?.some((process) => processRow(process.pid) === initialRow) ? "always" : true,
     enabled: connected,
   });
   const responsibilitiesQuery = useQuery({
@@ -145,11 +151,20 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
     () => (selected?.startsWith("proc:") ? processes.find((process) => processRow(process.pid) === selected) ?? null : null),
     [selected, processes],
   );
+  const missingRequestedRow = selected !== null && selected === initialRow && (
+    (selected.startsWith("proc:") && !selectedProcess) || (selected.startsWith("target:") && !selectedPlace)
+  );
+  const requestedKind = selected?.startsWith("proc:") ? "process" : "place";
+  const requestedQuery = selected?.startsWith("proc:") ? processesQuery : targetsQuery;
 
   const [cmdOpen, setCmdOpen] = useState(false);
   /* the technical view shows raw syscalls and arguments; t toggles it */
   const [technical, setTechnical] = useState(false);
   const [processLimit, setProcessLimit] = useState(PROCESS_PAGE);
+  const shownProcesses = useMemo(() => visibleProcesses(processes, selected, processLimit), [processes, selected, processLimit]);
+  useEffect(() => {
+    if (shownProcesses.length > processLimit) setProcessLimit(shownProcesses.length);
+  }, [shownProcesses.length, processLimit]);
   const [openFile, setOpenFile] = useState<OpenFile | null>(null);
   const processNameFor = (pid: string): string => {
     const found = processes.find((process) => process.pid === pid);
@@ -201,16 +216,19 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
     return Array.from(nodes).map((node) => node.dataset.row).filter(isFleetRow);
   }, []);
   useEffect(() => {
+    if (selected?.startsWith("proc:") && (processesQuery.isPending || processesQuery.isFetching)) return;
+    if (selected?.startsWith("target:") && (targetsQuery.isPending || targetsQuery.isFetching)) return;
     const rows = visibleRows();
     if (rows.length === 0) return;
-    if (!selected || !rows.includes(selected)) setSelected(initialRow && rows.includes(initialRow) ? initialRow : rows[0]);
-  }, [places.length, processes.length, shownLedger.length, selected, initialRow, visibleRows]);
+    const next = reconcileFleetSelection(selected, initialRow, rows);
+    if (next !== selected) setSelected(next);
+  }, [places, shownProcesses, shownLedger, processesQuery.isPending, processesQuery.isFetching, targetsQuery.isPending, targetsQuery.isFetching, selected, initialRow, visibleRows]);
   useEffect(() => {
     if (!selected) return;
     const row = document.querySelector(`[data-row="${selected}"]`);
     // ledger rows are display: contents and have no box of their own; their first cell does
     (row?.firstElementChild ?? row)?.scrollIntoView({ block: "nearest" });
-  }, [selected]);
+  }, [selected, places, shownProcesses]);
   const selectedLine = useMemo(
     () => (selected?.startsWith("ledger:") ? shownLedger.find((line) => ledgerRow(line.id) === selected) ?? null : null),
     [selected, shownLedger],
@@ -252,7 +270,7 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
         loadOlder();
       } else if (event.key === "Enter" && selected === moreRow) {
         event.preventDefault();
-        setProcessLimit((limit) => (limit < processes.length ? limit + 20 : PROCESS_PAGE));
+        setProcessLimit(shownProcesses.length < processes.length ? shownProcesses.length + 20 : PROCESS_PAGE);
       } else if (event.key === "Enter") {
         const primary = inspectorRef.current?.querySelector<HTMLButtonElement>(".ibtn.is-primary");
         if (primary) {
@@ -265,7 +283,7 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [selected, openCmd, processes.length, visibleRows]);
+  }, [selected, openCmd, processes.length, shownProcesses.length, loadOlder, visibleRows]);
 
   useEffect(() => {
     if (!selected) return;
@@ -369,7 +387,7 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
                 </tr>
               </thead>
               <tbody>
-                {processes.slice(0, processLimit).map((process) => (
+                {shownProcesses.map((process) => (
                   <tr
                     key={process.pid}
                     data-row={processRow(process.pid)}
@@ -391,9 +409,9 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
                 {processes.length > PROCESS_PAGE ? (
                   <tr class={`more${selected === moreRow ? " is-sel" : ""}`} data-row={moreRow} tabIndex={0} onClick={() => setSelected(moreRow)}>
                     <td colSpan={6}>
-                      {processLimit < processes.length ? (
-                        <button type="button" onClick={() => setProcessLimit(processLimit + 20)}>
-                          show {Math.min(20, processes.length - processLimit)} more of {processes.length}
+                      {shownProcesses.length < processes.length ? (
+                        <button type="button" onClick={() => setProcessLimit(shownProcesses.length + 20)}>
+                          show {Math.min(20, processes.length - shownProcesses.length)} more of {processes.length}
                         </button>
                       ) : (
                         <button type="button" onClick={() => setProcessLimit(PROCESS_PAGE)}>
@@ -487,6 +505,18 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
               lines={shownLedger.filter((line) => line.processId === selectedProcess.pid).slice(0, 8)}
               placeLabelFor={placeLabel}
             />
+          ) : missingRequestedRow ? (
+            <div>
+              <h3>{requestedKind === "process" ? "Process" : "Place"}</h3>
+              <div class="sub">{selected?.slice(selected.indexOf(":") + 1)}</div>
+              {!connected || requestedQuery.isPending || requestedQuery.isFetching ? (
+                <p class="note" role="status">{connected ? `Loading ${requestedKind}…` : "Connecting…"}</p>
+              ) : requestedQuery.isError ? (
+                <p class="error" role="alert">Could not load this {requestedKind}: {requestedQuery.error.message}</p>
+              ) : (
+                <p class="note" role="status">This {requestedKind} is unavailable.</p>
+              )}
+            </div>
           ) : (
             <p class="note">{connected ? "Nothing here yet." : "Connecting…"}</p>
           )}

--- a/web/src/app/features/instrument/fleet/Fleet.tsx
+++ b/web/src/app/features/instrument/fleet/Fleet.tsx
@@ -18,7 +18,7 @@ import { readFilesPath } from "../../files/backend/filesService";
 import { executeTerminalCommand } from "../../terminal/backend/terminalService";
 import type { FleetRow } from "../Instrument";
 import { INSTRUMENT_LEDGER_KEY, INSTRUMENT_LEDGER_PAGE, INSTRUMENT_PROCESSES_KEY, INSTRUMENT_TARGETS_KEY } from "../wire/queryKeys";
-import { Wordmark } from "../shared/Wordmark";
+import { InstrumentHeader } from "../shared/InstrumentHeader";
 import {
   CLOUD_TARGET_ID,
   clockTime,
@@ -52,6 +52,7 @@ export type FleetProps = {
   initialRow: FleetRow | null;
   /** Back to Zen, optionally with text placed in the prompt (a file reference, for instance) and a process to open instead of the ship. */
   onZen: (prefill?: string, pid?: string) => void;
+  onMemory: () => void;
 };
 
 const LEDGER_PAGE = INSTRUMENT_LEDGER_PAGE;
@@ -81,7 +82,7 @@ function outcomeWord(outcome: string): string {
   return outcome;
 }
 
-export function Fleet({ initialRow, onZen }: FleetProps) {
+export function Fleet({ initialRow, onZen, onMemory }: FleetProps) {
   const { client, connected } = useGateway();
   const { snapshot } = useSession();
   const now = useNow();
@@ -227,7 +228,7 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
     if (!selected) return;
     const row = document.querySelector(`[data-row="${selected}"]`);
     // ledger rows are display: contents and have no box of their own; their first cell does
-    (row?.firstElementChild ?? row)?.scrollIntoView({ block: "nearest" });
+    row?.scrollIntoView({ block: "nearest" });
   }, [selected, places, shownProcesses]);
   const selectedLine = useMemo(
     () => (selected?.startsWith("ledger:") ? shownLedger.find((line) => ledgerRow(line.id) === selected) ?? null : null),
@@ -311,21 +312,20 @@ export function Fleet({ initialRow, onZen }: FleetProps) {
 
   return (
     <main class="fleet" aria-label="Fleet">
-      <div class="fleet-top">
-        <div>
-          <Wordmark /> &nbsp;·&nbsp; fleet
-        </div>
-        <div class="center">
-          {snapshot.username ? `${snapshot.username}'s installation` : "installation"} · {places.length} places ·{" "}
+      <InstrumentHeader status={<>
+          fleet · {snapshot.username ? `${snapshot.username}'s installation` : "installation"} · {places.length} places ·{" "}
           {processes.length} processes
           {modelsQuery.data?.preferredModelId ? ` · ${modelsQuery.data.preferredModelId}` : ""}
-        </div>
-        <div class="right">
-          <button type="button" onClick={() => onZen()}>
-            <kbd>z</kbd>zen
-          </button>
-        </div>
-      </div>
+      </>}>
+        <button type="button" onClick={() => onZen()}>
+          <kbd>z</kbd>zen
+        </button>
+        <span aria-current="page">fleet</span>
+        <button type="button" onClick={onMemory}>
+          memory
+        </button>
+        <span><kbd>?</kbd>keys</span>
+      </InstrumentHeader>
 
       <div class="fleet-body">
         <div ref={manifestRef} class="fleet-manifest">

--- a/web/src/app/features/instrument/fleet/fleet.css
+++ b/web/src/app/features/instrument/fleet/fleet.css
@@ -1,45 +1,31 @@
 /* Fleet: the far distance. A manifest, not a dashboard. */
 .fleet {
+  position: relative;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   /* header · body · the command line (absent while closed) · status; no fixed slot that can go empty */
-  grid-template-rows: 44px minmax(0, 1fr) auto auto;
+  grid-template-rows: minmax(0, 1fr) auto auto;
   height: 100%;
   min-height: 0;
   overflow: hidden;
 }
-.fleet-top {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  padding: 0 56px;
-  background: linear-gradient(180deg, rgba(19, 17, 46, 0.6), transparent);
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--text-dim);
-  border-bottom: 1px solid var(--border);
-}
-.fleet-top .center {
-  text-align: center;
-  color: var(--label);
-}
-.fleet-top .right {
-  text-align: right;
-}
 .fleet-body {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 360px;
+  min-width: 0;
   min-height: 0;
 }
-@media (max-width: 980px) {
+@container instrument (max-width: 980px) {
   .fleet-body { grid-template-columns: 1fr; }
   .fleet-inspector { display: none; }
 }
 .fleet-manifest {
+  min-width: 0;
   overflow-y: auto;
+  scroll-padding-top: var(--instrument-header-height);
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
-  padding: 0 0 var(--space-5);
+  padding: var(--instrument-header-height) 0 var(--space-5);
 }
 .fleet-block {
   padding: 18px var(--space-5) 6px;
@@ -218,7 +204,7 @@
 
 .fleet-inspector {
   border-left: 1px solid var(--border);
-  padding: 18px var(--space-5);
+  padding: calc(var(--instrument-header-height) + 18px) var(--space-5) 18px;
   overflow-y: auto;
   background: var(--inspector-bg);
 }
@@ -311,6 +297,7 @@
 }
 .fleet-cmdline input {
   flex: 1;
+  min-width: 0;
   background: transparent;
   border: 0;
   outline: 0;
@@ -323,8 +310,10 @@
 }
 .fleet-status {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 24px;
+  row-gap: 6px;
   padding: 0 var(--space-5);
   background: var(--panel);
   border-top: 1px solid var(--border);
@@ -332,7 +321,7 @@
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--text-dim);
-  height: 30px;
+  min-height: 30px;
 }
 .fleet-status .right {
   margin-left: auto;
@@ -375,7 +364,7 @@
 .fleet .file-preview pre { margin: 0; font-family: var(--gsv-font-mono); font-size: 11px; line-height: 1.5; color: var(--label); white-space: pre; }
 .fleet .file-preview img { max-width: 100%; display: block; }
 
-.fleet-ledger .row { display: contents; }
+.fleet-ledger .row { display: grid; grid-column: 1 / -1; grid-template-columns: subgrid; min-width: 0; padding-left: 8px; }
 .fleet-ledger .older { grid-column: 1 / -1; padding: 6px 0 2px; border-top: 1px solid var(--rule-inner); }
 .fleet-ledger .older button { font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); }
 .fleet-ledger .older button:hover { color: var(--accent); }
@@ -397,11 +386,10 @@
 
 /* ledger rows are rows: hover, selection, and the accent inset, as in the tables */
 .fleet-ledger .row { cursor: pointer; }
-.fleet-ledger .row:hover > span { background: var(--hover); }
-.fleet-ledger .row.is-sel > span { background: var(--selected); }
-.fleet-ledger .row.is-sel > span:first-child { box-shadow: inset 3px 0 0 var(--accent); padding-left: 8px; }
+.fleet-ledger .row:hover { background: var(--hover); }
+.fleet-ledger .row.is-sel { background: var(--selected); box-shadow: inset 3px 0 0 var(--accent); }
 .fleet-ledger .row > span { padding: 1px 0; }
-.fleet-ledger .row:focus-visible > span { outline: 1px solid var(--accent); outline-offset: -1px; }
+.fleet .fleet-ledger .row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .fleet .line-detail { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; font: inherit; color: var(--label); }
 
 .fleet tr.more.is-sel td { background: var(--selected); box-shadow: inset 3px 0 0 var(--accent); }

--- a/web/src/app/features/instrument/fleet/fleetModel.test.ts
+++ b/web/src/app/features/instrument/fleet/fleetModel.test.ts
@@ -16,6 +16,8 @@ import {
   shortPid,
   humanCall,
   ledgerFromSysLines,
+  visibleProcesses,
+  reconcileFleetSelection,
 } from "./fleetModel";
 
 function target(overrides: Partial<ConsoleTarget>): ConsoleTarget {
@@ -97,6 +99,14 @@ describe("places", () => {
 });
 
 describe("processes", () => {
+  it.each(["proc:replaced", "target:removed"] as const)("retains an unavailable explicit reference %s until the person leaves it", (requested) => {
+    const rows = ["target:gsv", "proc:current"] as const;
+    expect(reconcileFleetSelection(requested, requested, [])).toBe(requested);
+    expect(reconcileFleetSelection(requested, requested, rows)).toBe(requested);
+    expect(reconcileFleetSelection(requested, requested, [...rows, requested])).toBe(requested);
+    expect(reconcileFleetSelection("proc:current", requested, rows)).toBe("proc:current");
+    expect(reconcileFleetSelection("proc:disappeared", requested, rows)).toBe("target:gsv");
+  });
   it("leads with the ship, then the most recently active", () => {
     const ordered = orderProcesses([
       process({ pid: "42", lastActiveAt: 10 }),
@@ -109,6 +119,33 @@ describe("processes", () => {
   it("lists row keys as places then processes", () => {
     const keys = rowKeys(orderPlaces([target({})]), [process({ pid: "7" })]);
     expect(keys).toEqual(["target:laptop", "target:gsv", "proc:7"]);
+  });
+
+  it("reveals a linked process beyond the first page when the list arrives", () => {
+    const selected = "proc:helper:11";
+    expect(visibleProcesses([], selected, 8)).toEqual([]);
+    const loaded = Array.from({ length: 14 }, (_, index) => process({ pid: `helper:${index}` }));
+    const shown = visibleProcesses(loaded, selected, 8);
+    expect(shown.map((entry) => entry.pid)).toEqual(loaded.slice(0, 12).map((entry) => entry.pid));
+    expect(shown.at(-1)?.pid).toBe("helper:11");
+    expect(loaded).toHaveLength(14);
+  });
+
+  it("keeps the selected process visible when refreshed activity changes its position", () => {
+    const linked = process({ pid: "linked", lastActiveAt: 100 });
+    const others = Array.from({ length: 12 }, (_, index) => process({ pid: `other:${index}`, lastActiveAt: 90 - index }));
+    expect(visibleProcesses(orderProcesses([linked, ...others]), "proc:linked", 8)).toHaveLength(8);
+    const reordered = orderProcesses([{ ...linked, lastActiveAt: 0 }, ...others]);
+    const shown = visibleProcesses(reordered, "proc:linked", 8);
+    expect(shown).toHaveLength(13);
+    expect(shown.at(-1)?.pid).toBe("linked");
+  });
+
+  it("preserves expanded pages and does not treat another row kind as a process reference", () => {
+    const processes = Array.from({ length: 30 }, (_, index) => process({ pid: `helper:${index}` }));
+    expect(visibleProcesses(processes, "proc:helper:2", 20)).toHaveLength(20);
+    expect(visibleProcesses(processes, "target:helper:29", 8)).toHaveLength(8);
+    expect(visibleProcesses(processes, "proc:missing", 8)).toHaveLength(8);
   });
 });
 

--- a/web/src/app/features/instrument/fleet/fleetModel.ts
+++ b/web/src/app/features/instrument/fleet/fleetModel.ts
@@ -137,6 +137,18 @@ export function processRow(pid: string): FleetRow {
   return `proc:${pid}`;
 }
 
+/** An explicitly selected process stays visible even beyond the current page. */
+export function visibleProcesses(processes: readonly ConsoleProcess[], selected: FleetRow | null, limit: number): ConsoleProcess[] {
+  const selectedIndex = processes.findIndex((process) => processRow(process.pid) === selected);
+  return processes.slice(0, Math.max(limit, selectedIndex + 1));
+}
+
+/** A linked process or target keeps its identity when unavailable; ordinary row navigation can leave it. */
+export function reconcileFleetSelection(selected: FleetRow | null, initialRow: FleetRow | null, visibleRows: readonly FleetRow[]): FleetRow | null {
+  if (selected && (visibleRows.includes(selected) || (selected === initialRow && (selected.startsWith("proc:") || selected.startsWith("target:"))))) return selected;
+  return initialRow && visibleRows.includes(initialRow) ? initialRow : visibleRows[0] ?? null;
+}
+
 export function ledgerRow(lineId: string): FleetRow {
   return `ledger:${lineId}`;
 }

--- a/web/src/app/features/instrument/instrument.css
+++ b/web/src/app/features/instrument/instrument.css
@@ -6,6 +6,7 @@
   /* type scale: 1, 1.5 or 2; the x key cycles it. zoom scales layout with the type, and the container
    * queries below see the zoomed width, so 2x on a wide screen reflows like a narrow one. */
   --type-scale: 1;
+  --instrument-header-height: 44px;
   /* the instrument's own faces: Martian Mono for the machine, Host Grotesk for the person and the ship */
   --gsv-font-mono: "Martian Mono", "IBM Plex Mono", "JetBrains Mono", monospace;
   --gsv-font-prose: "Host Grotesk", "Avenir Next", "Segoe UI", sans-serif;
@@ -123,6 +124,37 @@
 }
 .instrument-top .keys span {
   margin-left: 14px;
+}
+.instrument-header {
+  position: absolute;
+  inset: 0 0 auto;
+  height: var(--instrument-header-height);
+  z-index: 3;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  pointer-events: none;
+}
+.instrument-header > * {
+  pointer-events: auto;
+  background: var(--void);
+  padding: 4px 8px;
+  min-width: 0;
+}
+.instrument-header > .wordmark { justify-self: start; margin-left: -8px; }
+.instrument-header .instrument-heading { justify-self: center; max-width: 100%; text-align: center; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.instrument-header .keys { display: flex; align-items: center; gap: 14px; justify-self: end; margin-right: -8px; }
+.instrument-header .keys span { margin-left: 0; }
+.instrument-header [aria-current="page"] { color: var(--text-hi); }
+@container instrument (max-width: 900px) {
+  .instrument-header { padding-inline: 18px; gap: 8px; }
+  .instrument-header .keys { gap: 8px; }
+  .instrument-header .keys kbd { display: none; }
+}
+@container instrument (max-width: 600px) {
+  .distance { --instrument-header-height: 68px; }
+  .instrument-header { grid-template-columns: auto minmax(0, 1fr); }
+  .instrument-header .instrument-heading { grid-row: 2; grid-column: 1 / -1; justify-self: center; max-width: 100%; }
+  .instrument-header .keys { grid-row: 1; grid-column: 2; }
 }
 .instrument kbd {
   font: inherit;
@@ -369,7 +401,7 @@
 }
 @container instrument (max-width: 900px) {
   .instrument-top { padding: 0 18px; }
-  .instrument-top .keys { display: none; }
+  .instrument-top:not(.instrument-header) .keys { display: none; }
   .fleet-body { grid-template-columns: 1fr; grid-template-rows: minmax(0, 1fr) auto; }
   .fleet-inspector { border-left: 0; border-top: 1px solid var(--border); max-height: 45vh; }
   .fleet-ledger { grid-template-columns: auto max-content minmax(0, 1fr) auto; }

--- a/web/src/app/features/instrument/memory/Memory.tsx
+++ b/web/src/app/features/instrument/memory/Memory.tsx
@@ -1,77 +1,111 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/preact-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { useGateway } from "../../../services/gateway/GatewayProvider";
-import { loadLibraryWorkspace, saveLibraryPage } from "../../gsv-console/library/libraryService";
-import type { LibraryEntry } from "../../gsv-console/library/libraryTypes";
+import { listLibraryCollections, saveLibraryPage } from "../../gsv-console/library/libraryService";
+import { libraryPathInDb } from "../../gsv-console/library/libraryModel";
+import type { MemoryPageRef } from "../shared/navigation";
+import type { LibrarySavePageInput, LibraryEntry } from "../../gsv-console/library/libraryTypes";
 import { renderMarkdownHtml } from "../shared/markdown";
 import { Wordmark } from "../shared/Wordmark";
+import { INSTRUMENT_MEMORY_KEY as MEMORY_KEY } from "../wire/queryKeys";
+import { listMemoryPages, readMemoryPage, searchMemory } from "./memoryService";
+import { refreshSavedMemoryPage } from "./memoryQueries";
 import "./memory.css";
 
 export type MemoryProps = {
+  initialPage?: MemoryPageRef | null;
+  onAsk: (page: MemoryPageRef, prompt: string) => void;
   onZen: () => void;
   onFleet: () => void;
 };
-
-const MEMORY_KEY = ["instrument", "memory"] as const;
-
-/** The pages a collection holds, or the search's matches while there is a query. */
-function shownPages(pages: readonly LibraryEntry[], matches: readonly LibraryEntry[] | null): LibraryEntry[] {
-  return (matches ?? pages).filter((entry) => entry.kind === "file");
-}
 
 /**
  * Memory: what the ship knows, as pages a person can read, search and
  * correct. The Personal wiki comes first; other collections sit beside it.
  * Prose on the void with one mono rail, the way Zen is, because the same two
- * voices write here.
+ * voices write here. Each read is one ask: the list from the tree, a page
+ * when opened, a search in the gateway.
  */
-export function Memory({ onZen, onFleet }: MemoryProps) {
+export function Memory({ initialPage, onAsk, onZen, onFleet }: MemoryProps) {
   const { client, connected } = useGateway();
   const queryClient = useQueryClient();
-  const [db, setDb] = useState<string | undefined>(undefined);
-  const [path, setPath] = useState<string | undefined>(undefined);
+  const [db, setDb] = useState<string | null>(initialPage?.db ?? null);
+  const [path, setPath] = useState<string | null>(initialPage?.path ?? null);
   const [query, setQuery] = useState("");
   const [asked, setAsked] = useState("");
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState("");
-  const [status, setStatus] = useState<string | null>(null);
+  const [editor, setEditor] = useState<LibrarySavePageInput | null>(null);
+  const [status, setStatus] = useState<{ db: string; path: string; text: string; error: boolean } | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<HTMLTextAreaElement>(null);
 
-  const workspace = useQuery({
-    queryKey: [...MEMORY_KEY, db ?? "", path ?? "", asked],
-    queryFn: () => loadLibraryWorkspace(client, { db, path, q: asked || undefined }),
+  useEffect(() => {
+    if (!initialPage) return;
+    setDb(initialPage.db);
+    setPath(initialPage.path);
+    setEditor(null);
+    setStatus(null);
+  }, [initialPage?.db, initialPage?.path]);
+
+  const collectionsQuery = useQuery({
+    queryKey: [...MEMORY_KEY, "collections"],
+    queryFn: () => listLibraryCollections(client),
     enabled: connected,
-    placeholderData: (previous) => previous,
   });
-  const state = workspace.data;
-  const pages = useMemo(() => shownPages(state?.pages ?? [], state?.searchMatches ?? null), [state]);
-  const note = state?.selectedNote ?? null;
-  const collections = state?.dbs ?? [];
-  const selectedDb = state?.selectedDb ?? db ?? "";
-  const writable = collections.find((entry) => entry.id === selectedDb)?.writable ?? false;
+  const collections = useMemo(() => collectionsQuery.data ?? [], [collectionsQuery.data]);
+  const collection = useMemo(
+    () => db !== null
+      ? collections.find((entry) => entry.id === db) ?? null
+      : collections.find((entry) => entry.id === "personal") ?? collections[0] ?? null,
+    [collections, db],
+  );
+  const selectedDb = collection?.id ?? "";
+  const writable = collection?.writable ?? false;
+
+  const pagesQuery = useQuery({
+    queryKey: [...MEMORY_KEY, "pages", selectedDb],
+    queryFn: () => (collection ? listMemoryPages(client, collection) : Promise.resolve([])),
+    enabled: connected && collection !== null,
+  });
+  const searchQuery = useQuery({
+    queryKey: [...MEMORY_KEY, "search", selectedDb, asked],
+    queryFn: () => (collection ? searchMemory(client, collection, asked) : Promise.resolve({ entries: [], truncated: false })),
+    enabled: connected && collection !== null && asked !== "",
+  });
+  const pages = useMemo(() => (asked ? (searchQuery.data?.entries ?? []) : (pagesQuery.data ?? [])), [asked, pagesQuery.data, searchQuery.data]);
+  /* the first page of a collection opens by itself; a page the person picked stays */
+  const currentPath = path ?? pagesQuery.data?.[0]?.path ?? null;
+  const pageQuery = useQuery({
+    queryKey: [...MEMORY_KEY, "page", selectedDb, currentPath ?? ""],
+    queryFn: () => (collection && currentPath ? readMemoryPage(client, collection, currentPath) : Promise.resolve(null)),
+    enabled: connected && collection !== null && currentPath !== null,
+  });
+  const note = pageQuery.data ?? null;
+  const editing = editor !== null && editor.db === selectedDb && editor.path === note?.path;
+  const pageStatus = status?.db === selectedDb && status.path === currentPath ? status : null;
 
   const save = useMutation({
-    mutationFn: (markdown: string) => saveLibraryPage(client, { db: selectedDb, path: note?.path ?? "", markdown }),
-    onSuccess: (result) => {
-      setEditing(false);
-      setStatus(result.statusText || "saved");
-      void queryClient.invalidateQueries({ queryKey: MEMORY_KEY });
+    mutationFn: (input: LibrarySavePageInput) => saveLibraryPage(client, input),
+    onSuccess: async (result, input) => {
+      setEditor((current) => current?.db === input.db && current.path === input.path && current.markdown === input.markdown ? null : current);
+      setStatus({ db: input.db, path: input.path, text: result.statusText || "saved", error: false });
+      await refreshSavedMemoryPage(queryClient, input);
     },
-    onError: (error: Error) => setStatus(error.message),
+    onError: (error: Error, input) => setStatus({ db: input.db, path: input.path, text: error.message, error: true }),
   });
+  const saveEdit = () => {
+    if (editor && editing && connected && writable && !save.isPending) save.mutate(editor);
+  };
 
   const open = useCallback((entry: LibraryEntry) => {
     setPath(entry.path);
-    setEditing(false);
+    setEditor(null);
     setStatus(null);
   }, []);
   const beginEdit = useCallback(() => {
     if (!note || !writable) return;
-    setDraft(note.markdown);
-    setEditing(true);
+    setEditor({ db: selectedDb, path: note.path, markdown: note.markdown });
     setStatus(null);
-  }, [note, writable]);
+  }, [note, selectedDb, writable]);
   useEffect(() => {
     if (editing) editorRef.current?.focus();
   }, [editing]);
@@ -84,7 +118,7 @@ export function Memory({ onZen, onFleet }: MemoryProps) {
       if (event.key === "Escape") {
         if (editing) {
           event.preventDefault();
-          setEditing(false);
+          setEditor(null);
           return;
         }
         if (typing && target instanceof HTMLElement) {
@@ -118,11 +152,11 @@ export function Memory({ onZen, onFleet }: MemoryProps) {
   const onEditorKey = (event: KeyboardEvent) => {
     if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
       event.preventDefault();
-      save.mutate(draft);
+      saveEdit();
     }
   };
 
-  const empty = connected && !workspace.isPending && collections.length === 0;
+  const empty = connected && collectionsQuery.isSuccess && collections.length === 0;
 
   return (
     <main class="memory" aria-label="Memory">
@@ -147,7 +181,9 @@ export function Memory({ onZen, onFleet }: MemoryProps) {
         </span>
       </div>
 
-      {empty ? (
+      {collectionsQuery.isError ? (
+        <div class="memory-empty" role="alert">{collectionsQuery.error.message}</div>
+      ) : empty ? (
         <div class="memory-empty">
           <p>
             Nothing here yet. Your ship writes what it learns about you into its <span class="place">personal</span> wiki as you
@@ -157,22 +193,23 @@ export function Memory({ onZen, onFleet }: MemoryProps) {
       ) : (
         <div class="memory-body">
           <aside class="memory-rail">
-            {collections.length > 1 ? (
+            {collections.length > 1 || (collections.length > 0 && !collection) ? (
               <div class="collections" role="tablist" aria-label="Collections">
-                {collections.map((collection) => (
+                {collections.map((entry) => (
                   <button
                     type="button"
                     role="tab"
-                    key={collection.id}
-                    aria-selected={collection.id === selectedDb}
-                    class={collection.id === selectedDb ? "is-sel" : ""}
+                    key={entry.id}
+                    aria-selected={entry.id === selectedDb}
+                    class={entry.id === selectedDb ? "is-sel" : ""}
                     onClick={() => {
-                      setDb(collection.id);
-                      setPath(undefined);
-                      setEditing(false);
+                      setDb(entry.id);
+                      setPath(null);
+                      setEditor(null);
+                      setStatus(null);
                     }}
                   >
-                    {collection.title || collection.id}
+                    {entry.title || entry.id}
                   </button>
                 ))}
               </div>
@@ -209,7 +246,14 @@ export function Memory({ onZen, onFleet }: MemoryProps) {
               ) : null}
             </form>
             <div class="pages" role="listbox" aria-label={asked ? "Matches" : "Pages"}>
-              {asked ? <div class="ph">{pages.length === 0 ? "nothing matches" : `${pages.length} ${pages.length === 1 ? "match" : "matches"}`}</div> : null}
+              {!asked && pagesQuery.isError ? <div class="ph" role="alert">{pagesQuery.error.message}</div> : null}
+              {asked ? (
+                <div class="ph">
+                  {searchQuery.isLoading ? "searching" : searchQuery.isError ? "Search failed" : pages.length === 0 ? "nothing matches" : `${pages.length} ${pages.length === 1 ? "match" : "matches"}`}
+                </div>
+              ) : null}
+              {asked && searchQuery.isError ? <div class="ph" role="alert">{searchQuery.error.message}</div> : null}
+              {asked && searchQuery.data?.truncated ? <div class="ph">More matches exist. Narrow your search.</div> : null}
               {pages.map((entry) => (
                 <button
                   type="button"
@@ -232,13 +276,17 @@ export function Memory({ onZen, onFleet }: MemoryProps) {
                 <div class="page-head">
                   <span class="path">{note.path}</span>
                   <span class="actions">
-                    {status ? <span class="status">{status}</span> : null}
+                    {pageStatus ? <span class={`status${pageStatus.error ? " is-error" : ""}`} role={pageStatus.error ? "alert" : "status"}>{pageStatus.text}</span> : null}
+                    {!editing && collection ? <button type="button" class="ibtn" onClick={() => onAsk(
+                      { db: selectedDb, path: note.path },
+                      `Tell me about the memory page “${note.title}” (gsv:/src/repos/${collection.repo}/${libraryPathInDb(note.path, selectedDb)}). `,
+                    )}>ask about this</button> : null}
                     {editing ? (
                       <>
-                        <button type="button" class="ibtn is-primary" disabled={save.isPending} onClick={() => save.mutate(draft)}>
+                        <button type="button" class="ibtn is-primary" disabled={save.isPending || !connected || !writable} onClick={() => saveEdit()}>
                           {save.isPending ? "saving" : "save"}
                         </button>
-                        <button type="button" class="ibtn" onClick={() => setEditing(false)}>
+                        <button type="button" class="ibtn" onClick={() => setEditor(null)}>
                           cancel
                         </button>
                       </>
@@ -249,22 +297,31 @@ export function Memory({ onZen, onFleet }: MemoryProps) {
                     ) : null}
                   </span>
                 </div>
+                {pageQuery.isError ? <div class="memory-none" role="alert">Could not refresh this page: {pageQuery.error.message}</div> : null}
                 {editing ? (
                   <textarea
                     ref={editorRef}
                     class="editor"
-                    value={draft}
+                    value={editor?.markdown ?? ""}
                     spellcheck={true}
                     aria-label="Page text"
-                    onInput={(event) => setDraft(event.currentTarget.value)}
+                    onInput={(event) => {
+                      const markdown = event.currentTarget.value;
+                      setEditor((current) => current ? { ...current, markdown } : current);
+                    }}
                     onKeyDown={onEditorKey}
                   />
                 ) : (
                   <article class="prose" dangerouslySetInnerHTML={{ __html: renderMarkdownHtml(note.markdown) }} />
                 )}
               </>
-            ) : workspace.isPending ? null : (
-              <div class="memory-none">{state?.errorText || "Pick a page, or search."}</div>
+            ) : collectionsQuery.isLoading || pageQuery.isLoading || pagesQuery.isLoading ? (
+              <div class="memory-none" role="status">Loading memory…</div>
+            ) : (
+              <div class="memory-none" role={pageQuery.isError || pagesQuery.isError || (db !== null && !collection) ? "alert" : undefined}>
+                {pageQuery.error?.message || pagesQuery.error?.message ||
+                  (db !== null && !collection ? `Collection “${db}” is unavailable.` : currentPath ? "This page is unavailable." : "No pages here yet.")}
+              </div>
             )}
           </section>
         </div>

--- a/web/src/app/features/instrument/memory/Memory.tsx
+++ b/web/src/app/features/instrument/memory/Memory.tsx
@@ -6,7 +6,7 @@ import { libraryPathInDb } from "../../gsv-console/library/libraryModel";
 import type { MemoryPageRef } from "../shared/navigation";
 import type { LibrarySavePageInput, LibraryEntry } from "../../gsv-console/library/libraryTypes";
 import { renderMarkdownHtml } from "../shared/markdown";
-import { Wordmark } from "../shared/Wordmark";
+import { InstrumentHeader } from "../shared/InstrumentHeader";
 import { INSTRUMENT_MEMORY_KEY as MEMORY_KEY } from "../wire/queryKeys";
 import { listMemoryPages, readMemoryPage, searchMemory } from "./memoryService";
 import { refreshSavedMemoryPage } from "./memoryQueries";
@@ -160,26 +160,23 @@ export function Memory({ initialPage, onAsk, onZen, onFleet }: MemoryProps) {
 
   return (
     <main class="memory" aria-label="Memory">
-      <div class="instrument-top">
-        <Wordmark />
-        <span>
+      <InstrumentHeader status={<>
           memory ·{" "}
           <span style={connected ? "color: var(--online)" : "color: var(--error)"}>
             {connected ? (collections.length === 1 ? "1 collection" : `${collections.length} collections`) : "offline"}
           </span>
+      </>}>
+        <button type="button" onClick={onZen}>
+          <kbd>m</kbd>zen
+        </button>
+        <button type="button" onClick={onFleet}>
+          <kbd>z</kbd>fleet
+        </button>
+        <span aria-current="page">memory</span>
+        <span>
+          <kbd>?</kbd>keys
         </span>
-        <span class="keys">
-          <button type="button" onClick={onZen}>
-            <kbd>m</kbd>zen
-          </button>
-          <button type="button" onClick={onFleet}>
-            <kbd>z</kbd>fleet
-          </button>
-          <span>
-            <kbd>?</kbd>keys
-          </span>
-        </span>
-      </div>
+      </InstrumentHeader>
 
       {collectionsQuery.isError ? (
         <div class="memory-empty" role="alert">{collectionsQuery.error.message}</div>
@@ -193,58 +190,60 @@ export function Memory({ initialPage, onAsk, onZen, onFleet }: MemoryProps) {
       ) : (
         <div class="memory-body">
           <aside class="memory-rail">
-            {collections.length > 1 || (collections.length > 0 && !collection) ? (
-              <div class="collections" role="tablist" aria-label="Collections">
-                {collections.map((entry) => (
+            <div class="memory-tools">
+              {collections.length > 1 || (collections.length > 0 && !collection) ? (
+                <div class="collections" role="tablist" aria-label="Collections">
+                  {collections.map((entry) => (
+                    <button
+                      type="button"
+                      role="tab"
+                      key={entry.id}
+                      aria-selected={entry.id === selectedDb}
+                      class={entry.id === selectedDb ? "is-sel" : ""}
+                      onClick={() => {
+                        setDb(entry.id);
+                        setPath(null);
+                        setEditor(null);
+                        setStatus(null);
+                      }}
+                    >
+                      {entry.title || entry.id}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+              <form
+                class="search"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  setAsked(query.trim());
+                }}
+              >
+                <span class="sigil">/</span>
+                <input
+                  ref={searchRef}
+                  type="text"
+                  value={query}
+                  placeholder="search what is known"
+                  aria-label="Search memory"
+                  spellcheck={false}
+                  onInput={(event) => setQuery(event.currentTarget.value)}
+                />
+                {asked ? (
                   <button
                     type="button"
-                    role="tab"
-                    key={entry.id}
-                    aria-selected={entry.id === selectedDb}
-                    class={entry.id === selectedDb ? "is-sel" : ""}
+                    class="clear"
+                    aria-label="Clear search"
                     onClick={() => {
-                      setDb(entry.id);
-                      setPath(null);
-                      setEditor(null);
-                      setStatus(null);
+                      setQuery("");
+                      setAsked("");
                     }}
                   >
-                    {entry.title || entry.id}
+                    ×
                   </button>
-                ))}
-              </div>
-            ) : null}
-            <form
-              class="search"
-              onSubmit={(event) => {
-                event.preventDefault();
-                setAsked(query.trim());
-              }}
-            >
-              <span class="sigil">/</span>
-              <input
-                ref={searchRef}
-                type="text"
-                value={query}
-                placeholder="search what is known"
-                aria-label="Search memory"
-                spellcheck={false}
-                onInput={(event) => setQuery(event.currentTarget.value)}
-              />
-              {asked ? (
-                <button
-                  type="button"
-                  class="clear"
-                  aria-label="Clear search"
-                  onClick={() => {
-                    setQuery("");
-                    setAsked("");
-                  }}
-                >
-                  ×
-                </button>
-              ) : null}
-            </form>
+                ) : null}
+              </form>
+            </div>
             <div class="pages" role="listbox" aria-label={asked ? "Matches" : "Pages"}>
               {!asked && pagesQuery.isError ? <div class="ph" role="alert">{pagesQuery.error.message}</div> : null}
               {asked ? (
@@ -270,7 +269,7 @@ export function Memory({ initialPage, onAsk, onZen, onFleet }: MemoryProps) {
             </div>
           </aside>
 
-          <section class="memory-page">
+          <section class={`memory-page${editing ? " is-editing" : ""}`}>
             {note ? (
               <>
                 <div class="page-head">

--- a/web/src/app/features/instrument/memory/memory.css
+++ b/web/src/app/features/instrument/memory/memory.css
@@ -1,7 +1,8 @@
 /* Memory: what the ship knows, as pages. Prose on the void, one mono rail. */
 .memory {
+  position: relative;
   display: grid;
-  grid-template-rows: 44px minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   height: 100%;
   min-height: 0;
   overflow: hidden;
@@ -12,16 +13,23 @@
   min-height: 0;
   overflow: hidden;
 }
-@media (max-width: 720px) {
-  .memory-body { grid-template-columns: 1fr; grid-template-rows: auto minmax(0, 1fr); }
-}
 .memory-rail {
-  display: flex;
-  flex-direction: column;
+  min-width: 0;
   min-height: 0;
+  padding-top: var(--instrument-header-height);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
   border-right: 1px solid var(--border);
   font-family: var(--gsv-font-mono);
   font-size: 12px;
+}
+.memory-rail::-webkit-scrollbar { display: none; }
+.memory-tools {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--void);
 }
 .memory-rail .collections {
   display: flex;
@@ -62,11 +70,8 @@
 .memory-rail .search input::placeholder { color: var(--faint); }
 .memory-rail .search .clear { color: var(--text-dim); cursor: pointer; }
 .memory-rail .pages {
-  overflow-y: auto;
-  scrollbar-width: none;
   padding: 8px 0 24px;
 }
-.memory-rail .pages::-webkit-scrollbar { display: none; }
 .memory-rail .ph {
   font-size: 10px;
   letter-spacing: 0.12em;
@@ -96,12 +101,19 @@
   text-overflow: ellipsis;
 }
 .memory-page {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
   min-height: 0;
-  overflow: hidden;
+  padding-top: var(--instrument-header-height);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
 }
+.memory-page::-webkit-scrollbar { display: none; }
 .memory-page .page-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--void);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -114,9 +126,6 @@
   text-transform: uppercase;
   color: var(--text-dim);
 }
-@media (max-width: 720px) {
-  .memory-page .page-head { padding: 10px 18px; }
-}
 .memory-page .page-head .path { color: var(--path); text-transform: none; letter-spacing: 0.02em; }
 .memory-page .page-head .actions { display: flex; align-items: center; gap: 10px; }
 .memory-page .page-head .status { color: var(--online); }
@@ -124,8 +133,6 @@
 .memory-page .page-head .ibtn { padding: 5px 10px; }
 .memory-page .page-head .ibtn kbd { margin-right: 6px; }
 .memory-page .prose {
-  overflow-y: auto;
-  scrollbar-width: none;
   padding: 5vh 40px 10vh;
   max-width: var(--measure-prose);
   font-family: var(--gsv-font-prose);
@@ -133,7 +140,6 @@
   line-height: 1.6;
   color: var(--text-hi);
 }
-.memory-page .prose::-webkit-scrollbar { display: none; }
 .memory-page .prose h1, .memory-page .prose h2, .memory-page .prose h3 { font-weight: 600; line-height: 1.2; margin: 1.4em 0 0.5em; }
 .memory-page .prose h1:first-child, .memory-page .prose h2:first-child { margin-top: 0; }
 .memory-page .prose p { margin: 0 0 0.8em; }
@@ -143,6 +149,8 @@
 .memory-page .prose ul, .memory-page .prose ol { padding-left: 1.3em; margin: 0 0 0.8em; }
 .memory-page .prose li::marker { color: var(--accent); }
 .memory-page .editor {
+  flex: 1;
+  min-height: 0;
   resize: none;
   width: 100%;
   max-width: var(--measure-prose);
@@ -157,6 +165,8 @@
   line-height: 1.6;
   caret-color: var(--accent);
 }
+.memory-page.is-editing { display: flex; flex-direction: column; overflow: hidden; }
+.memory-page.is-editing .page-head { flex-shrink: 0; }
 .memory-none, .memory-empty {
   padding: 8vh 40px;
   font-family: var(--gsv-font-prose);
@@ -165,3 +175,14 @@
   max-width: var(--measure-prose);
 }
 .memory-empty .place { color: var(--target); }
+.memory-empty { padding-top: calc(var(--instrument-header-height) + 8vh); }
+
+@container instrument (max-width: 720px) {
+  .memory-body { grid-template-columns: 1fr; grid-template-rows: minmax(120px, 35%) minmax(0, 1fr); }
+  .memory-rail { border-right: 0; border-bottom: 1px solid var(--border); }
+  .memory-tools { position: static; }
+  .memory-page { padding-top: 0; }
+  .memory-page .page-head { top: 0; padding: 10px 18px; flex-wrap: wrap; }
+  .memory-page .page-head .actions { flex-wrap: wrap; }
+  .memory-page .prose, .memory-page .editor { padding-inline: 18px; }
+}

--- a/web/src/app/features/instrument/memory/memory.css
+++ b/web/src/app/features/instrument/memory/memory.css
@@ -120,6 +120,7 @@
 .memory-page .page-head .path { color: var(--path); text-transform: none; letter-spacing: 0.02em; }
 .memory-page .page-head .actions { display: flex; align-items: center; gap: 10px; }
 .memory-page .page-head .status { color: var(--online); }
+.memory-page .page-head .status.is-error { color: var(--error); }
 .memory-page .page-head .ibtn { padding: 5px 10px; }
 .memory-page .page-head .ibtn kbd { margin-right: 6px; }
 .memory-page .prose {

--- a/web/src/app/features/instrument/memory/memoryQueries.test.ts
+++ b/web/src/app/features/instrument/memory/memoryQueries.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { QueryClient, QueryObserver } from "@tanstack/preact-query";
+import type { LibraryEntry, LibraryNote } from "../../gsv-console/library/libraryTypes";
+import { INSTRUMENT_MEMORY_KEY } from "../wire/queryKeys";
+import { refreshSavedMemoryPage } from "./memoryQueries";
+import type { MemorySearchResult } from "./memoryService";
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 15_000 } } });
+const pageKey = [...INSTRUMENT_MEMORY_KEY, "page", "personal", "personal/pages/example.md"];
+const pagesKey = [...INSTRUMENT_MEMORY_KEY, "pages", "personal"];
+const searchKey = [...INSTRUMENT_MEMORY_KEY, "search", "personal", "example"];
+const oldNote: LibraryNote = { path: "personal/pages/example.md", title: "Old title", markdown: "# Old title\n\nOld text." };
+const saved = { db: "personal", path: oldNote.path, markdown: "# New title\n\nSaved text." };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => { resolve = complete; });
+  return { promise, resolve };
+}
+
+afterEach(() => queryClient.clear());
+
+describe("Memory save cache refresh", () => {
+  it("keeps a saved page and invalidated search/list caches when pre-save requests finish after navigation", async () => {
+    const read = deferred<LibraryNote>();
+    const search = deferred<MemorySearchResult>();
+    const list = deferred<LibraryEntry[]>();
+    const originalSearch: MemorySearchResult = { entries: [], truncated: false };
+    queryClient.setQueryData(pageKey, oldNote);
+    queryClient.setQueryData(searchKey, originalSearch);
+    queryClient.setQueryData(pagesKey, []);
+    const observers = [
+      new QueryObserver(queryClient, { queryKey: pageKey, queryFn: () => read.promise, staleTime: 0 }),
+      new QueryObserver(queryClient, { queryKey: searchKey, queryFn: () => search.promise, staleTime: 0 }),
+      new QueryObserver(queryClient, { queryKey: pagesKey, queryFn: () => list.promise, staleTime: 0 }),
+    ];
+    const unsubscribe = observers.map((observer) => observer.subscribe(() => {}));
+    for (const key of [pageKey, searchKey, pagesKey]) {
+      expect(queryClient.getQueryState(key)?.fetchStatus).toBe("fetching");
+    }
+    unsubscribe.forEach((stop) => stop());
+    for (const key of [pageKey, searchKey, pagesKey]) {
+      expect(queryClient.getQueryCache().find({ queryKey: key })?.isActive()).toBe(false);
+    }
+
+    await refreshSavedMemoryPage(queryClient, saved);
+    read.resolve(oldNote);
+    const staleEntry: LibraryEntry = { kind: "file", path: oldNote.path, title: oldNote.title };
+    search.resolve({ entries: [staleEntry], truncated: false });
+    list.resolve([staleEntry]);
+    await Promise.all([read.promise, search.promise, list.promise]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(queryClient.getQueryData(pageKey)).toEqual({ path: saved.path, title: "New title", markdown: saved.markdown });
+    expect(queryClient.getQueryData(searchKey)).toEqual(originalSearch);
+    expect(queryClient.getQueryData(pagesKey)).toEqual([]);
+    for (const key of [pageKey, searchKey, pagesKey]) {
+      expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true);
+      expect(queryClient.getQueryState(key)?.fetchStatus).toBe("idle");
+    }
+  });
+
+  it("does not cancel a different collection's pending read", async () => {
+    const otherKey = [...INSTRUMENT_MEMORY_KEY, "page", "shared", "shared/pages/example.md"];
+    const otherNote: LibraryNote = { path: "shared/pages/example.md", title: "Shared", markdown: "Shared content." };
+    const read = deferred<LibraryNote>();
+    const observer = new QueryObserver(queryClient, { queryKey: otherKey, queryFn: () => read.promise });
+    const unsubscribe = observer.subscribe(() => {});
+    unsubscribe();
+
+    await refreshSavedMemoryPage(queryClient, saved);
+    expect(queryClient.getQueryState(otherKey)?.fetchStatus).toBe("fetching");
+    read.resolve(otherNote);
+    await read.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(queryClient.getQueryData(otherKey)).toEqual(otherNote);
+    expect(queryClient.getQueryState(otherKey)?.isInvalidated).toBe(false);
+  });
+
+  it("refetches an active saved page after retiring its earlier read", async () => {
+    const oldRead = deferred<LibraryNote>();
+    const savedNote: LibraryNote = { path: saved.path, title: "New title", markdown: saved.markdown };
+    let reads = 0;
+    queryClient.setQueryData(pageKey, oldNote);
+    const observer = new QueryObserver(queryClient, {
+      queryKey: pageKey,
+      staleTime: 0,
+      queryFn: () => ++reads === 1 ? oldRead.promise : Promise.resolve(savedNote),
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    await refreshSavedMemoryPage(queryClient, saved);
+    oldRead.resolve(oldNote);
+    await oldRead.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(reads).toBe(2);
+    expect(queryClient.getQueryData(pageKey)).toEqual(savedNote);
+    expect(queryClient.getQueryState(pageKey)?.isInvalidated).toBe(false);
+    unsubscribe();
+  });
+});

--- a/web/src/app/features/instrument/memory/memoryQueries.ts
+++ b/web/src/app/features/instrument/memory/memoryQueries.ts
@@ -1,0 +1,20 @@
+import type { QueryClient } from "@tanstack/preact-query";
+import { extractLibraryTitle } from "../../gsv-console/library/libraryModel";
+import type { LibrarySavePageInput } from "../../gsv-console/library/libraryTypes";
+import { INSTRUMENT_MEMORY_KEY } from "../wire/queryKeys";
+
+export async function refreshSavedMemoryPage(queryClient: QueryClient, input: LibrarySavePageInput): Promise<void> {
+  const affectedKeys = [
+    [...INSTRUMENT_MEMORY_KEY, "page", input.db],
+    [...INSTRUMENT_MEMORY_KEY, "pages", input.db],
+    [...INSTRUMENT_MEMORY_KEY, "search", input.db],
+  ];
+  // Inactive reads survive navigation; retire their results before publishing the save.
+  await Promise.all(affectedKeys.map((queryKey) => queryClient.cancelQueries({ queryKey })));
+  queryClient.setQueryData([...INSTRUMENT_MEMORY_KEY, "page", input.db, input.path], {
+    path: input.path,
+    title: extractLibraryTitle(input.markdown, input.path),
+    markdown: input.markdown,
+  });
+  await Promise.all(affectedKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })));
+}

--- a/web/src/app/features/instrument/memory/memoryService.test.ts
+++ b/web/src/app/features/instrument/memory/memoryService.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GSVClient } from "@humansandmachines/gsv/client";
+import type { RepoReadResult, RepoTreeEntry } from "@humansandmachines/gsv/protocol";
+import { listLibraryCollections } from "../../gsv-console/library/libraryService";
+import type { LibraryCollection } from "../../gsv-console/library/libraryTypes";
+import { listMemoryPages, readMemoryPage, searchMemory } from "./memoryService";
+
+const collection: LibraryCollection = {
+  id: "personal",
+  title: "Personal memory",
+  repo: "agent/knowledge",
+  writable: true,
+  updatedAt: null,
+};
+
+function memoryClient() {
+  return { call: vi.fn<GSVClient["call"]>(), request: vi.fn<GSVClient["request"]>() };
+}
+
+function tree(path: string, entries: Array<[string, RepoTreeEntry["type"]]>): RepoReadResult {
+  return {
+    repo: collection.repo,
+    ref: "HEAD",
+    path,
+    kind: "tree",
+    entries: entries.map(([name, type]) => ({
+      name,
+      path: path ? `${path}/${name}` : name,
+      type,
+      mode: type === "tree" ? "040000" : "100644",
+      hash: `hash:${name}`,
+    })),
+  };
+}
+
+function file(path: string, content: string | null, isBinary = false): RepoReadResult {
+  return {
+    repo: collection.repo,
+    ref: "HEAD",
+    path,
+    kind: "file",
+    content,
+    isBinary,
+    size: content?.length ?? 4,
+  };
+}
+
+describe("Memory repository browsing", () => {
+  it("discovers collections from manifests and retains the repository and permission", async () => {
+    const client = memoryClient();
+    client.call.mockResolvedValueOnce({ repos: [
+      { repo: "agent/knowledge", owner: "agent", name: "knowledge", kind: "user", writable: false, public: true },
+      { repo: "agent/code", owner: "agent", name: "code", kind: "user", writable: true, public: false },
+    ] });
+    client.call.mockResolvedValueOnce(file("wiki.json", JSON.stringify({ kind: "gsv.wiki", id: "personal", title: "Personal memory" })));
+    client.call.mockRejectedValueOnce(new Error("Path not found: wiki.json"));
+
+    expect(await listLibraryCollections(client)).toEqual([{ ...collection, writable: false }]);
+    expect(client.call.mock.calls).toEqual([
+      ["repo.list", {}],
+      ["repo.read", { repo: "agent/knowledge", path: "wiki.json" }],
+      ["repo.read", { repo: "agent/code", path: "wiki.json" }],
+    ]);
+  });
+
+  it("lists the overview and nested markdown pages without reading page contents", async () => {
+    const client = memoryClient();
+    client.call.mockResolvedValueOnce(tree("", [["wiki.json", "blob"], ["pages", "tree"], ["index.md", "blob"]]));
+    client.call.mockResolvedValueOnce(tree("pages", [["zebra.md", "blob"], ["nested", "tree"], [".dir", "blob"], ["alpha_note.MD", "blob"], ["image.png", "blob"]]));
+    client.call.mockResolvedValueOnce(tree("pages/nested", [["second-page.md", "blob"]]));
+
+    expect(await listMemoryPages(client, collection)).toEqual([
+      { kind: "file", path: "personal/index.md", title: "Overview" },
+      { kind: "file", path: "personal/pages/alpha_note.MD", title: "Alpha Note" },
+      { kind: "file", path: "personal/pages/nested/second-page.md", title: "Second Page" },
+      { kind: "file", path: "personal/pages/zebra.md", title: "Zebra" },
+    ]);
+    expect(client.call.mock.calls).toEqual([
+      ["repo.read", { repo: collection.repo, path: "" }],
+      ["repo.read", { repo: collection.repo, path: "pages" }],
+      ["repo.read", { repo: collection.repo, path: "pages/nested" }],
+    ]);
+  });
+
+  it("keeps the overview when a collection has no pages directory", async () => {
+    const client = memoryClient();
+    client.call.mockResolvedValueOnce(tree("", [["index.md", "blob"]]));
+    client.call.mockRejectedValueOnce(new Error("Path not found: pages"));
+
+    expect(await listMemoryPages(client, collection)).toEqual([
+      { kind: "file", path: "personal/index.md", title: "Overview" },
+    ]);
+  });
+
+  it.each([
+    "Forbidden: cannot read repo agent/knowledge",
+    "Repository not found: agent/knowledge",
+    "Gateway route not found",
+    "Request timed out",
+  ])("does not conceal repository or transport errors: %s", async (message) => {
+    const client = memoryClient();
+    const error = new Error(message);
+    client.call.mockRejectedValue(error);
+
+    await expect(listMemoryPages(client, collection)).rejects.toBe(error);
+    await expect(readMemoryPage(client, collection, "personal/pages/example.md")).rejects.toBe(error);
+  });
+});
+
+describe("Memory page reads", () => {
+  it("opens exactly one page in its collection repository and retains its complete markdown", async () => {
+    const client = memoryClient();
+    const markdown = "---\ntitle: Frontmatter\n---\n# Authored title\n\nOriginal body.\n";
+    client.call.mockResolvedValue(file("pages/nested/example.md", markdown));
+
+    expect(await readMemoryPage(client, collection, "personal/pages/nested/example.md")).toEqual({
+      path: "personal/pages/nested/example.md",
+      title: "Authored title",
+      markdown,
+    });
+    expect(client.call.mock.calls).toEqual([
+      ["repo.read", { repo: collection.repo, path: "pages/nested/example.md" }],
+    ]);
+  });
+
+  it("preserves a genuinely empty text page", async () => {
+    const client = memoryClient();
+    client.call.mockResolvedValue(file("pages/empty-page.md", ""));
+
+    expect(await readMemoryPage(client, collection, "personal/pages/empty-page.md")).toEqual({
+      path: "personal/pages/empty-page.md",
+      title: "Empty Page",
+      markdown: "",
+    });
+  });
+
+  it.each([true, false])("rejects unreadable content instead of offering an empty replacement (binary=%s)", async (isBinary) => {
+    const client = memoryClient();
+    client.call.mockResolvedValue(file("pages/binary.md", null, isBinary));
+
+    await expect(readMemoryPage(client, collection, "personal/pages/binary.md"))
+      .rejects.toThrow("This page is not readable text.");
+  });
+
+  it("returns no page for a removed path or a directory", async () => {
+    const client = memoryClient();
+    client.call.mockRejectedValueOnce(new Error("Path not found: pages/deleted.md"));
+    client.call.mockResolvedValueOnce(tree("pages", []));
+
+    expect(await readMemoryPage(client, collection, "personal/pages/deleted.md")).toBeNull();
+    expect(await readMemoryPage(client, collection, "personal/pages")).toBeNull();
+  });
+
+  it("rejects path traversal before issuing a repository read", async () => {
+    const client = memoryClient();
+
+    await expect(readMemoryPage(client, collection, "personal/pages/../../other.md"))
+      .rejects.toThrow("invalid library path");
+    expect(client.call).not.toHaveBeenCalled();
+  });
+
+  it("rejects a page from another collection before issuing a repository read", async () => {
+    const client = memoryClient();
+
+    await expect(readMemoryPage(client, collection, "shared/pages/example.md"))
+      .rejects.toThrow("This page does not belong to the selected collection.");
+    expect(client.call).not.toHaveBeenCalled();
+  });
+});
+
+describe("Memory repository search", () => {
+  it("groups and ranks gateway matches without reading pages and preserves partial-result status", async () => {
+    const client = memoryClient();
+    const firstLine = `  ${"x".repeat(170)}  `;
+    client.call.mockResolvedValue({
+      repo: collection.repo,
+      ref: "HEAD",
+      query: "lit:memory",
+      truncated: true,
+      matches: [
+        { path: "pages/zebra.md", line: 2, content: "zebra memory" },
+        { path: "index.md", line: 3, content: " overview memory " },
+        { path: "pages/alpha.MD", line: 4, content: firstLine },
+        { path: "pages/alpha.MD", line: 7, content: "second match" },
+        { path: "wiki.json", line: 1, content: "not a page" },
+      ],
+    });
+
+    expect(await searchMemory(client, collection, "lit:memory")).toEqual({
+      entries: [
+        { kind: "file", path: "personal/pages/alpha.MD", title: "Alpha", snippet: "x".repeat(160) },
+        { kind: "file", path: "personal/index.md", title: "Overview", snippet: "overview memory" },
+        { kind: "file", path: "personal/pages/zebra.md", title: "Zebra", snippet: "zebra memory" },
+      ],
+      truncated: true,
+    });
+    expect(client.call.mock.calls).toEqual([
+      ["repo.search", { repo: collection.repo, query: "lit:memory" }],
+    ]);
+  });
+
+  it("reports a complete empty search and propagates gateway failures", async () => {
+    const client = memoryClient();
+    const error = new Error("Search unavailable");
+    client.call.mockResolvedValueOnce({ repo: collection.repo, ref: "HEAD", query: "missing", matches: [] });
+    client.call.mockRejectedValueOnce(error);
+
+    expect(await searchMemory(client, collection, "missing")).toEqual({ entries: [], truncated: false });
+    await expect(searchMemory(client, collection, "memory")).rejects.toBe(error);
+  });
+});

--- a/web/src/app/features/instrument/memory/memoryService.ts
+++ b/web/src/app/features/instrument/memory/memoryService.ts
@@ -1,0 +1,100 @@
+import type { GSVClient } from "@humansandmachines/gsv/client";
+import { extractLibraryTitle, libraryPathInDb, libraryTitleFromPath, normalizeLibraryPath } from "../../gsv-console/library/libraryModel";
+import type { LibraryCollection, LibraryEntry, LibraryNote } from "../../gsv-console/library/libraryTypes";
+
+type MemoryClient = Pick<GSVClient, "call">;
+
+export type MemorySearchResult = { entries: LibraryEntry[]; truncated: boolean };
+
+/**
+ * Memory reads one thing per ask. The page list comes from the tree alone,
+ * titled from paths, so listing a collection reads no page; a page is read
+ * when it is opened; a search runs in the gateway over the repository and
+ * comes back as matches with their lines, so it reads no page either.
+ */
+
+async function treeEntries(client: MemoryClient, repo: string, path: string): Promise<Array<{ name: string; type: string }>> {
+  try {
+    const result = await client.call("repo.read", { repo, path });
+    return result.kind === "tree" ? result.entries : [];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("Path not found:")) return [];
+    throw error;
+  }
+}
+
+async function collectPages(client: MemoryClient, collection: LibraryCollection, localPath: string, out: LibraryEntry[]): Promise<void> {
+  const entries = await treeEntries(client, collection.repo, localPath);
+  for (const entry of [...entries].sort((left, right) => left.name.localeCompare(right.name))) {
+    if (entry.name === ".dir") continue;
+    const childPath = `${localPath}/${entry.name}`;
+    if (entry.type === "tree") {
+      await collectPages(client, collection, childPath, out);
+      continue;
+    }
+    if (!/\.md$/i.test(entry.name)) continue;
+    out.push({ kind: "file", path: `${collection.id}/${childPath}`, title: libraryTitleFromPath(childPath) });
+  }
+}
+
+/** The collection's pages, the overview first, without reading any of them. */
+export async function listMemoryPages(client: MemoryClient, collection: LibraryCollection): Promise<LibraryEntry[]> {
+  const pages: LibraryEntry[] = [];
+  const root = await treeEntries(client, collection.repo, "");
+  if (root.some((entry) => entry.name === "index.md" && entry.type !== "tree")) {
+    pages.push({ kind: "file", path: `${collection.id}/index.md`, title: "Overview" });
+  }
+  await collectPages(client, collection, "pages", pages);
+  return pages;
+}
+
+/** One page, read when opened. */
+export async function readMemoryPage(client: MemoryClient, collection: LibraryCollection, externalPath: string): Promise<LibraryNote | null> {
+  const path = normalizeLibraryPath(externalPath);
+  if (!path.startsWith(`${collection.id}/`)) {
+    throw new Error("This page does not belong to the selected collection.");
+  }
+  const localPath = libraryPathInDb(path, collection.id);
+  try {
+    const node = await client.call("repo.read", { repo: collection.repo, path: localPath });
+    if (node.kind !== "file") return null;
+    if (node.isBinary || node.content === null) {
+      throw new Error("This page is not readable text.");
+    }
+    const markdown = node.content;
+    return { path, title: extractLibraryTitle(markdown, path), markdown };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("Path not found:")) return null;
+    throw error;
+  }
+}
+
+/** Matches from the gateway's search over the repository, one entry per page with the first matching line as its snippet. */
+export async function searchMemory(client: MemoryClient, collection: LibraryCollection, query: string): Promise<MemorySearchResult> {
+  const result = await client.call("repo.search", { repo: collection.repo, query });
+  const byPath = new Map<string, LibraryEntry & { hits: number }>();
+  for (const match of result.matches) {
+    if (!/\.md$/i.test(match.path)) continue;
+    const externalPath = `${collection.id}/${match.path}`;
+    const existing = byPath.get(externalPath);
+    if (existing) {
+      existing.hits += 1;
+      continue;
+    }
+    byPath.set(externalPath, {
+      kind: "file",
+      path: externalPath,
+      title: match.path === "index.md" ? "Overview" : libraryTitleFromPath(match.path),
+      snippet: match.content.trim().slice(0, 160),
+      hits: 1,
+    });
+  }
+  return {
+    entries: [...byPath.values()]
+      .sort((left, right) => right.hits - left.hits || left.path.localeCompare(right.path))
+      .map(({ hits: _hits, ...entry }) => entry),
+    truncated: result.truncated === true,
+  };
+}

--- a/web/src/app/features/instrument/shared/InstrumentHeader.tsx
+++ b/web/src/app/features/instrument/shared/InstrumentHeader.tsx
@@ -1,0 +1,12 @@
+import type { ComponentChildren } from "preact";
+import { Wordmark } from "./Wordmark";
+
+export function InstrumentHeader({ status, children }: { status: ComponentChildren; children: ComponentChildren }) {
+  return (
+    <header class="instrument-top instrument-header">
+      <Wordmark />
+      <div class="instrument-heading">{status}</div>
+      <nav class="keys" aria-label="Views">{children}</nav>
+    </header>
+  );
+}

--- a/web/src/app/features/instrument/shared/navigation.ts
+++ b/web/src/app/features/instrument/shared/navigation.ts
@@ -1,0 +1,2 @@
+/** A Memory page uses the same collection-scoped path as the library. */
+export type MemoryPageRef = { db: string; path: string };

--- a/web/src/app/features/instrument/wire/queryKeys.ts
+++ b/web/src/app/features/instrument/wire/queryKeys.ts
@@ -3,3 +3,6 @@ export const INSTRUMENT_TARGETS_KEY = ["instrument", "targets"] as const;
 export const INSTRUMENT_PROCESSES_KEY = ["instrument", "processes"] as const;
 export const INSTRUMENT_LEDGER_KEY = ["instrument", "ledger"] as const;
 export const INSTRUMENT_LEDGER_PAGE = 60;
+
+/** Memory reads share their cache between the browser and references in Zen. */
+export const INSTRUMENT_MEMORY_KEY = ["instrument", "memory"] as const;

--- a/web/src/app/features/instrument/zen/ActivityWorking.tsx
+++ b/web/src/app/features/instrument/zen/ActivityWorking.tsx
@@ -1,0 +1,34 @@
+import type { Activity } from "./zenModel";
+
+export function ActivityWorking({ activity }: { activity: Activity }) {
+  return (
+    <div class="work-calls">
+      {activity.calls.map((call) => {
+        const shell = call.syscall === "shell.exec";
+        const code = call.syscall === "codemode.exec" || call.syscall === "codemode.run" || call.syscall === "CodeMode";
+        const subject = call.operation?.subject ?? (call.summary === call.syscall ? "" : call.summary);
+        const state = call.failed ? "failed" : !call.finished && !call.operation ? "running…" : "";
+        return (
+          <div key={call.callId} class={`work-call${shell ? " work-shell" : code ? " work-code" : " work-operation"}${call.failed ? " is-failed" : ""}`}>
+            {shell ? (
+              <pre class="work-command"><span class="shell-prompt">$</span> {call.summary}</pre>
+            ) : (
+              <div class="work-heading">
+                <span>{code ? "CodeMode" : call.operation?.label ?? call.syscall}</span>
+                {!code && subject ? <> <code class="work-subject">{subject}</code></> : null}
+                {call.operation?.detail ? <span class="work-detail"> · {call.operation.detail}</span> : null}
+                {state ? <span class="work-state"> · {state}</span> : null}
+              </div>
+            )}
+            {code && call.summary ? <pre class="work-source"><code>{call.summary}</code></pre> : null}
+            {call.output ? <>
+              {code ? <div class="work-output-label">output</div> : null}
+              <pre class="work-output">{call.output}</pre>
+            </> : null}
+            {shell && state ? <div class="work-state">{state}</div> : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/app/features/instrument/zen/Zen.tsx
+++ b/web/src/app/features/instrument/zen/Zen.tsx
@@ -22,7 +22,7 @@ import { INSTRUMENT_MEMORY_KEY, INSTRUMENT_TARGETS_KEY } from "../wire/queryKeys
 import type { MemoryPageRef } from "../shared/navigation";
 import { renderMarkdownHtml, escapeHtml } from "../shared/markdown";
 import { PromptLine, type PromptPlace } from "../shared/PromptLine";
-import { Wordmark } from "../shared/Wordmark";
+import { InstrumentHeader } from "../shared/InstrumentHeader";
 import {
   activityDuration,
   answerAttribution,
@@ -43,15 +43,13 @@ import {
   trimOutput,
   noteSummary,
   receiptDuration,
-  receiptPhrases,
-  receiptRunning,
+  receiptTargets,
   receiptSteps,
   CLOUD_PLACE_ID,
   RESOLVE_TAIL,
   type Activity,
   type Moment,
   type Place,
-  type ReceiptPhrase,
 } from "./zenModel";
 import "./zen.css";
 
@@ -133,8 +131,7 @@ function ActivityLine({
   const head = activity.live && running ? (
     <>
       <span class="pulse blink" />
-      on <span class="place">{label}</span>{" "}
-      <span class="n">· {running.syscall} {running.summary}</span>
+      {activity.you ? "you are using" : "using"} <span class="place">{label}</span>
     </>
   ) : (
     <>
@@ -184,45 +181,27 @@ function Receipt({ moment, places, collections, open, onToggle, onMemory, onFlee
   onMemory: ZenProps["onMemory"];
   onFleet: ZenProps["onFleet"];
 }) {
-  const phrases = receiptPhrases(moment);
-  const running = receiptRunning(moment);
+  const targets = receiptTargets(moment);
   const steps = receiptSteps(moment);
   const duration = receiptDuration(moment);
   const notes = moment.narration ? moment.narration.split(/\n\n+/).length : 0;
   const worked = moment.activities.filter((activity) => !activity.you);
   const pages = onMemory ? memoryPagesForMoment(moment, collections) : [];
-  const phrase = (entry: ReceiptPhrase) =>
-    entry.what === null ? (
-      <>
-        {entry.verb} {entry.count} {entry.noun}
-      </>
-    ) : (
-      <>
-        {entry.verb} <em>{entry.what}</em>
-      </>
-    );
   return (
     <div class={`receipt${open ? " is-open" : ""}`}>
       <div class="line">
         <button type="button" class="receipt-toggle" aria-expanded={open} onClick={onToggle}>
-          {running ? (
-            <span class="now">
-              <span class="pulse blink" />
-              {phrase(running)}
-            </span>
-          ) : null}
-          {phrases.map((entry, index) => (
-            <span key={index} class={entry.failed ? "is-failed" : ""}>
-              {index > 0 || running ? " · " : ""}
-              {phrase(entry)}
-              {entry.failed ? " · failed" : ""}
+          {targets.map((target, index) => (
+            <span key={target.target} class={target.live ? "now" : target.failed ? "is-failed" : ""}>
+              {index > 0 ? " · " : ""}
+              {target.live ? <span class="pulse blink" /> : null}
+              {target.live ? "using" : "used"} <span class="place">{placeLabel(target.target, places)}</span>
+              {target.failed ? " · failed" : ""}
             </span>
           ))}
-          <span class="n">
-            {steps > 0 ? ` · ${countLabel(steps, "step")}${duration ? `, ${duration}` : ""}` : ""}
-            {notes > 0 ? ` · ${countLabel(notes, "note")}` : ""}
-            {` · ${open ? "close" : "open"}`}
-          </span>
+          {targets.length === 0 ? (moment.narration ? (moment.thinking ? "thinking" : "thought it through") : "response details") : null}
+          {moment.attribution?.fallbacks.length ? <span class="is-failed"> · fallback used</span> : null}
+          <span class="n"> · {open ? "close" : "open"}</span>
         </button>
         {pages.length > 0 ? (
           <span class="memory-references"> · from your memory: {pages.map((page, index) => (
@@ -235,6 +214,21 @@ function Receipt({ moment, places, collections, open, onToggle, onMemory, onFlee
       </div>
       {open ? (
         <div class="detail">
+          <div class="receipt-meta">
+            {moment.attribution?.model ? <span class="answer-model" title={moment.attribution.provider ?? undefined}>answered by {moment.attribution.model}</span> : null}
+            {steps > 0 ? <span>{countLabel(steps, "step")}{duration ? ` · ${duration}` : ""}</span> : null}
+            {notes > 0 ? <span>{countLabel(notes, "note")}</span> : null}
+          </div>
+          {moment.attribution?.fallbacks.length ? (
+            <div class="zen-model-fallback">
+              {moment.attribution.fallbacks.map((fallback, index) => (
+                <span key={`${fallback.from}:${fallback.to}`} title={fallback.reason ?? undefined}>
+                  {index ? " · " : "fallback: "}{fallback.from} → {fallback.to}
+                </span>
+              ))}
+              {moment.attribution.omittedFallbacks ? ` · ${moment.attribution.omittedFallbacks} earlier` : ""}
+            </div>
+          ) : null}
           {worked.map((activity) => (
             <div key={activity.key} class="place-rail">
               <div class="ph">on {activity.target === "unknown target" ? placeLabel(activity.target, places) : (
@@ -741,10 +735,10 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
       }
       if (typing) return;
       const focused = browse !== null ? moments[browse] : latest;
-      if (event.key === "o" && focused && (focused.activities.length > 0 || focused.narration)) {
+      if (event.key === "o" && focused && (focused.activities.length > 0 || focused.narration || focused.attribution)) {
         event.preventDefault();
         const yours = focused.activities.filter((activity) => activity.you);
-        const worked = focused.role === "ship" && (focused.activities.some((activity) => !activity.you) || focused.narration);
+        const worked = focused.role === "ship" && (focused.activities.some((activity) => !activity.you) || focused.narration || focused.attribution);
         toggleActivity(worked ? `receipt:${focused.id}` : yours[yours.length - 1].key);
         return;
       }
@@ -829,13 +823,13 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
   }, [browse, connected, lastAnswer, lastRun, latest, localRuns, moments.length, now, pendingHil, pid, places, runtime.context, thinking, where]);
 
   const onlinePlaces = places.filter((place) => place.online);
+  const latestMessageIndex = moments.reduce((latest, moment, index) =>
+    moment.role === "human" || (moment.role === "ship" && (moment.text !== "" || moment.streaming)) ? index : latest, -1);
   const empty = ready && moments.length === 0 && pid !== null;
 
   return (
     <main class={`zen${browse !== null ? " is-browse" : ""}`} aria-label="Zen">
-      <div class="instrument-top">
-        <Wordmark />
-        <span>
+      <InstrumentHeader status={<span>
           ship ·{" "}
           <span class={connected ? "is-on" : "is-err"} style={connected ? "color: var(--online)" : "color: var(--error)"}>
             {pidProp ? (
@@ -851,24 +845,19 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
               "offline"
             )}
           </span>
-        </span>
-        <span class="keys">
+        </span>}>
+        <span aria-current="page">zen</span>
         <button type="button" onClick={() => onFleet()}>
           <kbd>z</kbd>fleet
-        </button>
-        <button type="button" onClick={onFirstDay}>
-          <kbd>n</kbd>first day
         </button>
         {onMemory ? (
           <button type="button" onClick={() => onMemory()}>
             <kbd>m</kbd>memory
           </button>
         ) : null}
-        <span>
-          <kbd>?</kbd>keys
-        </span>
-      </span>
-      </div>
+        <button type="button" onClick={onFirstDay}><kbd>n</kbd>first day</button>
+        <span><kbd>?</kbd>keys</span>
+      </InstrumentHeader>
 
       <div class="zen-body">
         <div class="zen-timeline" aria-hidden="true">
@@ -918,21 +907,10 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
                 );
               }
               return (
-                <div key={moment.id} data-index={index} class={`zen-moment ${moment.role === "human" ? "is-human" : "is-ship"}${pending ? " is-pending" : ""}${materialising ? " is-materialising" : ""}${isLatest ? "" : " is-older"}${browse === index ? " is-focus" : ""}`}>
-                  <div class="who">
+                <div key={moment.id} data-index={index} class={`zen-moment ${moment.role === "human" ? "is-human" : "is-ship"}${!moment.text && !moment.streaming ? " is-work" : ""}${pending ? " is-pending" : ""}${materialising ? " is-materialising" : ""}${index < latestMessageIndex ? " is-older" : ""}${browse === index ? " is-focus" : ""}`}>
+                  {moment.role === "human" || moment.text || moment.streaming ? <div class="who">
                     {moment.role === "human" ? who : "ship"}
-                    {moment.attribution?.model ? <span class="answer-model" title={moment.attribution.provider ?? undefined}> · {moment.attribution.model}</span> : null}
-                  </div>
-                  {moment.attribution?.fallbacks.length ? (
-                    <div class="zen-model-fallback">
-                      {moment.attribution.fallbacks.map((fallback, index) => (
-                        <span key={`${fallback.from}:${fallback.to}`} title={fallback.reason ?? undefined}>
-                          {index ? " · " : "fallback: "}{fallback.from} → {fallback.to}
-                        </span>
-                      ))}
-                      {moment.attribution.omittedFallbacks ? ` · ${moment.attribution.omittedFallbacks} earlier` : null}
-                    </div>
-                  ) : null}
+                  </div> : null}
                   {moment.activities
                     .filter((activity) => activity.you)
                     .map((activity) => (
@@ -945,6 +923,17 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
                         onFleet={onFleet}
                       />
                     ))}
+                  {moment.role === "ship" && (moment.activities.some((activity) => !activity.you) || moment.narration || moment.attribution) ? (
+                    <Receipt
+                      moment={moment}
+                      places={places}
+                      collections={memoryCollections.data ?? []}
+                      onMemory={onMemory}
+                      onFleet={onFleet}
+                      open={openActivities.has(`receipt:${moment.id}`)}
+                      onToggle={() => toggleActivity(`receipt:${moment.id}`)}
+                    />
+                  ) : null}
                   {moment.role === "human" ? (
                     settlePrefix(moment) !== null ? (
                       <div class="text is-settling">
@@ -970,17 +959,6 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
                     <div class="text">
                       <span class="zen-caret blink" />
                     </div>
-                  ) : null}
-                  {moment.role === "ship" && (moment.activities.some((activity) => !activity.you) || moment.narration) ? (
-                    <Receipt
-                      moment={moment}
-                      places={places}
-                      collections={memoryCollections.data ?? []}
-                      onMemory={onMemory}
-                      onFleet={onFleet}
-                      open={openActivities.has(`receipt:${moment.id}`)}
-                      onToggle={() => toggleActivity(`receipt:${moment.id}`)}
-                    />
                   ) : null}
                   {isLatest && pendingHil ? (
                     <div class="zen-approval">

--- a/web/src/app/features/instrument/zen/Zen.tsx
+++ b/web/src/app/features/instrument/zen/Zen.tsx
@@ -13,9 +13,13 @@ import {
 import { useChatConversation } from "../../chat/hooks/useChatConversation";
 import { useChatRuntime } from "../../chat/hooks/useChatRuntime";
 import { loadConsoleTargets } from "../../gsv-console/backend/consoleService";
+import { listLibraryCollections } from "../../gsv-console/library/libraryService";
+import { libraryTitleFromPath } from "../../gsv-console/library/libraryModel";
+import type { LibraryCollection } from "../../gsv-console/library/libraryTypes";
 import { executeTerminalCommand } from "../../terminal/backend/terminalService";
 import type { FleetRow } from "../Instrument";
-import { INSTRUMENT_TARGETS_KEY } from "../wire/queryKeys";
+import { INSTRUMENT_MEMORY_KEY, INSTRUMENT_TARGETS_KEY } from "../wire/queryKeys";
+import type { MemoryPageRef } from "../shared/navigation";
 import { renderMarkdownHtml, escapeHtml } from "../shared/markdown";
 import { PromptLine, type PromptPlace } from "../shared/PromptLine";
 import { Wordmark } from "../shared/Wordmark";
@@ -29,6 +33,7 @@ import {
   isStringValue,
   linkPlaceReferences,
   momentsFromConversation,
+  memoryPagesForMoment,
   parsePromptInput,
   PLACE_REFERENCE_PREFIX,
   placeLabel,
@@ -51,7 +56,7 @@ import {
 import "./zen.css";
 
 export type ZenProps = {
-  onMemory?: () => void;
+  onMemory?: (page?: MemoryPageRef) => void;
   /** Step back to Fleet, optionally landing on a row (a place mentioned in a response, for instance). */
   onFleet: (row?: FleetRow) => void;
   /** Open the first day: the places manifest with empty rows. */
@@ -115,11 +120,13 @@ function ActivityLine({
   places,
   open,
   onToggle,
+  onFleet,
 }: {
   activity: Activity;
   places: readonly Place[];
   open: boolean;
   onToggle: () => void;
+  onFleet: ZenProps["onFleet"];
 }) {
   const label = placeLabel(activity.target, places);
   const running = activity.calls.find((call) => !call.finished);
@@ -159,6 +166,7 @@ function ActivityLine({
       </div>
       {open ? (
         <div class="detail">
+          <button type="button" class="work-link" onClick={() => onFleet(`target:${activity.target}`)}>view {label} in fleet</button>
           <div class="machine-rail" dangerouslySetInnerHTML={{ __html: railHtml(activity) }} />
         </div>
       ) : null}
@@ -167,13 +175,22 @@ function ActivityLine({
 }
 
 /** One line under a ship's message: what it did, generated from its calls; the working opens beneath. */
-function Receipt({ moment, places, open, onToggle }: { moment: Moment; places: readonly Place[]; open: boolean; onToggle: () => void }) {
+function Receipt({ moment, places, collections, open, onToggle, onMemory, onFleet }: {
+  moment: Moment;
+  places: readonly Place[];
+  collections: readonly LibraryCollection[];
+  open: boolean;
+  onToggle: () => void;
+  onMemory: ZenProps["onMemory"];
+  onFleet: ZenProps["onFleet"];
+}) {
   const phrases = receiptPhrases(moment);
   const running = receiptRunning(moment);
   const steps = receiptSteps(moment);
   const duration = receiptDuration(moment);
   const notes = moment.narration ? moment.narration.split(/\n\n+/).length : 0;
   const worked = moment.activities.filter((activity) => !activity.you);
+  const pages = onMemory ? memoryPagesForMoment(moment, collections) : [];
   const phrase = (entry: ReceiptPhrase) =>
     entry.what === null ? (
       <>
@@ -186,43 +203,43 @@ function Receipt({ moment, places, open, onToggle }: { moment: Moment; places: r
     );
   return (
     <div class={`receipt${open ? " is-open" : ""}`}>
-      <div
-        class="line"
-        role="button"
-        tabIndex={0}
-        aria-expanded={open}
-        onClick={onToggle}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            onToggle();
-          }
-        }}
-      >
-        {running ? (
-          <span class="now">
-            <span class="pulse blink" />
-            {phrase(running)}
+      <div class="line">
+        <button type="button" class="receipt-toggle" aria-expanded={open} onClick={onToggle}>
+          {running ? (
+            <span class="now">
+              <span class="pulse blink" />
+              {phrase(running)}
+            </span>
+          ) : null}
+          {phrases.map((entry, index) => (
+            <span key={index} class={entry.failed ? "is-failed" : ""}>
+              {index > 0 || running ? " · " : ""}
+              {phrase(entry)}
+              {entry.failed ? " · failed" : ""}
+            </span>
+          ))}
+          <span class="n">
+            {steps > 0 ? ` · ${countLabel(steps, "step")}${duration ? `, ${duration}` : ""}` : ""}
+            {notes > 0 ? ` · ${countLabel(notes, "note")}` : ""}
+            {` · ${open ? "close" : "open"}`}
           </span>
+        </button>
+        {pages.length > 0 ? (
+          <span class="memory-references"> · from your memory: {pages.map((page, index) => (
+            <span key={`${page.db}:${page.path}`}>
+              {index > 0 ? ", " : ""}
+              <button type="button" class="work-link" title={page.path} onClick={() => onMemory?.(page)}>{page.path === `${page.db}/index.md` ? "Overview" : libraryTitleFromPath(page.path)}</button>
+            </span>
+          ))}</span>
         ) : null}
-        {phrases.map((entry, index) => (
-          <span key={index} class={entry.failed ? "is-failed" : ""}>
-            {index > 0 || running ? " · " : ""}
-            {phrase(entry)}
-            {entry.failed ? " · failed" : ""}
-          </span>
-        ))}
-        <span class="n">
-          {steps > 0 ? ` · ${countLabel(steps, "step")}${duration ? `, ${duration}` : ""}` : ""}
-          {notes > 0 ? ` · ${countLabel(notes, "note")}` : ""}
-          {` · ${open ? "close" : "open"}`}
-        </span>
       </div>
       {open ? (
         <div class="detail">
           {worked.map((activity) => (
             <div key={activity.key} class="place-rail">
-              <div class="ph">on {placeLabel(activity.target, places)}</div>
+              <div class="ph">on {activity.target === "unknown target" ? placeLabel(activity.target, places) : (
+                <button type="button" class="work-link" onClick={() => onFleet(`target:${activity.target}`)}>{placeLabel(activity.target, places)}</button>
+              )}</div>
               <div class="machine-rail" dangerouslySetInnerHTML={{ __html: railHtml(activity) }} />
             </div>
           ))}
@@ -232,6 +249,7 @@ function Receipt({ moment, places, open, onToggle }: { moment: Moment; places: r
               <div class="machine-rail narration">{moment.narration}</div>
             </div>
           ) : null}
+          {moment.processId ? <button type="button" class="work-link" onClick={() => onFleet(`proc:${moment.processId}`)}>view process</button> : null}
         </div>
       ) : null}
     </div>
@@ -486,6 +504,17 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
     return [...fromRuntime, ...fromLocal].sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
   }, [answerHistory, conversation.rows, localRuns, runtime.activeRunId, runtime.rows]);
 
+  const hasMemoryRead = moments.some((moment) => moment.activities.some((activity) =>
+    !activity.you && activity.target === "gsv" && activity.calls.some((call) =>
+      call.syscall === "fs.read" && call.finished && !call.failed && call.filePath?.startsWith("/src/repos/"),
+    ),
+  ));
+  const memoryCollections = useQuery({
+    queryKey: [...INSTRUMENT_MEMORY_KEY, "collections"],
+    queryFn: () => listLibraryCollections(client),
+    enabled: connected && Boolean(onMemory) && hasMemoryRead,
+  });
+
   const seenMomentsRef = useRef<Set<string> | null>(null);
   const streamedMomentsRef = useRef<Set<string>>(new Set());
   useLayoutEffect(() => {
@@ -655,14 +684,14 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
   }, [pendingHil]);
 
   useEffect(() => {
-    if (!prefill) return;
+    if (!prefill || !connected || !pid) return;
     const input = promptRef.current?.querySelector("input");
-    if (!input) return;
+    if (!input || input.disabled) return;
     input.value = prefill;
     input.focus();
     input.setSelectionRange(input.value.length, input.value.length);
     onPrefillUsed?.();
-  }, [prefill, onPrefillUsed]);
+  }, [prefill, onPrefillUsed, connected, pid]);
 
   const focusPrompt = useCallback(() => {
     promptRef.current?.querySelector("input")?.focus();
@@ -831,7 +860,7 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
           <kbd>n</kbd>first day
         </button>
         {onMemory ? (
-          <button type="button" onClick={onMemory}>
+          <button type="button" onClick={() => onMemory()}>
             <kbd>m</kbd>memory
           </button>
         ) : null}
@@ -913,6 +942,7 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
                         places={places}
                         open={openActivities.has(activity.key)}
                         onToggle={() => toggleActivity(activity.key)}
+                        onFleet={onFleet}
                       />
                     ))}
                   {moment.role === "human" ? (
@@ -945,6 +975,9 @@ export function Zen({ onFleet, onFirstDay, onMemory, prefill, onPrefillUsed, pid
                     <Receipt
                       moment={moment}
                       places={places}
+                      collections={memoryCollections.data ?? []}
+                      onMemory={onMemory}
+                      onFleet={onFleet}
                       open={openActivities.has(`receipt:${moment.id}`)}
                       onToggle={() => toggleActivity(`receipt:${moment.id}`)}
                     />

--- a/web/src/app/features/instrument/zen/Zen.tsx
+++ b/web/src/app/features/instrument/zen/Zen.tsx
@@ -102,10 +102,13 @@ function placesFromTargets(targets: Awaited<ReturnType<typeof loadConsoleTargets
 }
 
 function railHtml(activity: Activity): string {
-  const where = escapeHtml(activity.target);
+  const where = activity.target === null ? "" : escapeHtml(activity.target);
   return activity.calls
     .map((call) => {
-      const head = `<span class="cmd"><span class="where">${where}</span> <span class="dir">~</span> $ ${call.syscall === "shell.exec" ? escapeHtml(call.summary) : `${escapeHtml(call.syscall)} ${escapeHtml(call.summary)}`}</span>`;
+      const code = call.syscall === "codemode.exec" || call.syscall === "codemode.run" || call.syscall === "CodeMode";
+      const head = code
+        ? `<span class="cmd">CodeMode</span>${call.summary ? `\n${escapeHtml(call.summary)}` : ""}`
+        : `<span class="cmd"><span class="where">${where}</span> <span class="dir">~</span> $ ${call.syscall === "shell.exec" ? escapeHtml(call.summary) : `${escapeHtml(call.syscall)} ${escapeHtml(call.summary)}`}</span>`;
       const body = call.output ? `\n${escapeHtml(call.output)}` : call.finished ? "" : `\n<span class="meta">running…</span>`;
       const failed = call.failed ? `\n<span class="err">failed</span>` : "";
       return `${head}${body}${failed}`;
@@ -126,7 +129,7 @@ function ActivityLine({
   onToggle: () => void;
   onFleet: ZenProps["onFleet"];
 }) {
-  const label = placeLabel(activity.target, places);
+  const label = activity.target === null ? "process working" : placeLabel(activity.target, places);
   const running = activity.calls.find((call) => !call.finished);
   const head = activity.live && running ? (
     <>
@@ -163,7 +166,7 @@ function ActivityLine({
       </div>
       {open ? (
         <div class="detail">
-          <button type="button" class="work-link" onClick={() => onFleet(`target:${activity.target}`)}>view {label} in fleet</button>
+          {activity.target !== null ? <button type="button" class="work-link" onClick={() => onFleet(`target:${activity.target}`)}>view {label} in fleet</button> : null}
           <div class="machine-rail" dangerouslySetInnerHTML={{ __html: railHtml(activity) }} />
         </div>
       ) : null}
@@ -186,6 +189,7 @@ function Receipt({ moment, places, collections, open, onToggle, onMemory, onFlee
   const duration = receiptDuration(moment);
   const notes = moment.narration ? moment.narration.split(/\n\n+/).length : 0;
   const worked = moment.activities.filter((activity) => !activity.you);
+  const processWork = worked.filter((activity) => activity.target === null);
   const pages = onMemory ? memoryPagesForMoment(moment, collections) : [];
   return (
     <div class={`receipt${open ? " is-open" : ""}`}>
@@ -199,7 +203,8 @@ function Receipt({ moment, places, collections, open, onToggle, onMemory, onFlee
               {target.failed ? " · failed" : ""}
             </span>
           ))}
-          {targets.length === 0 ? (moment.narration ? (moment.thinking ? "thinking" : "thought it through") : "response details") : null}
+          {targets.length === 0 ? (processWork.length > 0 ? (processWork.some((activity) => activity.live) ? "working" : "worked") : moment.narration ? (moment.thinking ? "thinking" : "thought it through") : "response details") : null}
+          {processWork.some((activity) => activity.calls.some((call) => call.failed)) ? <span class="is-failed"> · work failed</span> : null}
           {moment.attribution?.fallbacks.length ? <span class="is-failed"> · fallback used</span> : null}
           <span class="n"> · {open ? "close" : "open"}</span>
         </button>
@@ -231,9 +236,9 @@ function Receipt({ moment, places, collections, open, onToggle, onMemory, onFlee
           ) : null}
           {worked.map((activity) => (
             <div key={activity.key} class="place-rail">
-              <div class="ph">on {activity.target === "unknown target" ? placeLabel(activity.target, places) : (
+              <div class="ph">{activity.target === null ? "working" : <>on {activity.target === "unknown target" ? placeLabel(activity.target, places) : (
                 <button type="button" class="work-link" onClick={() => onFleet(`target:${activity.target}`)}>{placeLabel(activity.target, places)}</button>
-              )}</div>
+              )}</>}</div>
               <div class="machine-rail" dangerouslySetInnerHTML={{ __html: railHtml(activity) }} />
             </div>
           ))}

--- a/web/src/app/features/instrument/zen/Zen.tsx
+++ b/web/src/app/features/instrument/zen/Zen.tsx
@@ -20,9 +20,10 @@ import { executeTerminalCommand } from "../../terminal/backend/terminalService";
 import type { FleetRow } from "../Instrument";
 import { INSTRUMENT_MEMORY_KEY, INSTRUMENT_TARGETS_KEY } from "../wire/queryKeys";
 import type { MemoryPageRef } from "../shared/navigation";
-import { renderMarkdownHtml, escapeHtml } from "../shared/markdown";
+import { renderMarkdownHtml } from "../shared/markdown";
 import { PromptLine, type PromptPlace } from "../shared/PromptLine";
 import { InstrumentHeader } from "../shared/InstrumentHeader";
+import { ActivityWorking } from "./ActivityWorking";
 import {
   activityDuration,
   answerAttribution,
@@ -101,21 +102,6 @@ function placesFromTargets(targets: Awaited<ReturnType<typeof loadConsoleTargets
   return targets.map((target) => ({ id: target.deviceId, label: target.label || target.deviceId, online: target.online }));
 }
 
-function railHtml(activity: Activity): string {
-  const where = activity.target === null ? "" : escapeHtml(activity.target);
-  return activity.calls
-    .map((call) => {
-      const code = call.syscall === "codemode.exec" || call.syscall === "codemode.run" || call.syscall === "CodeMode";
-      const head = code
-        ? `<span class="cmd">CodeMode</span>${call.summary ? `\n${escapeHtml(call.summary)}` : ""}`
-        : `<span class="cmd"><span class="where">${where}</span> <span class="dir">~</span> $ ${call.syscall === "shell.exec" ? escapeHtml(call.summary) : `${escapeHtml(call.syscall)} ${escapeHtml(call.summary)}`}</span>`;
-      const body = call.output ? `\n${escapeHtml(call.output)}` : call.finished ? "" : `\n<span class="meta">running…</span>`;
-      const failed = call.failed ? `\n<span class="err">failed</span>` : "";
-      return `${head}${body}${failed}`;
-    })
-    .join("\n\n");
-}
-
 function ActivityLine({
   activity,
   places,
@@ -167,7 +153,7 @@ function ActivityLine({
       {open ? (
         <div class="detail">
           {activity.target !== null ? <button type="button" class="work-link" onClick={() => onFleet(`target:${activity.target}`)}>view {label} in fleet</button> : null}
-          <div class="machine-rail" dangerouslySetInnerHTML={{ __html: railHtml(activity) }} />
+          <ActivityWorking activity={activity} />
         </div>
       ) : null}
     </div>
@@ -239,7 +225,7 @@ function Receipt({ moment, places, collections, open, onToggle, onMemory, onFlee
               <div class="ph">{activity.target === null ? "working" : <>on {activity.target === "unknown target" ? placeLabel(activity.target, places) : (
                 <button type="button" class="work-link" onClick={() => onFleet(`target:${activity.target}`)}>{placeLabel(activity.target, places)}</button>
               )}</>}</div>
-              <div class="machine-rail" dangerouslySetInnerHTML={{ __html: railHtml(activity) }} />
+              <ActivityWorking activity={activity} />
             </div>
           ))}
           {moment.narration ? (

--- a/web/src/app/features/instrument/zen/zen.css
+++ b/web/src/app/features/instrument/zen/zen.css
@@ -165,8 +165,19 @@
   padding-left: 12px;
   letter-spacing: 0.02em;
 }
-.receipt .line { cursor: pointer; }
-.receipt .line:hover { color: var(--text-hi); }
+.receipt-toggle, .zen .work-link {
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  color: inherit;
+  text-align: left;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+.receipt-toggle:hover, .zen .work-link:hover { color: var(--text-hi); }
+.zen .work-link { text-decoration: underline; text-underline-offset: 3px; }
 .receipt em { font-style: normal; color: var(--path); }
 .receipt .n { color: var(--faint); }
 .receipt .is-failed { color: var(--warn); }

--- a/web/src/app/features/instrument/zen/zen.css
+++ b/web/src/app/features/instrument/zen/zen.css
@@ -1,7 +1,7 @@
 /* Zen: the response is the page. */
 .zen {
   display: grid;
-  grid-template-rows: 44px minmax(0, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr) auto;
   height: 100%;
   min-height: 0;
   overflow: hidden;
@@ -42,7 +42,8 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-width: none;
-  padding: 5vh 0 6vh;
+  padding: calc(var(--instrument-header-height) + 5vh) 0 6vh;
+  scroll-padding-top: calc(var(--instrument-header-height) + 12px);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -57,6 +58,7 @@
   padding: 2.2vh 0;
 }
 .zen-moment.is-older { opacity: 0.55; }
+.zen-moment.is-work { padding-block: 1vh; }
 .zen-moment > .who {
   font-size: 11px;
   letter-spacing: 0.2em;
@@ -155,7 +157,7 @@
 
 /* the receipt under a ship's message: what it did, in words; the working opens beneath */
 .receipt {
-  margin-top: 10px;
+  margin: 0 0 12px;
   max-width: var(--measure-prose);
   font-family: var(--gsv-font-mono);
   font-size: 12px;
@@ -192,6 +194,8 @@
   margin-right: 8px;
 }
 .receipt .detail { margin-top: 8px; }
+.receipt-meta { display: flex; flex-wrap: wrap; gap: 6px 14px; color: var(--text-dim); }
+.receipt-meta:empty { display: none; }
 .receipt .ph { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--faint); margin: 10px 0 4px; }
 .receipt .place-rail:first-child .ph { margin-top: 0; }
 

--- a/web/src/app/features/instrument/zen/zen.css
+++ b/web/src/app/features/instrument/zen/zen.css
@@ -179,6 +179,8 @@
   cursor: pointer;
 }
 .receipt-toggle:hover, .zen .work-link:hover { color: var(--text-hi); }
+.receipt-toggle { color: var(--label); }
+.receipt-toggle .place { color: var(--target); }
 .zen .work-link { text-decoration: underline; text-underline-offset: 3px; }
 .receipt em { font-style: normal; color: var(--path); }
 .receipt .n { color: var(--faint); }

--- a/web/src/app/features/instrument/zen/zen.css
+++ b/web/src/app/features/instrument/zen/zen.css
@@ -199,6 +199,37 @@
 .receipt .ph { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--faint); margin: 10px 0 4px; }
 .receipt .place-rail:first-child .ph { margin-top: 0; }
 
+.work-calls { margin: 8px 0; display: grid; gap: 14px; }
+.work-call { min-width: 0; }
+.work-heading {
+  color: var(--text);
+  font-family: var(--gsv-font-prose);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+}
+.work-heading .work-subject { font-family: var(--gsv-font-mono); font-size: 12px; color: var(--path); white-space: pre-wrap; }
+.work-detail, .work-state { color: var(--text-dim); }
+.work-call.is-failed .work-state, .work-call.is-failed .work-output { color: var(--error); }
+.work-command, .work-source, .work-output {
+  margin: 0;
+  font-family: var(--gsv-font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--label);
+}
+.work-command, .work-source { color: var(--text-hi); }
+.work-source code { font: inherit; }
+.work-shell { border-left: 2px solid var(--border); padding-left: 12px; }
+.shell-prompt { color: var(--accent); }
+.work-operation .work-output { margin-top: 4px; }
+.work-code .work-source { margin-top: 6px; border-left: 2px solid var(--border); padding-left: 12px; }
+.work-code .work-output { padding-left: 12px; }
+.work-output-label { margin: 8px 0 4px; font-size: 10px; color: var(--faint); letter-spacing: 0.12em; text-transform: uppercase; }
+
 /* approvals: a boxed question with keys, as the TUI does it */
 .zen-approval {
   margin: 16px 0 4px;

--- a/web/src/app/features/instrument/zen/zenModel.test.ts
+++ b/web/src/app/features/instrument/zen/zenModel.test.ts
@@ -319,14 +319,22 @@ describe("filesystem operation presentation", () => {
     const search = present("fs.search", { ok: true, matches: [{ path: "/tmp/hit.txt", line: 2, content: "needle" }], count: 1 }, {
       toolArgs: { query: "needle", path: "/tmp", include: "*.txt" },
     });
-    expect(search.operation).toEqual({ label: "searched", subject: "needle in /tmp" });
-    expect(search.output).toBe("/tmp/hit.txt");
+    expect(search.operation).toEqual({ label: "searched", subject: "needle in /tmp", detail: "1 result" });
+    expect(search.output).toBe("");
     const noScope = present("fs.search", { ok: true, matches: [], count: 0 }, { toolArgs: { query: "needle" } });
-    expect(noScope.operation).toEqual({ label: "searched", subject: "needle" });
+    expect(noScope.operation).toEqual({ label: "searched", subject: "needle", detail: "0 results" });
+    expect(noScope.output).toBe("");
+    const truncated = present("fs.search", { ok: true, matches: [], count: 25, truncated: true }, { toolArgs: { query: "needle" } });
+    expect(truncated.operation).toEqual({ label: "searched", subject: "needle", detail: "25+ results" });
+    expect(truncated.output).toBe("");
     const unknown = present("fs.search", { matches: [] }, { toolArgs: { query: "needle", path: "/tmp" } });
     expect(unknown.operation?.label).toBe("search");
     const failed = present("fs.search", { ok: false, error: "search rejected" }, { toolArgs: { query: "needle", path: "/tmp" }, toolOutcome: "failed" });
     expect(failed).toMatchObject({ operation: { label: "search", subject: "needle in /tmp" }, output: "search rejected", failed: true });
+    const interrupted = present("fs.search", { ok: true, matches: [{ path: "/tmp/hit.txt", line: 2, content: "needle" }], count: 1 }, {
+      toolArgs: { query: "needle", path: "/tmp" }, toolOutcome: "failed", text: "search interrupted",
+    });
+    expect(interrupted).toMatchObject({ operation: { label: "search", subject: "needle in /tmp" }, output: "search interrupted", failed: true });
   });
 
   it("does not invent search terms or filesystem operations from tool text", () => {
@@ -342,7 +350,7 @@ describe("filesystem operation presentation", () => {
       row({ id: "result", role: "toolResult", status: "done", toolCallId: "search", toolSyscall: "fs.search", toolTarget: "gsv", toolOutcome: "completed", toolOutput: { ok: true, matches: [], count: 0 } }),
     ], "run", false)[0].calls;
     expect(calls).toHaveLength(1);
-    expect(calls[0].operation).toEqual({ label: "searched", subject: "needle in /tmp" });
+    expect(calls[0].operation).toEqual({ label: "searched", subject: "needle in /tmp", detail: "0 results" });
   });
 });
 

--- a/web/src/app/features/instrument/zen/zenModel.test.ts
+++ b/web/src/app/features/instrument/zen/zenModel.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { ProcHistoryRecord } from "@humansandmachines/gsv/protocol";
 import type { ChatTranscriptRow } from "../../chat/domain/transcript";
+import { mergeTranscriptRows } from "../../chat/domain/transcriptMerge";
+import { transcriptRowsFromRecords } from "../../chat/domain/typedHistory";
 import type { LibraryCollection } from "../../gsv-console/library/libraryTypes";
 import {
   activitiesForRows,
@@ -18,8 +20,7 @@ import {
   parsePromptInput,
   placeLabel,
   receiptDuration,
-  receiptPhrases,
-  receiptRunning,
+  receiptTargets,
   receiptSteps,
   resolvePlace,
   resolveTail,
@@ -347,10 +348,13 @@ describe("momentsFromConversation", () => {
       message({ id: "orphan-call", role: "tool", toolSyscall: "fs.read", runId: "working-run", processId: "worker", status: "running" }),
       message({ id: "event", role: "system", text: "Notice", processId: "event-owner" }),
     ], "working-run");
-    expect(moments.map((moment) => [moment.id, moment.processId])).toEqual([
-      ["old", "old-ship"], ["new", "new-ship"], ["human", "conversation-owner"],
-      ["event", "event-owner"], ["run:working-run", "worker"],
+    expect(moments.slice(0, 4).map((moment) => [moment.id, moment.processId])).toEqual([
+      ["old", "old-ship"], ["new", "new-ship"], ["human", "conversation-owner"], ["event", "event-owner"],
     ]);
+    expect(moments[0].narration).toBe("");
+    expect(moments[1].narration).toBe("New working");
+    expect(moments[4]).toMatchObject({ processId: "current-ship", text: "", narration: "Old working" });
+    expect(moments[5]).toMatchObject({ processId: "worker", thinking: true });
   });
   it("shows what the ship sent, folds what it told itself, and keeps the run's work", () => {
     const messages = [
@@ -374,6 +378,167 @@ describe("momentsFromConversation", () => {
     const moments = momentsFromConversation([], transcript, "r2");
     expect(moments).toHaveLength(1);
     expect(moments[0]).toMatchObject({ role: "ship", text: "", thinking: true, runId: "r2" });
+  });
+
+  const sent = (id: string, timestamp: number, overrides: Partial<ChatTranscriptRow> = {}) => message({
+    id: `conversation:${id}`, messageId: id, runId: "run", processId: "ship", text: id, timestamp, ...overrides,
+  });
+  const call = (id: string, timestamp: number, overrides: Partial<ChatTranscriptRow> = {}) => message({
+    id, role: "toolResult", text: "", toolCallId: id, toolSyscall: "fs.read", toolTarget: "gsv",
+    toolArgs: { path: `/pages/${id}.md` }, toolOutput: id, toolOutcome: "completed", status: "done",
+    runId: "run", processId: "ship", timestamp, ...overrides,
+  });
+  const outgoing = (id: string, key: string, timestamp: number) => message({
+    id: `history:${key}`, historyRecordKey: key, messageDirection: "out", conversationMessageId: id,
+    text: id, runId: "run", processId: "ship", timestamp,
+  });
+  const callsOf = (moment: Moment) => moment.activities.flatMap((activity) => activity.calls.map((entry) => entry.callId));
+
+  it("partitions two Sends and trailing work without duplicating narration or calls", () => {
+    const messages = [sent("first", 20), sent("second", 40)];
+    const transcript = [
+      call("before-first", 10), message({ id: "n1", runId: "run", processId: "ship", text: "First thought", timestamp: 11 }),
+      outgoing("first", "20:0", 20),
+      call("before-second", 30), message({ id: "n2", runId: "run", processId: "ship", text: "Second thought", timestamp: 31 }),
+      outgoing("second", "40:0", 40),
+      call("after-second", 50), message({ id: "n3", runId: "run", processId: "ship", text: "More work", timestamp: 51 }),
+      call("send-control", 52, { toolName: "Send", toolSyscall: null }),
+      call("shell-control", 53, { toolName: "Shell", toolSyscall: null, toolRunControl: true }),
+    ];
+    const moments = momentsFromConversation(messages, transcript, "run");
+    expect(moments.map((entry) => [entry.text, callsOf(entry), entry.narration])).toEqual([
+      ["first", ["before-first"], "First thought"],
+      ["second", ["before-second"], "Second thought"],
+      ["", ["after-second"], "More work"],
+    ]);
+    expect(moments.slice(0, 2).map(({ id, timestamp, processId }) => ({ id, timestamp, processId }))).toEqual([
+      { id: "conversation:first", timestamp: 20, processId: "ship" },
+      { id: "conversation:second", timestamp: 40, processId: "ship" },
+    ]);
+    expect(new Set(moments.flatMap((entry) => entry.activities.map((activity) => activity.key))).size).toBe(3);
+    const completed = momentsFromConversation(messages, transcript, null);
+    expect(completed.map((entry) => entry.id)).toEqual(moments.map((entry) => entry.id));
+    expect(completed.at(-1)?.thinking).toBe(false);
+    const next = momentsFromConversation([...messages, sent("third", 60)], transcript, null);
+    expect(next.map((entry) => [entry.text, callsOf(entry)])).toEqual([
+      ["first", ["before-first"]], ["second", ["before-second"]], ["third", ["after-second"]],
+    ]);
+  });
+
+  it("keeps interleaved processes and runs in their own message intervals", () => {
+    const messages = [sent("one", 20), sent("other-process", 30, { processId: "worker" }), sent("other-run", 35, { runId: "run2" }), sent("two", 50)];
+    const transcript = [call("a", 10), call("b", 15, { processId: "worker" }), call("c", 25, { runId: "run2" }), call("d", 40), call("e", 45, { processId: "worker" })];
+    const moments = momentsFromConversation(messages, transcript, null);
+    expect(moments.map((entry) => [entry.text, entry.processId, callsOf(entry)])).toEqual([
+      ["one", "ship", ["a"]], ["other-process", "worker", ["b"]], ["other-run", "ship", ["c"]],
+      ["", "worker", ["e"]], ["two", "ship", ["d"]],
+    ]);
+  });
+
+  it("uses durable call and outgoing coordinates when multiple Sends share one millisecond", () => {
+    const messages = [sent("first", 100, { conversationSequence: 1 }), sent("second", 100, { conversationSequence: 2 })];
+    const transcript = [
+      call("first-call", 300, { historyRecordKey: "9:0", toolCallRecordKey: "1:1", toolStartedAt: 100 }),
+      outgoing("first", "2:0", 100),
+      call("second-call", 300, { historyRecordKey: "10:0", toolCallRecordKey: "3:1", toolStartedAt: 100 }),
+      outgoing("second", "4:0", 100),
+      call("last-call", 300, { historyRecordKey: "11:0", toolCallRecordKey: "5:1", toolStartedAt: 99 }),
+    ];
+    const moments = momentsFromConversation(messages, transcript, null).sort((left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0));
+    expect(moments.map((entry) => [entry.text, callsOf(entry)])).toEqual([
+      ["first", ["first-call"]], ["second", ["second-call"]], ["", ["last-call"]],
+    ]);
+    expect(moments.at(-1)?.timestamp).toBe(100);
+    expect(moments.at(-1)?.activities[0].startedAt).toBe(99);
+  });
+
+  it("keeps a pending parallel call with the message it preceded when completion arrives after a later Send", () => {
+    const messages = [sent("first", 20), sent("second", 40)];
+    const pending = call("slow", 10, { role: "tool", status: "running", toolOutcome: undefined, toolOutput: undefined, toolTarget: "laptop" });
+    const between = call("quick", 30);
+    const before = momentsFromConversation(messages, [pending, between], "run");
+    expect(before.map(callsOf)).toEqual([["slow"], ["quick"]]);
+    expect(before[0].activities[0].live).toBe(true);
+    const result = call("slow", 60, { toolArgs: undefined, toolTarget: undefined, toolSyscall: undefined, toolOutput: "finished later" });
+    const after = momentsFromConversation(messages, [pending, between, result], "run");
+    expect(after.map(callsOf)).toEqual([["slow"], ["quick"]]);
+    expect(after[0].activities[0]).toMatchObject({ target: "laptop", startedAt: 10, endedAt: 60, live: false });
+    expect(after[0].activities[0].calls[0]).toMatchObject({ finished: true, output: "finished later", filePath: "/pages/slow.md" });
+    const reloaded = momentsFromConversation(messages, [{ ...result, toolStartedAt: 10, toolTarget: "laptop", toolSyscall: "fs.read", toolArgs: pending.toolArgs }, between], "run");
+    expect(reloaded).toEqual(after);
+  });
+
+  it("joins a streamed message to its committed identity without repeating its work", () => {
+    const streaming = sent("first", 20, { id: "stream:first", text: "Fir", streaming: true });
+    const committed = sent("first", 20, { text: "First answer", streaming: false });
+    const transcript = [call("a", 10), call("b", 30)];
+    const live = momentsFromConversation([streaming], transcript, "run");
+    const durable = momentsFromConversation([streaming, committed], [...transcript, outgoing("first", "20:0", 20)], "run");
+    expect(live.map(callsOf)).toEqual([["a"], ["b"]]);
+    expect(durable.map(callsOf)).toEqual([["a"], ["b"]]);
+    expect(durable[0]).toMatchObject({ id: committed.id, text: "First answer", streaming: false, timestamp: 20 });
+    expect(durable[1].id).toBe(live[1].id);
+    expect(momentsFromConversation([committed, streaming], transcript, "run")[0]).toMatchObject({ id: committed.id, streaming: false });
+  });
+
+  it("does not attach work before an unloaded Send to the next visible message", () => {
+    const moments = momentsFromConversation([sent("visible", 40)], [
+      call("old", 10), outgoing("unloaded", "20:0", 20), call("current", 30), outgoing("visible", "40:0", 40),
+    ], null);
+    expect(moments.map((entry) => [entry.text, callsOf(entry)])).toEqual([["", ["old"]], ["visible", ["current"]]]);
+  });
+
+  it("keeps same-millisecond unpersisted work in deterministic input order without merging distinct messages", () => {
+    const moments = momentsFromConversation([sent("first", 100), sent("second", 100)], [call("a", 100), call("b", 100)], null);
+    expect(moments.map((entry) => [entry.id, callsOf(entry)])).toEqual([
+      ["conversation:first", ["a", "b"]], ["conversation:second", []],
+    ]);
+  });
+
+  it("preserves call placement through actual typed projection and a partial live-result merge", () => {
+    const envelope = (messageId: number, createdAt: number) => ({
+      id: messageId, messageId, index: 0, generation: 1, runId: "run", createdAt, source: "typed" as const,
+    });
+    const before: ProcHistoryRecord[] = [
+      { ...envelope(1, 10), kind: "call", payload: { callId: "slow", tool: "Read", syscall: "fs.read", args: { path: "/pages/slow.md" }, target: "laptop", runId: "run" } },
+      { ...envelope(2, 20), kind: "message", payload: { direction: "out", text: "first", media: [], origin: {}, conversationMessageId: "first" } },
+    ];
+    const projected = transcriptRowsFromRecords(before).map((entry) => ({ ...entry, processId: "ship" }));
+    const messages = [sent("first", 20), sent("second", 40)];
+    const pending = momentsFromConversation(messages, projected, "run");
+    expect(pending.map(callsOf)).toEqual([["slow"], []]);
+    expect(pending[0].activities[0].live).toBe(true);
+    const merged = mergeTranscriptRows(projected, [row({
+      id: "finish", role: "toolResult", runId: "run", toolCallId: "slow", toolName: "Read", text: "", toolOutput: "finished", status: "done", timestamp: 60,
+    })]);
+    const live = momentsFromConversation(messages, merged, "run");
+    const after: ProcHistoryRecord[] = [...before,
+      { ...envelope(3, 40), kind: "message", payload: { direction: "out", text: "second", media: [], origin: {}, conversationMessageId: "second" } },
+      { ...envelope(4, 60), kind: "result", payload: { callId: "slow", tool: "Read", outcome: "completed", output: "finished", media: [], resources: [] } },
+    ];
+    const durable = momentsFromConversation(messages, transcriptRowsFromRecords(after).map((entry) => ({ ...entry, processId: "ship" })), "run");
+    expect(live).toEqual(durable);
+    expect(durable[0].activities[0]).toMatchObject({ startedAt: 10, endedAt: 60, target: "laptop", live: false });
+    expect(durable.map(callsOf)).toEqual([["slow"], []]);
+  });
+
+  it("retains distinct identities and unknown times for unlinked historical work", () => {
+    const moments = momentsFromConversation([], [
+      call("a", 1, { runId: undefined, timestamp: null }), call("b", 2, { runId: undefined, timestamp: null }),
+    ], null);
+    expect(moments.map(callsOf)).toEqual([["a"], ["b"]]);
+    expect(new Set(moments.map((entry) => entry.id)).size).toBe(2);
+    expect(moments.map((entry) => entry.timestamp)).toEqual([null, null]);
+  });
+
+  it("orders parallel calls by start while retaining the last completion time for the target", () => {
+    const moments = momentsFromConversation([sent("first", 20)], [
+      call("fast", 15, { toolStartedAt: 11 }), call("slow", 60, { toolStartedAt: 10 }),
+    ], null);
+    expect(moments).toHaveLength(1);
+    expect(callsOf(moments[0])).toEqual(["slow", "fast"]);
+    expect(moments[0].activities[0]).toMatchObject({ startedAt: 10, endedAt: 60 });
+    expect(receiptDuration(moments[0])).toBe(formatSeconds(50));
   });
 });
 
@@ -511,29 +676,40 @@ describe("receipt", () => {
     activities: activitiesForRows(rows, "run", active),
     narration: "",
   });
-  it("names each finished call by verb and place-qualified argument, in order", () => {
+  it("summarizes targets in first-touch order, retaining failure and expanded call details", () => {
     const rows = [
       row({ id: "t1", role: "toolResult", toolCallId: "1", toolSyscall: "fs.search", toolTarget: "gsv", toolArgs: { path: "~/mail", q: "statement" }, status: "done", timestamp: 100 }),
       row({ id: "t2", role: "toolResult", toolCallId: "2", toolSyscall: "fs.read", toolTarget: "laptop", toolArgs: { target: "laptop", path: "~/Downloads/Q2.pdf" }, status: "done", timestamp: 150 }),
       row({ id: "t3", role: "toolResult", toolCallId: "3", toolSyscall: "shell.exec", toolTarget: "laptop", toolArgs: { target: "laptop", input: "cp ~/Downloads/Q2.pdf ~/Documents/Taxes/" }, toolOutcome: "denied", status: "done", timestamp: 300 }),
     ];
     // places come in first-touch order, and each place's calls in theirs
-    expect(receiptPhrases(moment(rows)).map((phrase) => [phrase.verb, phrase.what, phrase.failed])).toEqual([
-      ["searched", "~/mail", false],
-      ["read", "laptop:~/Downloads/Q2.pdf", false],
-      ["ran", "cp ~/Downloads/Q2.pdf ~/Documents/Taxes/", true],
+    expect(receiptTargets(moment(rows))).toEqual([
+      { target: "gsv", live: false, failed: false },
+      { target: "laptop", live: false, failed: true },
     ]);
+    expect(moment(rows).activities[1].calls.map((call) => call.syscall)).toEqual(["fs.read", "shell.exec"]);
     expect(receiptSteps(moment(rows))).toBe(3);
     expect(receiptDuration(moment(rows))).toBe(formatSeconds(200));
   });
-  it("folds three or more alike calls into a count and keeps two apart", () => {
+  it("keeps one target summary for mixed work without discarding any calls", () => {
     const read = (id: string, path: string) => row({ id, role: "toolResult", toolCallId: id, toolSyscall: "fs.read", toolTarget: "gsv", toolArgs: { path }, status: "done", timestamp: 1 });
-    expect(receiptPhrases(moment([read("1", "a"), read("2", "b"), read("3", "c")]))).toEqual([{ verb: "read", what: null, count: 3, noun: "files", failed: false }]);
-    expect(receiptPhrases(moment([read("1", "a"), read("2", "b")])).map((phrase) => phrase.what)).toEqual(["a", "b"]);
+    const value = moment([read("1", "a"), read("2", "b"), read("3", "c")]);
+    expect(receiptTargets(value)).toEqual([{ target: "gsv", live: false, failed: false }]);
+    expect(value.activities[0].calls.map((call) => call.summary)).toEqual(["a", "b", "c"]);
   });
-  it("says what is still running in the present tense", () => {
+  it("identifies the target still in use and omits empty work", () => {
     const rows = [row({ id: "t1", role: "tool", toolCallId: "1", toolSyscall: "fs.read", toolTarget: "laptop", toolArgs: { target: "laptop", path: "~/x" }, status: "running" })];
-    expect(receiptRunning(moment(rows, true))).toMatchObject({ verb: "reading", what: "laptop:~/x" });
-    expect(receiptRunning(moment([]))).toBeNull();
+    expect(receiptTargets(moment(rows, true))).toEqual([{ target: "laptop", live: true, failed: false }]);
+    expect(receiptTargets(moment([]))).toEqual([]);
+  });
+  it("keeps every unfinished parallel target live when a later target has already finished", () => {
+    const value = moment([
+      row({ id: "a", role: "tool", toolCallId: "a", toolSyscall: "fs.read", toolTarget: "laptop", status: "running" }),
+      row({ id: "b", role: "tool", toolCallId: "b", toolSyscall: "fs.read", toolTarget: "office", status: "running" }),
+      row({ id: "c", role: "toolResult", toolCallId: "c", toolSyscall: "fs.read", toolTarget: "gsv", status: "done" }),
+    ], true);
+    expect(receiptTargets(value)).toEqual([
+      { target: "laptop", live: true, failed: false }, { target: "office", live: true, failed: false }, { target: "gsv", live: false, failed: false },
+    ]);
   });
 });

--- a/web/src/app/features/instrument/zen/zenModel.test.ts
+++ b/web/src/app/features/instrument/zen/zenModel.test.ts
@@ -240,6 +240,112 @@ describe("activitiesForRows", () => {
   });
 });
 
+describe("filesystem operation presentation", () => {
+  const present = (syscall: string, output: ChatTranscriptValue, overrides: Partial<ChatTranscriptRow> = {}) => activitiesForRows([row({
+    id: "operation", role: "toolResult", toolCallId: "operation", toolSyscall: syscall, toolTarget: "gsv",
+    toolArgs: { path: "/tmp/requested.txt" }, toolOutput: output, toolOutcome: "completed", status: "done", text: "original diagnostic",
+    ...overrides,
+  })], "run", false)[0].calls[0];
+
+  it("moves verified mutation confirmations into the heading using returned paths and counts", () => {
+    const cases: [string, ChatTranscriptValue, { label: string; subject: string; detail?: string }][] = [
+      ["fs.write", { ok: true, path: "/tmp/resolved.txt", size: 11 }, { label: "wrote", subject: "/tmp/resolved.txt", detail: "11 bytes" }],
+      ["fs.write", { ok: true, path: "/tmp/empty.txt", size: 0 }, { label: "wrote", subject: "/tmp/empty.txt", detail: "0 bytes" }],
+      ["fs.write", { ok: true, path: "/tmp/one.txt", size: 1 }, { label: "wrote", subject: "/tmp/one.txt", detail: "1 byte" }],
+      ["fs.edit", { ok: true, path: "/tmp/resolved.txt", replacements: 1 }, { label: "edited", subject: "/tmp/resolved.txt", detail: "1 replacement" }],
+      ["fs.edit", { ok: true, path: "/tmp/resolved.txt", replacements: 2 }, { label: "edited", subject: "/tmp/resolved.txt", detail: "2 replacements" }],
+      ["fs.delete", { ok: true, path: "/tmp/resolved.txt" }, { label: "deleted", subject: "/tmp/resolved.txt" }],
+    ];
+    for (const [syscall, output, operation] of cases) {
+      const call = present(syscall, output);
+      expect(call).toMatchObject({ operation, finished: true, failed: false, output: "" });
+      expect(outputText(syscall, output, "fallback")).not.toBe("");
+    }
+  });
+
+  it.each(["failed", "denied", "cancelled"] as const)("keeps %s operations neutral and retains the diagnostic body", (outcome) => {
+    for (const [syscall, label] of [["fs.write", "write"], ["fs.edit", "edit"], ["fs.delete", "delete"]]) {
+      expect(present(syscall, { ok: false, error: "permission denied" }, { toolOutcome: outcome })).toMatchObject({
+        operation: { label, subject: "/tmp/requested.txt" }, failed: true, output: "permission denied",
+      });
+    }
+  });
+
+  it("does not turn contradictory or unknown outcomes into successful headings or hide their result", () => {
+    const output = { ok: true, path: "/tmp/resolved.txt", size: 11 };
+    for (const overrides of [
+      { toolOutcome: undefined }, { toolOutcome: "failed" as const }, { isError: true }, { status: "error" as const },
+    ]) {
+      const call = present("fs.write", output, { ...overrides, text: "" });
+      expect(call.operation).toEqual({ label: "write", subject: "/tmp/requested.txt" });
+      expect(call.output).toBe(JSON.stringify(output, null, 2));
+    }
+  });
+
+  it("keeps the authoritative typed failure message when its output has a success shape", () => {
+    const result = present("fs.write", { ok: true, path: "/tmp/resolved.txt", size: 11 }, {
+      toolOutcome: "failed", text: "The returned result could not be retained.",
+    });
+    expect(result).toMatchObject({ operation: { label: "write", subject: "/tmp/requested.txt" }, failed: true,
+      output: "The returned result could not be retained.",
+    });
+  });
+
+  it("retains malformed mutation data instead of inferring success from the stored prose", () => {
+    const malformed: [string, ChatTranscriptValue, string][] = [
+      ["fs.write", { ok: true, path: "/tmp/resolved.txt", size: "11" }, "write"],
+      ["fs.edit", { ok: true, path: "/tmp/resolved.txt", replacements: -1 }, "edit"],
+      ["fs.delete", { ok: true }, "delete"],
+    ];
+    for (const [syscall, output, label] of malformed) {
+      expect(present(syscall, output, { text: "wrote 11 bytes" })).toMatchObject({
+        operation: { label, subject: "/tmp/requested.txt" }, output: "wrote 11 bytes",
+      });
+    }
+  });
+
+  it("describes running and planned operations without claiming completion", () => {
+    const output = { ok: true, path: "/tmp/resolved.txt", size: 11 };
+    const running = present("fs.write", output, { role: "tool", status: "running", toolOutcome: undefined });
+    expect(running).toMatchObject({ operation: { label: "writing", subject: "/tmp/requested.txt" }, finished: false, output: "" });
+    const planned = present("fs.delete", null, { role: "tool", status: "planning", toolOutcome: undefined });
+    expect(planned.operation).toEqual({ label: "delete", subject: "/tmp/requested.txt" });
+  });
+
+  it("keeps file content in the body and search query/path separate from matching results", () => {
+    const read = present("fs.read", { ok: true, path: "/tmp/requested.txt", kind: "text", content: "line one\nline two" });
+    expect(read.operation).toEqual({ label: "read", subject: "/tmp/requested.txt" });
+    expect(read.output).toBe("line one\nline two");
+    const search = present("fs.search", { ok: true, matches: [{ path: "/tmp/hit.txt", line: 2, content: "needle" }], count: 1 }, {
+      toolArgs: { query: "needle", path: "/tmp", include: "*.txt" },
+    });
+    expect(search.operation).toEqual({ label: "searched", subject: "needle in /tmp" });
+    expect(search.output).toBe("/tmp/hit.txt");
+    const noScope = present("fs.search", { ok: true, matches: [], count: 0 }, { toolArgs: { query: "needle" } });
+    expect(noScope.operation).toEqual({ label: "searched", subject: "needle" });
+    const unknown = present("fs.search", { matches: [] }, { toolArgs: { query: "needle", path: "/tmp" } });
+    expect(unknown.operation?.label).toBe("search");
+    const failed = present("fs.search", { ok: false, error: "search rejected" }, { toolArgs: { query: "needle", path: "/tmp" }, toolOutcome: "failed" });
+    expect(failed).toMatchObject({ operation: { label: "search", subject: "needle in /tmp" }, output: "search rejected", failed: true });
+  });
+
+  it("does not invent search terms or filesystem operations from tool text", () => {
+    const search = present("fs.search", { matches: [] }, { toolArgs: { q: "not query", path: "/tmp" }, text: "searched secret in /elsewhere" });
+    expect(search.operation).toEqual({ label: "search", subject: "in /tmp" });
+    expect(present("shell.exec", { stdout: "ok", exitCode: 0 }, { toolArgs: { input: "cat file", path: "/tmp" } }).operation).toBeUndefined();
+    expect(present("codemode.exec", { status: "completed", result: 1 }, { toolArgs: { code: "return 1;", path: "/tmp" } }).operation).toBeUndefined();
+  });
+
+  it("preserves the original search subject when the final result arrives without arguments", () => {
+    const calls = activitiesForRows([
+      row({ id: "search", role: "tool", status: "running", toolCallId: "search", toolSyscall: "fs.search", toolTarget: "gsv", toolArgs: { query: "needle", path: "/tmp" } }),
+      row({ id: "result", role: "toolResult", status: "done", toolCallId: "search", toolSyscall: "fs.search", toolTarget: "gsv", toolOutcome: "completed", toolOutput: { ok: true, matches: [], count: 0 } }),
+    ], "run", false)[0].calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].operation).toEqual({ label: "searched", subject: "needle in /tmp" });
+  });
+});
+
 describe("momentsFromRows", () => {
   it("retains originating process identities on messages, working moments, and events", () => {
     const moments = momentsFromRows([

--- a/web/src/app/features/instrument/zen/zenModel.test.ts
+++ b/web/src/app/features/instrument/zen/zenModel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ProcHistoryRecord } from "@humansandmachines/gsv/protocol";
 import type { ChatTranscriptRow } from "../../chat/domain/transcript";
+import type { LibraryCollection } from "../../gsv-console/library/libraryTypes";
 import {
   activitiesForRows,
   answerAttribution,
@@ -11,6 +12,7 @@ import {
   linkPlaceReferences,
   momentsFromRows,
   momentsFromConversation,
+  memoryPagesForMoment,
   isMessageSend,
   outputText,
   parsePromptInput,
@@ -238,6 +240,18 @@ describe("activitiesForRows", () => {
 });
 
 describe("momentsFromRows", () => {
+  it("retains originating process identities on messages, working moments, and events", () => {
+    const moments = momentsFromRows([
+      row({ id: "human", role: "user", text: "Look", processId: "previous-ship" }),
+      row({ id: "call", role: "tool", runId: "work", toolSyscall: "fs.read", toolTarget: "gsv", status: "running" }),
+      row({ id: "answer", role: "assistant", runId: "work", text: "Done", processId: "worker" }),
+      row({ id: "later", role: "assistant", runId: "work", text: "Still done", processId: "different-process" }),
+      row({ id: "event", role: "system", text: "An event", processId: "event-owner" }),
+    ], null);
+    expect(moments.map((moment) => [moment.role, moment.processId])).toEqual([
+      ["human", "previous-ship"], ["ship", "worker"], ["note", "event-owner"],
+    ]);
+  });
   it("folds a run into a human moment and one ship moment carrying its activities", () => {
     const rows = [
       row({ id: "u1", role: "user", text: "look around", runId: "r1", timestamp: 1 }),
@@ -322,6 +336,22 @@ describe("momentsFromConversation", () => {
   const message = (overrides: Partial<ChatTranscriptRow>): ChatTranscriptRow => ({
     id: "m", role: "assistant", text: "", time: "", timestamp: 1_000, ...overrides,
   });
+  it("keeps the canonical reply's process when joining another transcript and fills only absent identities", () => {
+    const moments = momentsFromConversation([
+      message({ id: "old", text: "Old answer", runId: "old-run", processId: "old-ship" }),
+      message({ id: "new", text: "New answer", runId: "new-run" }),
+      message({ id: "human", role: "user", text: "Question", processId: "conversation-owner" }),
+    ], [
+      message({ id: "old-note", text: "Old working", runId: "old-run", processId: "current-ship" }),
+      message({ id: "new-note", text: "New working", runId: "new-run", processId: "new-ship" }),
+      message({ id: "orphan-call", role: "tool", toolSyscall: "fs.read", runId: "working-run", processId: "worker", status: "running" }),
+      message({ id: "event", role: "system", text: "Notice", processId: "event-owner" }),
+    ], "working-run");
+    expect(moments.map((moment) => [moment.id, moment.processId])).toEqual([
+      ["old", "old-ship"], ["new", "new-ship"], ["human", "conversation-owner"],
+      ["event", "event-owner"], ["run:working-run", "worker"],
+    ]);
+  });
   it("shows what the ship sent, folds what it told itself, and keeps the run's work", () => {
     const messages = [
       message({ id: "u1", role: "user", text: "tidy my downloads", timestamp: 1_000 }),
@@ -344,6 +374,89 @@ describe("momentsFromConversation", () => {
     const moments = momentsFromConversation([], transcript, "r2");
     expect(moments).toHaveLength(1);
     expect(moments[0]).toMatchObject({ role: "ship", text: "", thinking: true, runId: "r2" });
+  });
+});
+
+describe("memoryPagesForMoment", () => {
+  const personal: LibraryCollection = { id: "personal", title: "Personal", repo: "owner/wiki", writable: true, updatedAt: null };
+  const read = (id: string, path: string, overrides: Partial<ChatTranscriptRow> = {}) => row({
+    id, role: "toolResult", toolCallId: id, toolSyscall: "fs.read", toolTarget: "gsv",
+    toolArgs: { path }, status: "done", toolOutcome: "completed", ...overrides,
+  });
+  const moment = (rows: ChatTranscriptRow[]): Moment => ({
+    id: "reply", role: "ship", text: "See personal/pages/example.md", streaming: false, thinking: false,
+    runId: "run", timestamp: 1, activities: activitiesForRows(rows, "run", false), narration: "",
+  });
+
+  it("resolves exact known pages after collection discovery and deduplicates repeated reads", () => {
+    const longPath = `pages/deep/${"long-name-".repeat(12)}.md`;
+    const value = moment([
+      read("overview", "/src/repos/owner/wiki/index.md"),
+      read("nested", `/src/repos/owner/wiki/${longPath}`),
+      read("again", "/src/repos/owner/wiki/index.md"),
+    ]);
+    expect(memoryPagesForMoment(value, [])).toEqual([]);
+    expect(memoryPagesForMoment(value, [personal])).toEqual([
+      { db: "personal", path: "personal/index.md" },
+      { db: "personal", path: `personal/${longPath}` },
+    ]);
+    expect(value.activities[0].calls[1].filePath).toBe(`/src/repos/owner/wiki/${longPath}`);
+  });
+
+  it("retains the exact Read path when its completion omits arguments", () => {
+    const path = "/src/repos/owner/wiki/pages/example.md";
+    const value = moment([
+      read("same-call", path, { role: "tool", status: "running", toolOutcome: undefined }),
+      read("same-call", path, { toolArgs: undefined }),
+    ]);
+    expect(value.activities[0].calls).toHaveLength(1);
+    expect(memoryPagesForMoment(value, [personal])).toEqual([{ db: "personal", path: "personal/pages/example.md" }]);
+  });
+
+  const ineligibleCalls: Partial<ChatTranscriptRow>[] = [
+    { role: "tool" as const, status: "running" as const, toolOutcome: undefined },
+    { toolOutcome: "failed" as const },
+    { toolOutcome: "denied" as const },
+    { toolOutcome: "cancelled" as const },
+    { isError: true },
+    { status: "error" as const },
+    { toolTarget: "laptop" },
+    { toolTarget: null },
+    { toolSyscall: "fs.write" },
+    { toolSyscall: "shell.exec", toolArgs: { input: "wiki read personal/pages/example.md" } },
+    { toolSyscall: "codemode.exec", toolArgs: { code: "read a wiki page" } },
+    { toolArgs: undefined, text: '{"path":"/src/repos/owner/wiki/pages/example.md"}', toolOutput: { path: "/src/repos/owner/wiki/pages/example.md" } },
+    { toolArgs: { path: 42 } },
+  ];
+  it.each(ineligibleCalls)("does not make a Memory link from an ineligible call: %j", (overrides) => {
+    expect(memoryPagesForMoment(moment([read("read", "/src/repos/owner/wiki/pages/example.md", overrides)]), [personal])).toEqual([]);
+  });
+
+  it("excludes direct user commands and text-only references", () => {
+    const value = moment([read("read", "/src/repos/owner/wiki/pages/example.md")]);
+    value.activities[0].you = true;
+    expect(memoryPagesForMoment(value, [personal])).toEqual([]);
+    expect(memoryPagesForMoment(moment([]), [personal])).toEqual([]);
+  });
+
+  it.each([
+    "personal/pages/example.md", "~/wiki/pages/example.md", "/src/repos/owner/unknown/pages/example.md",
+    "/src/repos/owner/wiki-extra/pages/example.md", "/src/repos/owner/wiki/README.md",
+    "/src/repos/owner/wiki/pages/example.txt", "/src/repos/owner/wiki/pages/folder",
+    "/src/repos/owner/wiki/pages/../index.md", "/src/repos/owner/wiki/pages/./example.md",
+    "/src/repos/owner/wiki/pages//example.md", "/src/repos/owner/wiki/pages/example.md/",
+    "/src/repos/owner/wiki/pages/example.md ", " /src/repos/owner/wiki/pages/example.md",
+    "/src/repos/owner/wiki/pages/\0example.md",
+  ])("rejects unmatched, non-page, or ambiguous path %j", (path) => {
+    const value = moment([read("read", path)]);
+    expect(value.activities[0].calls[0].filePath).toBe(path);
+    expect(memoryPagesForMoment(value, [personal])).toEqual([]);
+  });
+
+  it("does not choose between ambiguous repository or collection identities", () => {
+    const value = moment([read("read", "/src/repos/owner/wiki/pages/example.md")]);
+    expect(memoryPagesForMoment(value, [personal, { ...personal, id: "other" }])).toEqual([]);
+    expect(memoryPagesForMoment(value, [personal, { ...personal, repo: "other/wiki" }])).toEqual([]);
   });
 });
 

--- a/web/src/app/features/instrument/zen/zenModel.test.ts
+++ b/web/src/app/features/instrument/zen/zenModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ProcHistoryRecord } from "@humansandmachines/gsv/protocol";
-import type { ChatTranscriptRow } from "../../chat/domain/transcript";
+import type { ChatTranscriptRow, ChatTranscriptValue } from "../../chat/domain/transcript";
 import { mergeTranscriptRows } from "../../chat/domain/transcriptMerge";
 import { transcriptRowsFromRecords } from "../../chat/domain/typedHistory";
 import type { LibraryCollection } from "../../gsv-console/library/libraryTypes";
@@ -641,6 +641,55 @@ describe("outputText", () => {
     expect(outputText("shell.exec", { stdout: "", stderr: "no such file", exitCode: 1 }, "")).toBe("no such file");
     expect(outputText("shell.exec", { stdout: "", stderr: "", exitCode: 0 }, "")).toBe("");
     expect(outputText("shell.exec", { status: "completed", output: "total 21\ndrwxr-xr-x .gsv" }, "{json}")).toBe("total 21\ndrwxr-xr-x .gsv");
+  });
+  it("retains fallback for unknown or malformed shell results", () => {
+    expect(outputText("shell.exec", { status: "failed", error: "unrecognized failure" }, "fallback")).toBe("fallback");
+    expect(outputText("shell.exec", { stdout: 3 }, "fallback")).toBe("fallback");
+    expect(outputText("shell.exec", {}, "fallback")).toBe("fallback");
+  });
+  it.each(["codemode.exec", "codemode.run"])("shows %s logs, return values, and failures without treating returned data as a shell envelope", (syscall) => {
+    expect(outputText(syscall, { status: "completed", result: "hello", logs: ["first", "second"] }, "fallback")).toBe("first\nsecond\nhello");
+    expect(outputText(syscall, { status: "completed", result: false }, "fallback")).toBe("false");
+    expect(outputText(syscall, { status: "completed", result: 0 }, "fallback")).toBe("0");
+    expect(outputText(syscall, { status: "completed", result: null }, "fallback")).toBe("completed");
+    expect(outputText(syscall, { status: "completed", result: null, logs: ["logged"] }, "fallback")).toBe("logged");
+    expect(outputText(syscall, { status: "completed", result: "" }, "fallback")).toBe('""');
+    const returned = { stdout: "ordinary field", output: "also ordinary", exitCode: 0, values: [false, 0] };
+    expect(outputText(syscall, { status: "completed", result: returned }, "fallback")).toBe(JSON.stringify(returned, null, 2));
+    const literal = '{"stdout":"literal JSON-looking string"}';
+    expect(outputText(syscall, { status: "completed", result: literal }, "fallback")).toBe(literal);
+    expect(outputText(syscall, { status: "failed", error: "execution failed", logs: ["before failure"] }, "fallback")).toBe("before failure\nexecution failed");
+    expect(outputText(syscall, { status: "failed", error: "execution failed" }, "fallback")).toBe("execution failed");
+  });
+  it.each(["codemode.exec", "codemode.run"])("retains fallback for unknown or malformed %s results", (syscall) => {
+    const outputs: ChatTranscriptValue[] = [
+      {}, { status: "completed" }, { status: "completed", output: "not a CodeMode result" },
+      { status: "completed", result: 1, logs: [false] }, { status: "failed", error: false },
+      { status: "running", result: 1 }, { stdout: "not a CodeMode result" },
+    ];
+    for (const output of outputs) {
+      expect(outputText(syscall, output, "fallback")).toBe("fallback");
+    }
+    const literal = '{"status":"completed","result":1}';
+    expect(outputText(syscall, literal, "fallback")).toBe(literal);
+    expect(outputText("codemode.other", { status: "completed", result: 1 }, "fallback")).toBe("fallback");
+  });
+  it("describes successful filesystem mutations with correct counts", () => {
+    expect(outputText("fs.write", { ok: true, path: "/note.md", size: 11 }, "fallback")).toBe("wrote 11 bytes");
+    expect(outputText("fs.write", { ok: true, path: "/note.md", size: 1 }, "fallback")).toBe("wrote 1 byte");
+    expect(outputText("fs.write", { ok: true, path: "/note.md", size: 0 }, "fallback")).toBe("wrote 0 bytes");
+    expect(outputText("fs.edit", { ok: true, path: "/note.md", replacements: 1 }, "fallback")).toBe("replaced 1 occurrence");
+    expect(outputText("fs.edit", { ok: true, path: "/note.md", replacements: 2 }, "fallback")).toBe("replaced 2 occurrences");
+    expect(outputText("fs.edit", { ok: true, path: "/note.md", replacements: 0 }, "fallback")).toBe("replaced 0 occurrences");
+    expect(outputText("fs.delete", { ok: true, path: "/note.md" }, "fallback")).toBe("deleted");
+  });
+  it("retains fallback for malformed filesystem mutation results", () => {
+    expect(outputText("fs.write", { ok: true, path: "/note.md", size: "11" }, "fallback")).toBe("fallback");
+    expect(outputText("fs.write", { ok: true, size: 11 }, "fallback")).toBe("fallback");
+    expect(outputText("fs.write", { ok: true, path: "/note.md", size: -1 }, "fallback")).toBe("fallback");
+    expect(outputText("fs.edit", { ok: true, path: "/note.md", replacements: 1.5 }, "fallback")).toBe("fallback");
+    expect(outputText("fs.edit", { ok: false, path: "/note.md", replacements: 1, error: 1 }, "fallback")).toBe("fallback");
+    expect(outputText("fs.delete", { ok: true }, "fallback")).toBe("fallback");
   });
   it("renders typed output independently of JSON-looking row text", () => {
     const row: ChatTranscriptRow = { id: "t", role: "toolResult", text: "{\"output\":\"misleading prose\"}", toolOutput: { status: "completed", output: "hello\nworld" }, time: "", timestamp: 1, toolSyscall: "shell.exec", toolArgs: { input: "echo" } };

--- a/web/src/app/features/instrument/zen/zenModel.ts
+++ b/web/src/app/features/instrument/zen/zenModel.ts
@@ -67,6 +67,7 @@ export type ActivityCall = {
   output: string;
   finished: boolean;
   failed: boolean;
+  operation?: { label: string; subject: string; detail?: string };
   /** The original structured Read path, before display shortening. */
   filePath?: string;
 };
@@ -203,6 +204,30 @@ const fileEditResultSchema = z.object({ ok: z.literal(true), path: z.string(), r
 const fileDeleteResultSchema = z.object({ ok: z.literal(true), path: z.string() });
 const fileResultSchema = z.object({ content: z.string().optional(), entries: z.array(z.object({ name: z.string(), kind: z.string().optional() })).optional() });
 const searchResultSchema = z.object({ results: z.array(z.object({ path: z.string() })).optional(), matches: z.array(z.object({ path: z.string() })).optional() });
+const fileSearchResultSchema = z.object({ ok: z.literal(true), matches: z.array(z.object({ path: z.string(), line: z.number(), content: z.string() })), count: z.number().int().nonnegative() });
+const filesystemOperationVerbs = new Map([
+  ["fs.read", ["read", "reading", "read"]],
+  ["fs.write", ["write", "writing", "wrote"]],
+  ["fs.edit", ["edit", "editing", "edited"]],
+  ["fs.delete", ["delete", "deleting", "deleted"]],
+  ["fs.search", ["search", "searching", "searched"]],
+]);
+
+function mutationConfirmation(syscall: string, output: ChatTranscriptValue | undefined): { path: string; detail?: string } | null {
+  if (syscall === "fs.write") {
+    const result = fileWriteResultSchema.safeParse(output);
+    return result.success ? { path: result.data.path, detail: countLabel(result.data.size, "byte") } : null;
+  }
+  if (syscall === "fs.edit") {
+    const result = fileEditResultSchema.safeParse(output);
+    return result.success ? { path: result.data.path, detail: countLabel(result.data.replacements, "replacement") } : null;
+  }
+  if (syscall === "fs.delete") {
+    const result = fileDeleteResultSchema.safeParse(output);
+    return result.success ? { path: result.data.path } : null;
+  }
+  return null;
+}
 
 /** The tool result as a person would read it: stdout and stderr for a command, content or names for files, never the transport JSON. */
 export function outputText(syscall: string, output: ChatTranscriptValue | undefined, fallback: string): string {
@@ -268,7 +293,7 @@ function callFromRow(row: ChatTranscriptRow): ActivityCall {
   const syscall = row.toolSyscall ?? (row.toolName === "CodeMode" ? "codemode.exec" : row.toolName ?? "call");
   const finished = row.role === "toolResult" || row.status === "done" || row.status === "error";
   const summary = argumentThatMatters(syscall, row.toolArgs) || (row.toolName === "CodeMode" ? "" : row.toolName ?? syscall);
-  return {
+  const call: ActivityCall = {
     callId: row.toolCallId ?? row.id,
     syscall,
     summary,
@@ -277,6 +302,27 @@ function callFromRow(row: ChatTranscriptRow): ActivityCall {
     finished,
     failed: row.isError === true || row.status === "error" || (row.toolOutcome !== undefined && row.toolOutcome !== "completed"),
   };
+  const verb = filesystemOperationVerbs.get(syscall);
+  if (!verb) return call;
+  const completed = finished && !call.failed && row.toolOutcome === "completed";
+  const path = stringField(row.toolArgs, "path") ?? "";
+  call.operation = { label: !finished && !call.failed && row.status === "running" ? verb[1] : verb[0], subject: path };
+  if (syscall === "fs.search") {
+    const query = stringField(row.toolArgs, "query") ?? "";
+    call.operation.subject = [query, path ? `in ${path}` : ""].filter(Boolean).join(" ");
+    if (completed && fileSearchResultSchema.safeParse(row.toolOutput).success) call.operation.label = verb[2];
+  } else if (syscall !== "fs.read") {
+    const result = mutationConfirmation(syscall, row.toolOutput);
+    if (completed && result) {
+      call.operation.label = verb[2];
+      call.operation.subject = result.path;
+      if (result.detail) call.operation.detail = result.detail;
+      call.output = "";
+    } else if (finished && result) {
+      call.output = trimOutput(row.text || JSON.stringify(row.toolOutput, null, 2));
+    }
+  }
+  return call;
 }
 
 function isToolRow(row: ChatTranscriptRow): boolean {
@@ -307,6 +353,9 @@ export function activitiesForRows(rows: readonly ChatTranscriptRow[], runKey: st
       const index = existing.calls.findIndex((candidate) => candidate.callId === call.callId);
       if (index >= 0) {
         if (call.syscall === "fs.read" && row.toolArgs === undefined) call.filePath ??= existing.calls[index].filePath;
+        if (call.operation && !call.operation.subject && row.toolArgs === undefined) {
+          call.operation.subject = existing.calls[index].operation?.subject ?? "";
+        }
         existing.calls[index] = call;
       }
       else existing.calls.push(call);

--- a/web/src/app/features/instrument/zen/zenModel.ts
+++ b/web/src/app/features/instrument/zen/zenModel.ts
@@ -73,7 +73,7 @@ export type ActivityCall = {
 
 export type Activity = {
   key: string;
-  target: string;
+  target: string | null;
   calls: ActivityCall[];
   live: boolean;
   you: boolean;
@@ -174,6 +174,7 @@ function stringField(value: ChatTranscriptValue | undefined, key: string): strin
 /** The target a tool call touched: an explicit `target` argument, else the cloud home. */
 /** The one argument a person wants to see: the command, the path, the URL, or the tool's name. */
 export function argumentThatMatters(syscall: string, args: ChatTranscriptValue | undefined): string {
+  if (syscall === "codemode.exec" || syscall === "codemode.run" || syscall === "CodeMode") return stringField(args, "code") ?? "";
   const input = stringField(args, "input") ?? stringField(args, "command");
   if (input && syscall.startsWith("shell.")) return input;
   const path = stringField(args, "path");
@@ -189,9 +190,17 @@ export function trimOutput(text: string): string {
   return `${clean.slice(0, OUTPUT_LIMIT)}\n… ${clean.length - OUTPUT_LIMIT} more characters`;
 }
 
-const shellResultSchema = z.object({ stdout: z.string().optional(), stderr: z.string().optional(), exitCode: z.number().nullable().optional() });
+const shellResultSchema = z.object({ stdout: z.string().optional(), stderr: z.string().optional(), exitCode: z.number().nullable().optional() })
+  .refine((value) => value.stdout !== undefined || value.stderr !== undefined || value.exitCode !== undefined);
 const commandResultSchema = z.object({ status: z.string().optional(), output: z.string() });
+const codeModeResultSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("completed"), result: z.json(), logs: z.array(z.string()).optional() }),
+  z.object({ status: z.literal("failed"), error: z.string(), logs: z.array(z.string()).optional() }),
+]);
 const fileOperationErrorSchema = z.object({ ok: z.literal(false), error: z.string() });
+const fileWriteResultSchema = z.object({ ok: z.literal(true), path: z.string(), size: z.number().int().nonnegative() });
+const fileEditResultSchema = z.object({ ok: z.literal(true), path: z.string(), replacements: z.number().int().nonnegative() });
+const fileDeleteResultSchema = z.object({ ok: z.literal(true), path: z.string() });
 const fileResultSchema = z.object({ content: z.string().optional(), entries: z.array(z.object({ name: z.string(), kind: z.string().optional() })).optional() });
 const searchResultSchema = z.object({ results: z.array(z.object({ path: z.string() })).optional(), matches: z.array(z.object({ path: z.string() })).optional() });
 
@@ -202,7 +211,18 @@ export function outputText(syscall: string, output: ChatTranscriptValue | undefi
     const error = fileOperationErrorSchema.safeParse(output);
     if (error.success) return error.data.error;
   }
-  if (syscall === "shell.exec" || syscall.startsWith("codemode.")) {
+  if (syscall === "codemode.exec" || syscall === "codemode.run") {
+    const code = codeModeResultSchema.safeParse(output);
+    if (code.success) {
+      const logs = code.data.logs?.join("\n") ?? "";
+      const result = code.data.status === "failed" ? code.data.error
+        : code.data.result === null ? ""
+        : isStringValue(code.data.result) && code.data.result !== "" ? code.data.result
+        : JSON.stringify(code.data.result, null, 2);
+      return [logs, result].filter((text) => text !== "").join("\n") || code.data.status;
+    }
+  }
+  if (syscall === "shell.exec") {
     const command = commandResultSchema.safeParse(output);
     if (command.success) return command.data.output;
     const shell = shellResultSchema.safeParse(output);
@@ -213,6 +233,18 @@ export function outputText(syscall: string, output: ChatTranscriptValue | undefi
       const exit = shell.data.exitCode;
       return text.trim() ? text : exit === 0 || exit === null || exit === undefined ? "" : `exit ${exit}`;
     }
+  }
+  if (syscall === "fs.write") {
+    const file = fileWriteResultSchema.safeParse(output);
+    if (file.success) return `wrote ${file.data.size} ${file.data.size === 1 ? "byte" : "bytes"}`;
+  }
+  if (syscall === "fs.edit") {
+    const file = fileEditResultSchema.safeParse(output);
+    if (file.success) return `replaced ${file.data.replacements} ${file.data.replacements === 1 ? "occurrence" : "occurrences"}`;
+  }
+  if (syscall === "fs.delete") {
+    const file = fileDeleteResultSchema.safeParse(output);
+    if (file.success) return "deleted";
   }
   if (syscall === "fs.read") {
     const file = fileResultSchema.safeParse(output);
@@ -233,9 +265,9 @@ export function outputText(syscall: string, output: ChatTranscriptValue | undefi
 /** Some rows carry the result as a JSON string in their text; read it as the result it is.
  * TODO: remove once process history stores tool results structured (typed history records) instead of the model-facing text. */
 function callFromRow(row: ChatTranscriptRow): ActivityCall {
-  const syscall = row.toolSyscall ?? row.toolName ?? "call";
+  const syscall = row.toolSyscall ?? (row.toolName === "CodeMode" ? "codemode.exec" : row.toolName ?? "call");
   const finished = row.role === "toolResult" || row.status === "done" || row.status === "error";
-  const summary = argumentThatMatters(syscall, row.toolArgs) || (row.toolName ?? syscall);
+  const summary = argumentThatMatters(syscall, row.toolArgs) || (row.toolName === "CodeMode" ? "" : row.toolName ?? syscall);
   return {
     callId: row.toolCallId ?? row.id,
     syscall,
@@ -265,7 +297,8 @@ export function activitiesForRows(rows: readonly ChatTranscriptRow[], runKey: st
   const activities: Activity[] = [];
   for (const row of rows) {
     if (!isToolRow(row) || isMessageSend(row)) continue;
-    const target = row.toolTarget ?? "unknown target";
+    const target = row.toolSyscall === "codemode.exec" || row.toolSyscall === "codemode.run" || (row.toolSyscall == null && row.toolName === "CodeMode")
+      ? null : row.toolTarget ?? "unknown target";
     const call = callFromRow(row);
     const existing = activities.find((activity) => activity.target === target);
     const timestamp = row.timestamp ?? null;
@@ -281,7 +314,7 @@ export function activitiesForRows(rows: readonly ChatTranscriptRow[], runKey: st
       if (timestamp !== null) existing.endedAt = Math.max(existing.endedAt ?? timestamp, timestamp);
     } else {
       activities.push({
-        key: `${runKey}:${target}`,
+        key: JSON.stringify([runKey, target]),
         target,
         calls: [call],
         live: false,
@@ -447,7 +480,7 @@ export function countLabel(count: number, singular: string, plural = `${singular
 }
 
 export function placesUsed(moment: Moment): number {
-  return new Set(moment.activities.map((activity) => activity.target)).size;
+  return new Set(moment.activities.flatMap((activity) => activity.target === null ? [] : [activity.target])).size;
 }
 
 /* ---------- streaming text resolving out of ramp glyphs ---------- */
@@ -656,7 +689,7 @@ export function momentsFromConversation(
 /* the receipt: what a ship moment did, in plain words, generated from its calls */
 
 export function receiptTargets(moment: Moment): { target: string; live: boolean; failed: boolean }[] {
-  return moment.activities.filter((activity) => !activity.you).map((activity) => ({
+  return moment.activities.filter((activity): activity is Activity & { target: string } => !activity.you && activity.target !== null).map((activity) => ({
     target: activity.target,
     live: activity.live,
     failed: activity.calls.some((call) => call.failed),

--- a/web/src/app/features/instrument/zen/zenModel.ts
+++ b/web/src/app/features/instrument/zen/zenModel.ts
@@ -269,6 +269,7 @@ export function activitiesForRows(rows: readonly ChatTranscriptRow[], runKey: st
     const call = callFromRow(row);
     const existing = activities.find((activity) => activity.target === target);
     const timestamp = row.timestamp ?? null;
+    const startedAt = row.toolStartedAt ?? timestamp;
     if (existing) {
       const index = existing.calls.findIndex((candidate) => candidate.callId === call.callId);
       if (index >= 0) {
@@ -276,7 +277,8 @@ export function activitiesForRows(rows: readonly ChatTranscriptRow[], runKey: st
         existing.calls[index] = call;
       }
       else existing.calls.push(call);
-      if (timestamp !== null) existing.endedAt = timestamp;
+      if (startedAt !== null) existing.startedAt = Math.min(existing.startedAt ?? startedAt, startedAt);
+      if (timestamp !== null) existing.endedAt = Math.max(existing.endedAt ?? timestamp, timestamp);
     } else {
       activities.push({
         key: `${runKey}:${target}`,
@@ -284,15 +286,12 @@ export function activitiesForRows(rows: readonly ChatTranscriptRow[], runKey: st
         calls: [call],
         live: false,
         you: false,
-        startedAt: timestamp,
+        startedAt,
         endedAt: timestamp,
       });
     }
   }
-  if (active && activities.length > 0) {
-    const last = activities[activities.length - 1];
-    last.live = last.calls.some((call) => !call.finished);
-  }
+  for (const activity of activities) activity.live = active && activity.calls.some((call) => !call.finished);
   return activities;
 }
 
@@ -515,10 +514,50 @@ export function momentsFromConversation(
   activeRunId: string | null,
 ): Moment[] {
   const moments: Moment[] = [];
-  const shipByRun = new Map<string, Moment>();
+  const processesByRun = new Map<string, Set<string>>();
+  for (const row of [...messages, ...transcript]) {
+    if (!row.runId || !row.processId) continue;
+    const processes = processesByRun.get(row.runId) ?? new Set<string>();
+    processes.add(row.processId);
+    processesByRun.set(row.runId, processes);
+  }
+  type Position = { record: [number, number] | null; timestamp: number | null };
+  type Boundary = { id: string; position: Position; row: ChatTranscriptRow; moment?: Moment };
+  type Work = { position: Position; rows: ChatTranscriptRow[] };
+  type Run = { key: string; processId?: string; runId: string | null; boundaries: Boundary[]; work: Work[]; calls: Map<string, Work> };
+  const runs = new Map<string, Run>();
+  const runFor = (row: ChatTranscriptRow): Run => {
+    const candidates = row.runId ? processesByRun.get(row.runId) : undefined;
+    const processId = row.processId ?? (candidates?.size === 1 ? [...candidates][0] : undefined);
+    const key = JSON.stringify([processId ?? null, row.runId ?? null, row.runId ? null : row.toolCallId ?? row.id]);
+    let run = runs.get(key);
+    if (!run) {
+      run = { key, processId, runId: row.runId ?? null, boundaries: [], work: [], calls: new Map() };
+      runs.set(key, run);
+    }
+    return run;
+  };
+  const position = (row: ChatTranscriptRow, call = false): Position => {
+    const key = call ? row.toolCallRecordKey ?? row.historyRecordKey : row.historyRecordKey;
+    const match = key ? /^(\d+):(\d+)$/.exec(key) : null;
+    return {
+      record: match ? [Number(match[1]), Number(match[2])] : null,
+      timestamp: call ? row.toolStartedAt ?? row.timestamp : row.timestamp,
+    };
+  };
+  const compare = (left: Position, right: Position): number => {
+    if (left.record && right.record) return left.record[0] - right.record[0] || left.record[1] - right.record[1];
+    return (left.timestamp ?? Infinity) - (right.timestamp ?? Infinity);
+  };
+  const canonical = new Map<string, ChatTranscriptRow>();
   for (const row of messages) {
     if (row.role !== "user" && row.role !== "assistant") continue;
-    if (row.role === "assistant" && !row.text.trim() && !row.streaming) continue;
+    const key = JSON.stringify([row.role, row.messageId ?? row.id]);
+    const previous = canonical.get(key);
+    if (!previous || previous.streaming || !row.streaming) canonical.set(key, row);
+  }
+  for (const row of canonical.values()) {
+    if (row.role === "assistant" && !row.text.trim() && !row.streaming && !row.media?.length) continue;
     const moment: Moment = {
       id: row.id,
       role: row.role === "user" ? "human" : "ship",
@@ -532,146 +571,96 @@ export function momentsFromConversation(
       narration: "",
     };
     moments.push(moment);
-    if (moment.role === "ship" && moment.runId) shipByRun.set(moment.runId, moment);
+    if (moment.role === "ship" && moment.runId) {
+      const run = runFor(row);
+      moment.processId ??= run.processId;
+      run.boundaries.push({ id: String(row.messageId ?? row.id), position: position(row), row, moment });
+    }
   }
 
-  const toolRowsByRun = new Map<string, ChatTranscriptRow[]>();
-  const narrationByRun = new Map<string, string[]>();
-  const runStarted = new Map<string, number | null>();
-  const processByRun = new Map<string, string>();
-  transcript.forEach((row, index) => {
+  for (const row of transcript) {
     if (row.role === "system" && row.text.trim()) {
-      if (row.event?.audience === "model" && row.event.kind !== "history.compacted") return;
+      if (row.event?.audience === "model" && row.event.kind !== "history.compacted") continue;
       moments.push({ id: row.id, role: "note", event: row.event, text: row.text, streaming: false, thinking: false, runId: row.runId ?? null, processId: row.processId, timestamp: row.timestamp ?? null, activities: [], narration: "" });
-      return;
+      continue;
     }
-    const runKey = runKeyOf(row, index);
-    if (!runStarted.has(runKey)) runStarted.set(runKey, row.timestamp ?? null);
-    if (row.processId && !processByRun.has(runKey)) processByRun.set(runKey, row.processId);
-    if (isToolRow(row)) {
-      const bucket = toolRowsByRun.get(runKey) ?? [];
-      bucket.push(row);
-      toolRowsByRun.set(runKey, bucket);
-    } else if (row.role === "assistant" && row.messageDirection !== "out" && row.text.trim()) {
-      const bucket = narrationByRun.get(runKey) ?? [];
-      bucket.push(row.text.trim());
-      narrationByRun.set(runKey, bucket);
+    if (row.messageDirection === "out") {
+      if (!row.runId || !row.conversationMessageId) continue;
+      const run = runFor(row);
+      const boundary = run.boundaries.find((entry) => entry.id === row.conversationMessageId);
+      if (boundary) boundary.position.record = position(row).record;
+      else run.boundaries.push({ id: row.conversationMessageId, position: position(row), row });
+      continue;
     }
-  });
-
-  const runKeys = new Set([...toolRowsByRun.keys(), ...narrationByRun.keys()]);
-  for (const runKey of runKeys) {
-    const toolRows = toolRowsByRun.get(runKey) ?? [];
-    const active = activeRunId !== null && runKey === activeRunId;
-    let moment = shipByRun.get(runKey);
-    if (!moment) {
-      // a run that has not sent anything yet, or never did: it still shows what it did
-      moment = { id: `run:${runKey}`, role: "ship", text: "", streaming: false, thinking: active, runId: runKey, timestamp: runStarted.get(runKey) ?? null, activities: [], narration: "" };
-      moments.push(moment);
-      shipByRun.set(runKey, moment);
+    if (isToolRow(row) && !isMessageSend(row)) {
+      const run = runFor(row);
+      const key = row.toolCallId ?? row.id;
+      const existing = run.calls.get(key);
+      const start = position(row, true);
+      if (existing) {
+        existing.rows.push(row);
+        if (compare(start, existing.position) < 0) existing.position = start;
+      } else {
+        const work = { position: start, rows: [row] };
+        run.calls.set(key, work);
+        run.work.push(work);
+      }
+    } else if (row.role === "assistant" && row.text.trim()) {
+      runFor(row).work.push({ position: position(row), rows: [row] });
     }
-    moment.processId ??= processByRun.get(runKey);
-    moment.activities = toolRows.length > 0 ? activitiesForRows(toolRows, runKey, active) : [];
-    moment.narration = (narrationByRun.get(runKey) ?? []).join("\n\n");
-    if (moment.thinking && (moment.activities.length > 0 || moment.narration)) moment.thinking = active;
   }
 
+  for (const run of runs.values()) {
+    run.boundaries.sort((left, right) => compare(left.position, right.position)
+      || (left.row.conversationSequence ?? Infinity) - (right.row.conversationSequence ?? Infinity));
+    run.work.sort((left, right) => compare(left.position, right.position));
+    const segments = new Map<Boundary | undefined, Work[]>();
+    for (const work of run.work) {
+      const boundary = run.boundaries.find((entry) => compare(work.position, entry.position) <= 0);
+      const segment = segments.get(boundary) ?? [];
+      segment.push(work);
+      segments.set(boundary, segment);
+    }
+    for (const [boundary, work] of segments) {
+      const previous = boundary ? run.boundaries[run.boundaries.indexOf(boundary) - 1] : run.boundaries.at(-1);
+      const active = activeRunId !== null && run.runId === activeRunId;
+      let moment = boundary?.moment;
+      if (!moment) {
+        // a run that has not sent anything yet, or never did: it still shows what it did
+        moment = {
+          id: `work:${JSON.stringify([run.key, boundary ? ["before", boundary.id] : ["after", previous?.id ?? null]])}`,
+          role: "ship", text: "", streaming: false, thinking: active, runId: run.runId, processId: run.processId,
+          timestamp: work[0].position.timestamp, activities: [], narration: "",
+        };
+        if (previous?.moment?.timestamp !== undefined && previous.moment.timestamp !== null) {
+          moment.timestamp = Math.max(moment.timestamp ?? previous.moment.timestamp, previous.moment.timestamp);
+        }
+        moments.push(moment);
+      }
+      const tools = work.filter((entry) => isToolRow(entry.rows[0])).map((entry) => {
+        const terminal = entry.rows.filter((row) => row.role === "toolResult" || row.status === "done" || row.status === "error");
+        const result = terminal.at(-1) ?? entry.rows.at(-1)!;
+        const call = entry.rows.find((row) => row.role === "tool") ?? entry.rows[0];
+        return {
+          ...result, toolArgs: result.toolArgs ?? call.toolArgs, toolTarget: result.toolTarget ?? call.toolTarget,
+          toolSyscall: result.toolSyscall ?? call.toolSyscall, toolStartedAt: entry.position.timestamp,
+        };
+      });
+      moment.activities = activitiesForRows(tools, moment.id, active);
+      moment.narration = work.filter((entry) => entry.rows[0].role === "assistant").map((entry) => entry.rows[0].text.trim()).join("\n\n");
+    }
+  }
   return moments.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
 }
 
 /* the receipt: what a ship moment did, in plain words, generated from its calls */
 
-type ReceiptVerb = { past: string; present: string; noun: string };
-const verb = (past: string, present: string, noun: string): ReceiptVerb => ({ past, present, noun });
-const RECEIPT_VERBS = new Map<string, ReceiptVerb>([
-  ["fs.read", verb("read", "reading", "files")],
-  ["fs.write", verb("wrote", "writing", "files")],
-  ["fs.edit", verb("edited", "editing", "files")],
-  ["fs.delete", verb("deleted", "deleting", "files")],
-  ["fs.list", verb("listed", "listing", "folders")],
-  ["fs.search", verb("searched", "searching", "searches")],
-  ["fs.grep", verb("searched", "searching", "searches")],
-  ["fs.copy", verb("copied", "copying", "files")],
-  ["fs.stat", verb("checked", "checking", "files")],
-  ["fs.transfer.send", verb("sent", "sending", "files")],
-  ["shell.exec", verb("ran", "running", "commands")],
-  ["codemode.exec", verb("ran code", "running code", "scripts")],
-  ["net.fetch", verb("fetched", "fetching", "pages")],
-]);
-
-/** The words that stand for a syscall; an unknown one keeps its own name, which is still true. */
-function receiptVerb(syscall: string, present: boolean): [verb: string, noun: string] {
-  const known = RECEIPT_VERBS.get(syscall);
-  if (known) return [present ? known.present : known.past, known.noun];
-  return [present ? `${syscall}…` : syscall, "steps"];
-}
-
-function shortenMiddle(text: string, max = 48): string {
-  if (text.length <= max) return text;
-  const head = Math.ceil((max - 1) / 2);
-  const tail = Math.floor((max - 1) / 2);
-  return `${text.slice(0, head)}…${text.slice(-tail)}`;
-}
-
-/** The one argument a person wants to see, qualified by its place when that place is not the cloud home. */
-function receiptWhat(syscall: string, summary: string, target: string): string {
-  if (!summary) return "";
-  if (syscall.startsWith("net.")) {
-    try {
-      return new URL(summary).host;
-    } catch {
-      return shortenMiddle(summary);
-    }
-  }
-  const qualified = syscall.startsWith("fs.") && target !== CLOUD_PLACE_ID ? `${target}:${summary}` : summary;
-  return shortenMiddle(qualified);
-}
-
-export type ReceiptPhrase = {
-  verb: string;
-  /** The argument shown; null when three or more alike calls were folded into a count. */
-  what: string | null;
-  count: number;
-  noun: string;
-  failed: boolean;
-};
-
-const RECEIPT_FOLD_AT = 3;
-
-/** Finished calls as phrases, in order; a run of three or more with the same verb folds into a count. */
-export function receiptPhrases(moment: Moment): ReceiptPhrase[] {
-  const singles: ReceiptPhrase[] = [];
-  for (const activity of moment.activities) {
-    if (activity.you) continue;
-    for (const call of activity.calls) {
-      if (!call.finished) continue;
-      const [verb, noun] = receiptVerb(call.syscall, false);
-      singles.push({ verb, what: receiptWhat(call.syscall, call.summary, activity.target), count: 1, noun, failed: call.failed });
-    }
-  }
-  const phrases: ReceiptPhrase[] = [];
-  let index = 0;
-  while (index < singles.length) {
-    let end = index + 1;
-    while (end < singles.length && singles[end].verb === singles[index].verb && !singles[end].failed && !singles[index].failed) end += 1;
-    const run = end - index;
-    if (run >= RECEIPT_FOLD_AT) phrases.push({ ...singles[index], what: null, count: run });
-    else phrases.push(...singles.slice(index, end));
-    index = end;
-  }
-  return phrases;
-}
-
-/** The call still running, in the present tense, or null when nothing is. */
-export function receiptRunning(moment: Moment): ReceiptPhrase | null {
-  for (const activity of moment.activities) {
-    if (activity.you) continue;
-    const call = activity.calls.find((entry) => !entry.finished);
-    if (!call) continue;
-    const [verb, noun] = receiptVerb(call.syscall, true);
-    return { verb, what: receiptWhat(call.syscall, call.summary, activity.target), count: 1, noun, failed: false };
-  }
-  return null;
+export function receiptTargets(moment: Moment): { target: string; live: boolean; failed: boolean }[] {
+  return moment.activities.filter((activity) => !activity.you).map((activity) => ({
+    target: activity.target,
+    live: activity.live,
+    failed: activity.calls.some((call) => call.failed),
+  }));
 }
 
 export function receiptSteps(moment: Moment): number {

--- a/web/src/app/features/instrument/zen/zenModel.ts
+++ b/web/src/app/features/instrument/zen/zenModel.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import type { ProcHistoryRecordsResult, ProcMessageMetadata } from "@humansandmachines/gsv/protocol";
 import type { ChatTranscriptRow, ChatTranscriptValue } from "../../chat/domain/transcript";
+import type { LibraryCollection } from "../../gsv-console/library/libraryTypes";
+import type { MemoryPageRef } from "../shared/navigation";
 
 /* ---------- the prompt line ---------- */
 
@@ -65,6 +67,8 @@ export type ActivityCall = {
   output: string;
   finished: boolean;
   failed: boolean;
+  /** The original structured Read path, before display shortening. */
+  filePath?: string;
 };
 
 export type Activity = {
@@ -86,6 +90,7 @@ export type Moment = {
   streaming: boolean;
   thinking: boolean;
   runId: string | null;
+  processId?: string;
   timestamp: number | null;
   activities: Activity[];
   /** The ship's working narration for this run: what it told itself, not what it sent. Folded by default. */
@@ -235,9 +240,10 @@ function callFromRow(row: ChatTranscriptRow): ActivityCall {
     callId: row.toolCallId ?? row.id,
     syscall,
     summary,
+    filePath: syscall === "fs.read" ? stringField(row.toolArgs, "path") ?? undefined : undefined,
     output: finished ? trimOutput(outputText(syscall, row.toolOutput, row.text)) : "",
     finished,
-    failed: row.isError === true || row.toolOutcome === "failed" || row.toolOutcome === "denied",
+    failed: row.isError === true || row.status === "error" || (row.toolOutcome !== undefined && row.toolOutcome !== "completed"),
   };
 }
 
@@ -265,7 +271,10 @@ export function activitiesForRows(rows: readonly ChatTranscriptRow[], runKey: st
     const timestamp = row.timestamp ?? null;
     if (existing) {
       const index = existing.calls.findIndex((candidate) => candidate.callId === call.callId);
-      if (index >= 0) existing.calls[index] = call;
+      if (index >= 0) {
+        if (call.syscall === "fs.read" && row.toolArgs === undefined) call.filePath ??= existing.calls[index].filePath;
+        existing.calls[index] = call;
+      }
       else existing.calls.push(call);
       if (timestamp !== null) existing.endedAt = timestamp;
     } else {
@@ -285,6 +294,28 @@ export function activitiesForRows(rows: readonly ChatTranscriptRow[], runKey: st
     last.live = last.calls.some((call) => !call.finished);
   }
   return activities;
+}
+
+/** Only successful structured reads of an unambiguous known wiki page become Memory links. */
+export function memoryPagesForMoment(moment: Moment, collections: readonly LibraryCollection[]): MemoryPageRef[] {
+  const pages = new Map<string, MemoryPageRef>();
+  for (const activity of moment.activities) {
+    if (activity.you || activity.target !== CLOUD_PLACE_ID) continue;
+    for (const call of activity.calls) {
+      if (call.syscall !== "fs.read" || !call.finished || call.failed || !call.filePath) continue;
+      const path = call.filePath;
+      if (!path.startsWith("/src/repos/") || path.includes("\0") || path.split("/").slice(1).some((part) => !part || part === "." || part === "..")) continue;
+      const matches = collections.filter((collection) => path.startsWith(`/src/repos/${collection.repo}/`));
+      if (matches.length !== 1) continue;
+      const collection = matches[0];
+      if (collections.filter((entry) => entry.id === collection.id).length !== 1) continue;
+      const localPath = path.slice(`/src/repos/${collection.repo}/`.length);
+      if (localPath !== "index.md" && !/^pages\/(?:[^/]+\/)*[^/]+\.md$/i.test(localPath)) continue;
+      const page = { db: collection.id, path: `${collection.id}/${localPath}` };
+      pages.set(page.path, page);
+    }
+  }
+  return [...pages.values()];
 }
 
 function runKeyOf(row: ChatTranscriptRow, index: number): string {
@@ -310,6 +341,7 @@ export function momentsFromRows(rows: readonly ChatTranscriptRow[], activeRunId:
         streaming: false,
         thinking: false,
         runId: row.runId ?? null,
+        processId: row.processId,
         timestamp: row.timestamp ?? null,
         activities: [],
         narration: "",
@@ -328,12 +360,16 @@ export function momentsFromRows(rows: readonly ChatTranscriptRow[], activeRunId:
           streaming: false,
           thinking: activeRunId !== null && row.runId === activeRunId,
           runId: row.runId ?? null,
+          processId: row.processId,
           timestamp: row.timestamp ?? null,
           activities: [],
           narration: "",
         };
         shipByRun.set(runKey, placeholder);
         moments.push(placeholder);
+      } else {
+        const existing = shipByRun.get(runKey);
+        if (existing) existing.processId ??= row.processId;
       }
       return;
     }
@@ -346,6 +382,7 @@ export function momentsFromRows(rows: readonly ChatTranscriptRow[], activeRunId:
         existing.streaming = row.streaming === true;
         existing.thinking = false;
         existing.timestamp = row.timestamp ?? existing.timestamp;
+        existing.processId ??= row.processId;
         return;
       }
       const moment: Moment = {
@@ -355,6 +392,7 @@ export function momentsFromRows(rows: readonly ChatTranscriptRow[], activeRunId:
         streaming: row.streaming === true,
         thinking: false,
         runId: row.runId ?? null,
+        processId: row.processId,
         timestamp: row.timestamp ?? null,
         activities: [],
         narration: "",
@@ -372,6 +410,7 @@ export function momentsFromRows(rows: readonly ChatTranscriptRow[], activeRunId:
         streaming: false,
         thinking: false,
         runId: row.runId ?? null,
+        processId: row.processId,
         timestamp: row.timestamp ?? null,
         activities: [],
         narration: "",
@@ -487,6 +526,7 @@ export function momentsFromConversation(
       streaming: row.streaming === true,
       thinking: false,
       runId: row.runId ?? null,
+      processId: row.processId,
       timestamp: row.timestamp ?? null,
       activities: [],
       narration: "",
@@ -498,14 +538,16 @@ export function momentsFromConversation(
   const toolRowsByRun = new Map<string, ChatTranscriptRow[]>();
   const narrationByRun = new Map<string, string[]>();
   const runStarted = new Map<string, number | null>();
+  const processByRun = new Map<string, string>();
   transcript.forEach((row, index) => {
     if (row.role === "system" && row.text.trim()) {
       if (row.event?.audience === "model" && row.event.kind !== "history.compacted") return;
-      moments.push({ id: row.id, role: "note", event: row.event, text: row.text, streaming: false, thinking: false, runId: row.runId ?? null, timestamp: row.timestamp ?? null, activities: [], narration: "" });
+      moments.push({ id: row.id, role: "note", event: row.event, text: row.text, streaming: false, thinking: false, runId: row.runId ?? null, processId: row.processId, timestamp: row.timestamp ?? null, activities: [], narration: "" });
       return;
     }
     const runKey = runKeyOf(row, index);
     if (!runStarted.has(runKey)) runStarted.set(runKey, row.timestamp ?? null);
+    if (row.processId && !processByRun.has(runKey)) processByRun.set(runKey, row.processId);
     if (isToolRow(row)) {
       const bucket = toolRowsByRun.get(runKey) ?? [];
       bucket.push(row);
@@ -528,6 +570,7 @@ export function momentsFromConversation(
       moments.push(moment);
       shipByRun.set(runKey, moment);
     }
+    moment.processId ??= processByRun.get(runKey);
     moment.activities = toolRows.length > 0 ? activitiesForRows(toolRows, runKey, active) : [];
     moment.narration = (narrationByRun.get(runKey) ?? []).join("\n\n");
     if (moment.thinking && (moment.activities.length > 0 || moment.narration)) moment.thinking = active;

--- a/web/src/app/features/instrument/zen/zenModel.ts
+++ b/web/src/app/features/instrument/zen/zenModel.ts
@@ -204,7 +204,7 @@ const fileEditResultSchema = z.object({ ok: z.literal(true), path: z.string(), r
 const fileDeleteResultSchema = z.object({ ok: z.literal(true), path: z.string() });
 const fileResultSchema = z.object({ content: z.string().optional(), entries: z.array(z.object({ name: z.string(), kind: z.string().optional() })).optional() });
 const searchResultSchema = z.object({ results: z.array(z.object({ path: z.string() })).optional(), matches: z.array(z.object({ path: z.string() })).optional() });
-const fileSearchResultSchema = z.object({ ok: z.literal(true), matches: z.array(z.object({ path: z.string(), line: z.number(), content: z.string() })), count: z.number().int().nonnegative() });
+const fileSearchResultSchema = z.object({ ok: z.literal(true), matches: z.array(z.object({ path: z.string(), line: z.number(), content: z.string() })), count: z.number().int().nonnegative(), truncated: z.boolean().optional() });
 const filesystemOperationVerbs = new Map([
   ["fs.read", ["read", "reading", "read"]],
   ["fs.write", ["write", "writing", "wrote"]],
@@ -310,7 +310,14 @@ function callFromRow(row: ChatTranscriptRow): ActivityCall {
   if (syscall === "fs.search") {
     const query = stringField(row.toolArgs, "query") ?? "";
     call.operation.subject = [query, path ? `in ${path}` : ""].filter(Boolean).join(" ");
-    if (completed && fileSearchResultSchema.safeParse(row.toolOutput).success) call.operation.label = verb[2];
+    const result = fileSearchResultSchema.safeParse(row.toolOutput);
+    if (completed && result.success) {
+      call.operation.label = verb[2];
+      call.operation.detail = result.data.truncated ? `${result.data.count}+ results` : countLabel(result.data.count, "result");
+      call.output = "";
+    } else if (finished && result.success) {
+      call.output = trimOutput(row.text || JSON.stringify(row.toolOutput, null, 2));
+    }
   } else if (syscall !== "fs.read") {
     const result = mutationConfirmation(syscall, row.toolOutput);
     if (completed && result) {


### PR DESCRIPTION
Memory now lists the repository tree, reads only the selected page, and searches through the gateway. Page corrections preserve authored overview sections and examples; delayed reads and search results cannot replace saved content or cross collection boundaries. Read, search, and unavailable-page failures remain visible.

Zen links successful structured reads of known Memory pages back to the exact page. “Ask about this” fills and focuses an editable question to Ship with the real repository path, without sending it. Expanded working links to its target and originating process in Fleet, including processes beyond the first page and unavailable historical references.

Working now follows each sent message within its process and run. For Read → Send → Read → Send → Read, Zen shows working → message → working → message → trailing working. Original call coordinates keep late results in their correct group across live updates and history reloads. Closed summaries describe targets (“used your cloud home”, “using macbook”); model attribution and individual tool details are inside the fold, with a visible fallback indicator when applicable.

Zen, Fleet, and Memory share navigation and header geometry. Each pane owns its scrolling, dividers extend through the header area, and controls remain reachable at narrow widths and 200% text size. Fleet ledger selection and hover cover the complete row while preserving column alignment.

Filesystem calls appear as plain operation rows, such as “wrote /tmp/test.txt · 11 bytes”, with file content or errors underneath. Successful Search shows only an inline result count, including zero and a `+` when truncated; search failures retain their error text. Only shell.exec receives a terminal prompt. CodeMode has separate source and output blocks; its return values, logs, and errors survive rendering, fixing the previous shell parser silently discarding them. CodeMode appears as process working without a fabricated target. Arbitrary returned objects remain inspectable as data. Nested CodeMode syscalls are not yet individual history records, so this change does not infer their targets. Closed summaries continue to describe targets.

Validation: web typecheck, 606 web tests, production web build, repository lint, diff checks, and independent code review pass. Regression cases cover CodeMode success/failure, false/zero/empty/object returns, missing source calls, typed history reloads, nullable target identities, and filesystem labels preserving failed/denied/unknown outcomes and authoritative error text. Isolated browser checks passed Memory browsing, search isolation, editing during navigation, focused Ask prefill without sending, exact page/target links, and original-process selection beyond Fleet's first page. Additional browser checks passed multiple Sends with preceding/trailing work, each tool appearing once, target summaries, folded model attribution, continuous ledger highlights and column alignment at three widths, shared headers and full-height dividers, and 200% layouts. Final checks on a2310aa3 verified scrolling to and opening the exact Memory page at 200%, plus opening/closing attribution-only response details with the keyboard.

Existing comments describing receipts beneath messages, only the last target being live, and ledger rows using display:contents are preserved under the repository's comment policy; those descriptions are now stale.

Final browser verification on 55cf19ce used real local filesystem mutations and DynamicWorkerExecutor. Confirmed readable Write/Edit/Delete successes, CodeMode source/logs/returned object/error visibility, process working without a fake target or shell prompt, and preserved ordinary target summaries and links. All isolated fixtures were cleaned up.

Presentation verification on 6cffee88 passed plain filesystem rows with inline success details, readable Read/Search bodies, failed Edit wording and error, a shell prompt only for actual Shell, distinct CodeMode source/output blocks, and unchanged closed target summaries. The isolated browser fixture was fully cleaned up. A pre-existing native Search failure under ~/ (undefined truncated result field) was recorded separately; repository search was used for this UI check.

The final Search display adjustment passed 121 focused tests, web typecheck, build, lint, diff checks, and independent review. Successful searches now show their count inline with no result-list body; failures and uncertain outcomes keep diagnostics.

Collapsed working restores the original label and target-name colors. A Chromium check confirmed they match the former activity component in both dark and light themes; build, diff checks, and independent CSS review pass.
