### PR TITLE
bound managed inference deadlines

### DIFF
--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -52,6 +52,25 @@ five to fifteen minutes, but must not use it after `expiresAt`. Entitlements do
 not replace strong usage accounting: inference, email, and other metered services
 still own their reservations, counters, idempotency, and settlement.
 
+## Inference deadlines
+
+The Gateway starts one generation budget before acquiring the managed inference
+target and forwards its absolute epoch-millisecond `deadlineAt` with `timeoutMs`.
+The service uses the earlier of that deadline and its own accepted time plus
+`timeoutMs`; omitting the deadline retains the legacy service timeout budget.
+An absolute deadline may only shorten the budget, including time already spent
+acquiring the target or waiting for the stream RPC.
+
+Deadline expiry produces an error and invokes `abort(logicalRequestId, "timeout")`.
+Explicit cancellation uses `abort(logicalRequestId)`; omitted reasons mean
+`"cancelled"`. The service retains the first terminal cause, including when an
+abort arrives before the generation RPC. The Gateway settles promptly, disposes
+acquired targets, and cancels late response bodies without exposing their output.
+
+Failed-attempt telemetry may include `timeoutKind` (`first_output` or
+`generation`), elapsed `firstActivityMs` and `lastActivityMs` for nonempty response
+body chunks, and `outputExposed`. These fields contain timing and outcome data.
+
 ## Adapters
 
 Adapters are an extension system, not a closed list of messenger brands. An

--- a/packages/gsv/src/protocol/managed-inference-stream.ts
+++ b/packages/gsv/src/protocol/managed-inference-stream.ts
@@ -186,7 +186,7 @@ export async function* decodeManagedInferenceStream(
     }
   } finally {
     signal?.removeEventListener("abort", cancelForAbort);
-    if (!completed) await reader.cancel().catch(() => {});
+    if (!completed) void reader.cancel().catch(() => {});
     reader.releaseLock();
   }
 }

--- a/packages/gsv/src/protocol/managed.ts
+++ b/packages/gsv/src/protocol/managed.ts
@@ -14,6 +14,7 @@ export {
 } from "../services/inference";
 export type {
   InferenceService as ManagedInferenceService,
+  ManagedInferenceAbortReason,
   ManagedInferenceAbortRequest,
   ManagedInferenceActor,
   ManagedInferencePartial,

--- a/packages/gsv/src/services/inference.ts
+++ b/packages/gsv/src/services/inference.ts
@@ -43,6 +43,8 @@ export type ManagedInferenceRequest = {
   maxOutputTokens: number;
   reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
   timeoutMs: number;
+  /** Gateway deadline in epoch milliseconds; may only shorten the service timeout. */
+  deadlineAt?: number;
 };
 
 export type ManagedInferenceResult = Omit<
@@ -94,10 +96,13 @@ export type ManagedInferenceStreamEvent =
       error: ManagedInferenceResult;
     };
 
+export type ManagedInferenceAbortReason = "cancelled" | "timeout";
+
 export type ManagedInferenceAbortRequest = {
   version: 1;
   installationId: string;
   logicalRequestId: string;
+  reason?: ManagedInferenceAbortReason;
 };
 
 /** Installation-scoped inference capability returned to a Gateway deployment. */
@@ -106,7 +111,8 @@ export interface InferenceTarget {
   generateStream(
     input: ManagedInferenceRequest,
   ): Promise<ReadableStream<Uint8Array>>;
-  abort(logicalRequestId: string): Promise<void>;
+  /** Omitted reasons mean cancellation; the service retains the first terminal cause. */
+  abort(logicalRequestId: string, reason?: ManagedInferenceAbortReason): Promise<void>;
 }
 
 /** Platform inference contract consumed by a Gateway deployment. */

--- a/packages/gsv/src/telemetry.ts
+++ b/packages/gsv/src/telemetry.ts
@@ -204,6 +204,10 @@ const inferenceProviderAttemptFailedSchema = z.strictObject({
     failureStage: inferenceFailureStageSchema,
     retryable: z.boolean(),
     providerStatusCode: z.optional(httpStatusCodeSchema),
+    timeoutKind: z.optional(z.enum(["first_output", "generation"])),
+    firstActivityMs: z.optional(nonNegativeIntegerSchema),
+    lastActivityMs: z.optional(nonNegativeIntegerSchema),
+    outputExposed: z.optional(z.boolean()),
   }),
 });
 

--- a/packages/gsv/test/managed-inference-stream.test.mjs
+++ b/packages/gsv/test/managed-inference-stream.test.mjs
@@ -60,6 +60,27 @@ test("cancels the owned stream when its consumer stops", async () => {
   assert.equal(cancelled, true);
 });
 
+test("settles stream cancellation without waiting for the source cleanup", async () => {
+  let cancelled = false;
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encodeManagedInferenceStreamEvent({
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "first",
+      }));
+    },
+    cancel() {
+      cancelled = true;
+      return new Promise(() => {});
+    },
+  });
+
+  for await (const _event of decodeManagedInferenceStream(body)) break;
+  assert.equal(cancelled, true);
+  assert.equal(body.locked, false);
+});
+
 function concatenate(...parts) {
   const output = new Uint8Array(
     parts.reduce((length, part) => length + part.byteLength, 0),

--- a/packages/gsv/test/telemetry.test.mjs
+++ b/packages/gsv/test/telemetry.test.mjs
@@ -131,6 +131,48 @@ describe("telemetry contract", () => {
     }).success, false);
   });
 
+  it("accepts bounded attempt timeout diagnostics and rejects invalid fields", () => {
+    const timeout = createTelemetryRecord({
+      installationId: "inst_telemetry",
+      component: "inference",
+      event: {
+        stream: "operational",
+        name: "inference.provider_attempt.failed",
+        properties: {
+          purpose: "agent",
+          workload: "interactive",
+          provider: "workers-ai",
+          model: "@cf/example/primary",
+          attempt: 1,
+          durationMs: 90_000,
+          failureKind: "timeout",
+          failureStage: "provider",
+          retryable: true,
+          timeoutKind: "first_output",
+          firstActivityMs: 50,
+          lastActivityMs: 80,
+          outputExposed: false,
+        },
+      },
+    });
+    assert.equal(telemetryRecordSchema.safeParse(timeout).success, true);
+    for (const invalid of [
+      { timeoutKind: "provider-specific detail" },
+      { firstActivityMs: -1 },
+      { lastActivityMs: "private data" },
+      { outputExposed: "true" },
+      { responseBody: "private response" },
+    ]) {
+      assert.equal(telemetryRecordSchema.safeParse({
+        ...timeout,
+        event: {
+          ...timeout.event,
+          properties: { ...timeout.event.properties, ...invalid },
+        },
+      }).success, false);
+    }
+  });
+
   it("accepts terminal adapter route diagnostics without delivery content", () => {
     const failure = createTelemetryRecord({
       installationId: "inst_telemetry",

--- a/workers/gateway/src/inference/gsv-provider.test.ts
+++ b/workers/gateway/src/inference/gsv-provider.test.ts
@@ -12,7 +12,7 @@ import type {
   InferenceService as ManagedInferenceService,
   InferenceTarget as ManagedInferenceTarget,
 } from "@humansandmachines/gsv/services/inference";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createGsvInferenceProviderFactory,
   gsvInferenceFeaturesFromEnv,
@@ -49,6 +49,8 @@ const RESULT: ManagedInferenceResult = {
 };
 
 describe("GSV inference provider", () => {
+  afterEach(() => vi.useRealTimers());
+
   it("advertises the default 32k output budget", () => {
     const service: ManagedInferenceService = {
       getInstallation: vi.fn<ManagedInferenceService["getInstallation"]>(),
@@ -255,6 +257,96 @@ describe("GSV inference provider", () => {
     expect(target.abort).not.toHaveBeenCalled();
   });
 
+  it("bounds acquisition by the original factory deadline and disposes a late target", async () => {
+    vi.useFakeTimers();
+    const deadlineAt = Date.now() + 1_000;
+    const acquisition = Promise.withResolvers<ManagedInferenceTarget>();
+    const { target, dispose } = managedService(vi.fn());
+    const service = { getInstallation: vi.fn(() => acquisition.promise) };
+    const factory = createGsvInferenceProviderFactory(service);
+    await vi.advanceTimersByTimeAsync(400);
+    const stream = providerStreamFromFactory(factory, new AbortController().signal, deadlineAt);
+
+    await vi.advanceTimersByTimeAsync(600);
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "error",
+      errorMessage: "Model generation timed out after 1000ms",
+    });
+    acquisition.resolve(target);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(target.generateStream).not.toHaveBeenCalled();
+    expect(target.abort).not.toHaveBeenCalled();
+  });
+
+  it("bounds a stalled stream RPC after delayed acquisition and cancels its late body", async () => {
+    vi.useFakeTimers();
+    const deadlineAt = Date.now() + 1_000;
+    const acquisition = Promise.withResolvers<ManagedInferenceTarget>();
+    const body = Promise.withResolvers<ReadableStream<Uint8Array>>();
+    const disposeBodyRpc = vi.fn();
+    Object.defineProperty(body.promise, Symbol.dispose, { value: disposeBodyRpc });
+    const abort = vi.fn(() => new Promise<void>(() => {}));
+    const { target, dispose } = managedService(vi.fn(() => body.promise), abort);
+    const service = { getInstallation: vi.fn(() => acquisition.promise) };
+    const stream = providerStream(service, new AbortController().signal);
+
+    await vi.advanceTimersByTimeAsync(400);
+    acquisition.resolve(target);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(target.generateStream).toHaveBeenCalledWith(expect.objectContaining({
+      timeoutMs: 1_000,
+      deadlineAt,
+    }));
+    await vi.advanceTimersByTimeAsync(600);
+    await expect(stream.result()).resolves.toMatchObject({ stopReason: "error" });
+    expect(abort).toHaveBeenCalledExactlyOnceWith(ATTRIBUTION.logicalRequestId, "timeout");
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(disposeBodyRpc).toHaveBeenCalledOnce();
+
+    const cancel = vi.fn();
+    body.resolve(new ReadableStream({ cancel }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(cancel).toHaveBeenCalledOnce();
+    await expect(stream.result()).resolves.toMatchObject({ stopReason: "error", content: [] });
+  });
+
+  it("times out an active stream without waiting for source cancellation", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    const { service, target, dispose } = managedService(vi.fn(async () => new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoded({
+          type: "start",
+          partial: { ...RESULT, content: [], stopReason: "pending" },
+        }));
+      },
+      cancel,
+    })));
+    const stream = providerStream(service, new AbortController().signal);
+    const events = stream[Symbol.asyncIterator]();
+    await expect(events.next()).resolves.toMatchObject({ value: { type: "start" } });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(events.next()).resolves.toMatchObject({ value: { type: "error", reason: "error" } });
+    await expect(events.next()).resolves.toMatchObject({ done: true });
+    expect(target.abort).toHaveBeenCalledExactlyOnceWith(ATTRIBUTION.logicalRequestId, "timeout");
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("clears the generation deadline after success", async () => {
+    vi.useFakeTimers();
+    const { service, target } = managedService(vi.fn(async () => eventStream({
+      type: "done", reason: "stop", message: RESULT,
+    })));
+    const stream = providerStream(service, new AbortController().signal);
+    await expect(stream.result()).resolves.toMatchObject({ stopReason: "stop" });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(target.abort).not.toHaveBeenCalled();
+  });
+
   it("aborts when cancellation overtakes the stream RPC", async () => {
     let markStarted: () => void = () => {};
     const started = new Promise<void>((resolve) => {
@@ -275,12 +367,14 @@ describe("GSV inference provider", () => {
     const stream = providerStream(service, controller.signal);
     await started;
     controller.abort(reason);
-    releaseStream(eventStream({ type: "done", reason: "stop", message: RESULT }));
 
     await expect(stream.result()).resolves.toMatchObject({
       stopReason: "aborted",
       errorMessage: "test cancellation",
     });
+    const cancel = vi.fn();
+    releaseStream(new ReadableStream({ cancel }));
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
     expect(abort).toHaveBeenCalledTimes(1);
     expect(dispose).toHaveBeenCalledOnce();
   });
@@ -299,8 +393,9 @@ function providerStream(
 function providerStreamFromFactory(
   factory: ReturnType<typeof createGsvInferenceProviderFactory>,
   signal: AbortSignal,
+  deadlineAt?: number,
 ) {
-  const provider = factory.create(ATTRIBUTION);
+  const provider = factory.create(ATTRIBUTION, deadlineAt === undefined ? undefined : { deadlineAt });
   const models = createModels();
   models.setProvider(provider);
   const model = models.getModel("gsv", GSV_INFERENCE_MODEL)!;

--- a/workers/gateway/src/inference/gsv-provider.ts
+++ b/workers/gateway/src/inference/gsv-provider.ts
@@ -29,6 +29,7 @@ import type {
   InferenceProviderFactory,
 } from "./provider";
 import { DEFAULT_TEXT_GENERATION_MAX_TOKENS } from "./default-models";
+import { createGenerationAbort, TimeoutError } from "./timeout";
 import { raceWithAbort } from "../shared/abort";
 import type { GatewayEnv } from "../runtime-env";
 
@@ -100,7 +101,7 @@ function createGsvInferenceProviderFactoryForAccess(
 ): InferenceProviderFactory {
   return {
     id: GSV_INFERENCE_PROVIDER,
-    create: (attribution) => createProvider({
+    create: (attribution, options) => createProvider({
       id: GSV_INFERENCE_PROVIDER,
       name: "GSV",
       auth: {
@@ -115,7 +116,7 @@ function createGsvInferenceProviderFactoryForAccess(
         },
       },
       models: [GSV_INFERENCE_MODEL_METADATA],
-      api: gsvInferenceStreams(access, attribution),
+      api: gsvInferenceStreams(access, attribution, options?.deadlineAt),
     }),
   };
 }
@@ -123,6 +124,7 @@ function createGsvInferenceProviderFactoryForAccess(
 function gsvInferenceStreams(
   access: ManagedInferenceAccess,
   attribution: InferenceAttribution,
+  deadlineAt?: number,
 ): ProviderStreams {
   return {
     stream: (_model, context, options) => streamGsvInference(
@@ -130,12 +132,14 @@ function gsvInferenceStreams(
       attribution,
       context,
       options,
+      deadlineAt,
     ),
     streamSimple: (_model, context, options) => streamGsvInference(
       access,
       attribution,
       context,
       options,
+      deadlineAt,
     ),
   };
 }
@@ -145,23 +149,26 @@ function streamGsvInference(
   attribution: InferenceAttribution,
   context: Context,
   options?: StreamOptions | SimpleStreamOptions,
+  deadlineAt?: number,
 ): AssistantMessageEventStream {
   if (options?.fetch) {
     throw new Error("GSV inference cannot originate model requests from a connected machine.");
   }
   const stream = createAssistantMessageEventStream();
+  const abort = createGenerationAbort(options?.signal, options?.timeoutMs ?? 180_000, deadlineAt);
   void pumpGsvInference(
     access,
-    buildManagedInferenceRequest(attribution, context, options),
+    buildManagedInferenceRequest(attribution, context, abort.deadlineAt, options),
     stream,
-    options?.signal,
-  );
+    abort.signal,
+  ).finally(abort.clear);
   return stream;
 }
 
 function buildManagedInferenceRequest(
   attribution: InferenceAttribution,
   context: Context,
+  deadlineAt: number,
   options?: StreamOptions | SimpleStreamOptions,
 ): ManagedInferenceRequest {
   const reasoning = options && "reasoning" in options
@@ -178,6 +185,7 @@ function buildManagedInferenceRequest(
     messages,
     maxOutputTokens: options?.maxTokens ?? GSV_INFERENCE_MODEL_METADATA.maxTokens,
     timeoutMs: options?.timeoutMs ?? 180_000,
+    deadlineAt,
   };
   if (attribution.workload) request.workload = attribution.workload;
   if (context.systemPrompt) request.systemPrompt = context.systemPrompt;
@@ -203,7 +211,11 @@ async function pumpGsvInference(
     if (target && generationStarted && !generationAbort) {
       generationAbort = (async () => {
         try {
-          await target.abort(request.logicalRequestId);
+          if (signal?.reason instanceof TimeoutError) {
+            await target.abort(request.logicalRequestId, "timeout");
+          } else {
+            await target.abort(request.logicalRequestId);
+          }
         } catch {}
       })();
     }
@@ -242,7 +254,16 @@ async function pumpGsvInference(
     const bodyPromise = target.generateStream(request);
     generationStarted = true;
     if (signal?.aborted) abortGeneration();
-    const body = await bodyPromise;
+    const body = await raceWithAbort(bodyPromise, signal, {
+      onAbort: () => {
+        // SAFETY: Workers RPC promises expose a disposer; local promises may omit it.
+        const disposable = bodyPromise as typeof bodyPromise & { [Symbol.dispose]?(): void };
+        disposable[Symbol.dispose]?.();
+      },
+      onLateResolve: (lateBody) => {
+        void lateBody.cancel(signal?.reason).catch(() => {});
+      },
+    });
     let partial: AssistantMessage | undefined;
     let terminal = false;
     for await (const raw of decodeManagedInferenceStream(body, signal)) {
@@ -263,7 +284,6 @@ async function pumpGsvInference(
     stream.push(gsvInferenceErrorEvent(signal?.aborted === true, signal));
   } finally {
     signal?.removeEventListener("abort", abortGeneration);
-    await generationAbort;
     disposeManagedInferenceTarget(target);
   }
 }
@@ -504,12 +524,14 @@ function gsvInferenceErrorEvent(
   aborted: boolean,
   abortSignal?: AbortSignal,
 ): Extract<AssistantMessageEvent, { type: "error" }> {
+  const timedOut = aborted && abortSignal?.reason instanceof TimeoutError;
+  const cancelled = aborted && !timedOut;
   const abortMessage = abortSignal?.reason instanceof Error
     ? abortSignal.reason.message.trim()
     : "";
   return {
     type: "error",
-    reason: aborted ? "aborted" : "error",
+    reason: cancelled ? "aborted" : "error",
     error: {
       role: "assistant",
       content: [],
@@ -524,7 +546,7 @@ function gsvInferenceErrorEvent(
         totalTokens: 0,
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
       },
-      stopReason: aborted ? "aborted" : "error",
+      stopReason: cancelled ? "aborted" : "error",
       errorMessage: aborted
         ? abortMessage || "GSV inference cancelled"
         : "GSV inference is unavailable",

--- a/workers/gateway/src/inference/provider.ts
+++ b/workers/gateway/src/inference/provider.ts
@@ -15,7 +15,7 @@ export type InferenceAttribution = {
 
 export type InferenceProviderFactory = {
   id: string;
-  create(attribution: InferenceAttribution): Provider;
+  create(attribution: InferenceAttribution, options?: { deadlineAt: number }): Provider;
 };
 
 export async function inferenceLogicalRequestId(

--- a/workers/gateway/src/inference/service.test.ts
+++ b/workers/gateway/src/inference/service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const completePiAiSimpleMock = vi.hoisted(() => vi.fn());
 const streamPiAiSimpleMock = vi.hoisted(() => vi.fn());
@@ -106,6 +106,8 @@ beforeEach(() => {
   streamWithOpenAiCodexFetchMock.mockReset();
 });
 
+afterEach(() => vi.useRealTimers());
+
 describe("resolveGenerationOptions", () => {
   it("preserves configured reasoning for chat replies", () => {
     const result = resolveGenerationOptions({
@@ -175,6 +177,47 @@ describe("resolveGenerationOptions", () => {
 });
 
 describe("createGenerationService", () => {
+  it("keeps the original deadline through provider creation and emits a timeout error", async () => {
+    vi.useFakeTimers();
+    const deadlineAt = Date.now() + 1_000;
+    const target: ManagedInferenceTarget = {
+      generate: vi.fn(),
+      generateStream: vi.fn(async () => new ReadableStream<Uint8Array>()),
+      abort: vi.fn(async () => {}),
+    };
+    const factory = createGsvInferenceProviderFactory({
+      getInstallation: async () => target,
+    });
+    const service = createProductionGenerationService({
+      providers: [{
+        ...factory,
+        create(attribution, options) {
+          vi.advanceTimersByTime(250);
+          return factory.create(attribution, options);
+        },
+      }],
+    });
+    const stream = service.stream({
+      config: { ...CONFIG, provider: GSV_INFERENCE_PROVIDER, model: GSV_INFERENCE_MODEL },
+      context: CONTEXT,
+      options: { timeoutMs: 1_000 },
+      attribution: {
+        installationId: "inst_test",
+        logicalRequestId: "request_deadline",
+        actor: { localUid: 1000 },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(target.generateStream).toHaveBeenCalledWith(expect.objectContaining({ deadlineAt }));
+    await vi.advanceTimersByTimeAsync(750);
+
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "error",
+      errorMessage: "Model generation timed out after 1000ms",
+    });
+    expect(target.abort).toHaveBeenCalledExactlyOnceWith("request_deadline", "timeout");
+  });
+
   it("routes gsv/default through the managed binding with trusted identity", async () => {
     const managedResult: ManagedInferenceResult = {
       role: "assistant",

--- a/workers/gateway/src/inference/service.ts
+++ b/workers/gateway/src/inference/service.ts
@@ -19,7 +19,7 @@ import {
   workersAiBindingFetch,
   workersAiProvider,
 } from "./workers-ai";
-import { withTimeout } from "./timeout";
+import { createGenerationAbort, generationTimeoutMessage, withTimeout } from "./timeout";
 import { resolveModelThinkingLevel, resolvePiAiModel } from "./model-registry";
 import {
   completePiAiSimple,
@@ -153,8 +153,9 @@ export function createGenerationService(
     }
 
     assertOpenAiCodexCredential(options.modelProvider, options.apiKey);
-    const piAi = resolvePiAiProviderModel(providerFactory, request, options);
-    const abort = createGenerationAbort(request.signal, generationTimeoutMs);
+    const deadlineAt = Date.now() + generationTimeoutMs;
+    const piAi = resolvePiAiProviderModel(providerFactory, request, options, deadlineAt);
+    const abort = createGenerationAbort(request.signal, generationTimeoutMs, deadlineAt);
     const openAiCodexFetch = options.modelProvider === OPENAI_CODEX_PROVIDER
       ? generationFetch ?? fetch
       : undefined;
@@ -247,8 +248,9 @@ export function createGenerationService(
     }
 
     assertOpenAiCodexCredential(options.modelProvider, options.apiKey);
-    const piAi = resolvePiAiProviderModel(providerFactory, request, options);
-    const abort = createGenerationAbort(request.signal, generationTimeoutMs);
+    const deadlineAt = Date.now() + generationTimeoutMs;
+    const piAi = resolvePiAiProviderModel(providerFactory, request, options, deadlineAt);
+    const abort = createGenerationAbort(request.signal, generationTimeoutMs, deadlineAt);
     const openAiCodexFetch = options.modelProvider === OPENAI_CODEX_PROVIDER
       ? generationFetch ?? fetch
       : undefined;
@@ -335,6 +337,7 @@ function resolvePiAiProviderModel(
   factory: InferenceProviderFactory | undefined,
   request: GenerateRequest,
   options: ResolvedGenerationOptions,
+  deadlineAt: number,
 ): PiAiProviderModel {
   if (isWorkersAiProvider(options.modelProvider)) {
     const models = modelsWithProviders([workersAiProvider]);
@@ -353,7 +356,7 @@ function resolvePiAiProviderModel(
   if (!request.attribution) {
     throw new Error(`Inference attribution is unavailable for provider: ${factory.id}`);
   }
-  const provider = factory.create(request.attribution);
+  const provider = factory.create(request.attribution, { deadlineAt });
   const models = modelsWithProviders([provider]);
   const model = models.getModel(provider.id, options.modelName);
   if (!model) {
@@ -489,26 +492,4 @@ function normalizePositiveNumber(value: number | null | undefined): number | nul
 
 function generationReasoningFromLevel(level: ReturnType<typeof resolveModelThinkingLevel>): ThinkingLevel | null {
   return level && level !== "off" ? level : null;
-}
-
-function generationTimeoutMessage(timeoutMs: number): string {
-  return `Model generation timed out after ${timeoutMs}ms`;
-}
-
-type GenerationAbort = { signal: AbortSignal; clear: () => void };
-
-function createGenerationAbort(
-  callerSignal: AbortSignal | undefined,
-  timeoutMs: number,
-): GenerationAbort {
-  const timeoutController = new AbortController();
-  const timeout = setTimeout(() => {
-    timeoutController.abort(new Error(generationTimeoutMessage(timeoutMs)));
-  }, timeoutMs);
-  return {
-    signal: callerSignal
-      ? AbortSignal.any([callerSignal, timeoutController.signal])
-      : timeoutController.signal,
-    clear: () => clearTimeout(timeout),
-  };
 }

--- a/workers/gateway/src/inference/timeout.ts
+++ b/workers/gateway/src/inference/timeout.ts
@@ -5,6 +5,32 @@ export class TimeoutError extends Error {
   }
 }
 
+export function generationTimeoutMessage(timeoutMs: number): string {
+  return `Model generation timed out after ${timeoutMs}ms`;
+}
+
+type GenerationAbort = { signal: AbortSignal; deadlineAt: number; clear: () => void };
+
+export function createGenerationAbort(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+  deadlineAt = Date.now() + timeoutMs,
+): GenerationAbort {
+  deadlineAt = Math.min(deadlineAt, Date.now() + timeoutMs);
+  const timeoutController = new AbortController();
+  const remainingMs = Math.max(0, deadlineAt - Date.now());
+  const abort = () => timeoutController.abort(new TimeoutError(generationTimeoutMessage(timeoutMs)));
+  const timeout = remainingMs > 0 ? setTimeout(abort, remainingMs) : undefined;
+  if (remainingMs === 0) abort();
+  return {
+    signal: callerSignal
+      ? AbortSignal.any([callerSignal, timeoutController.signal])
+      : timeoutController.signal,
+    deadlineAt,
+    clear: () => clearTimeout(timeout),
+  };
+}
+
 export function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,

--- a/workers/gateway/test-integration/fixtures/dependencies.ts
+++ b/workers/gateway/test-integration/fixtures/dependencies.ts
@@ -24,6 +24,7 @@ import type {
   InstallationDirectoryResult,
   InstallationOnboardingAuthorization,
   ManagedInstallationState,
+  ManagedInferenceAbortReason,
   ManagedInferenceRequest,
   ManagedInferenceResult,
 } from "@humansandmachines/gsv/protocol";
@@ -129,8 +130,18 @@ export class IntegrationState extends DurableObject<Env> {
     return failure;
   }
 
-  async recordManagedInferenceCancellation(installationId: string): Promise<void> {
-    await this.ctx.storage.put(`managed-inference-cancelled:${installationId}`, true);
+  async recordManagedInferenceCancellation(
+    installationId: string,
+    reason: ManagedInferenceAbortReason,
+  ): Promise<void> {
+    await this.ctx.storage.put({
+      [`managed-inference-cancelled:${installationId}`]: true,
+      [`managed-inference-abort-reason:${installationId}`]: reason,
+    });
+  }
+
+  async managedInferenceAbortReason(installationId: string): Promise<ManagedInferenceAbortReason | undefined> {
+    return await this.ctx.storage.get(`managed-inference-abort-reason:${installationId}`);
   }
 
   async wasManagedInferenceCancelled(installationId: string): Promise<boolean> {
@@ -291,12 +302,13 @@ class ManagedInferenceTarget
     });
   }
 
-  async abort(_logicalRequestId: string): Promise<void> {
+  async abort(_logicalRequestId: string, reason: ManagedInferenceAbortReason = "cancelled"): Promise<void> {
     const id = this.#env.INTEGRATION_STATE.idFromName(
       SINGLETON_INSTALLATION_ID,
     );
     await this.#env.INTEGRATION_STATE.get(id).recordManagedInferenceCancellation(
       this.#installationId,
+      reason,
     );
   }
 }

--- a/workers/gateway/test-integration/managed-routing.test.ts
+++ b/workers/gateway/test-integration/managed-routing.test.ts
@@ -148,7 +148,7 @@ describe("managed installation routing integration", () => {
     socket.close(1000, "test complete");
   });
 
-  it("derives managed inference identity behind the private service binding", async () => {
+  it("preserves managed identity and timeout failures across the service binding", async () => {
     await beginProvisioning(harness, "first");
     const socket = await openManagedSocket(harness, "first");
     await expectManagedRpcOk(socket, "setup-inference", "sys.setup", {
@@ -192,6 +192,26 @@ describe("managed installation routing integration", () => {
         text: "managed:inst_integration_first:uid:1000:pid:none:run:none",
       },
     });
+    const timedOut = await managedRpc(socket, "generate-managed-timeout", "ai.text.generate", {
+      messages: [{ role: "user", content: "wait for cancellation" }],
+      config: { modelConfig: { provider: "gsv", model: "default", apiKey: "" } },
+      options: { maxTokens: 128, timeoutMs: 200 },
+    });
+    expect(timedOut).toMatchObject({
+      ok: true,
+      data: {
+        message: {
+          stopReason: "error",
+          errorMessage: "Model generation timed out after 200ms",
+        },
+      },
+    });
+    const { INTEGRATION_STATE } = await harness.getWorker<{
+      INTEGRATION_STATE: DurableObjectNamespace<IntegrationState>;
+    }>("gsv-test-dependencies").getEnv();
+    const state = INTEGRATION_STATE.getByName("singleton");
+    await waitForManagedInferenceCancellation(state, "inst_integration_first");
+    expect(await state.managedInferenceAbortReason("inst_integration_first")).toBe("timeout");
     socket.close(1000, "test complete");
   });
 


### PR DESCRIPTION
Managed inference could consume the whole generation timeout while waiting for a service response or stalled stream, and deadline expiry could be reported as user cancellation. Carry one absolute deadline through capability acquisition and generation, cancel late bodies without waiting on a stuck producer, and send the service a distinct timeout reason.

The service-side companion adds bounded attempts so a stalled provider can reach fallback before the deadline. Deploy that additive service implementation before the gateway. This addresses the deadline portion of #308; background retry policy, allowance reconciliation, and the upstream stall cause remain separate follow-ups.

Validation: 104 SDK tests, 119 gateway inference tests, 15 clean managed-routing integration tests, gateway typecheck, and protocol checks pass. Integration coverage verifies a timeout reaches the client as an error and a subsequent generation succeeds.
