### PR TITLE
document hosting consolidation and directory contract

### DIFF
--- a/docs/architecture/installation-directory.md
+++ b/docs/architecture/installation-directory.md
@@ -1,0 +1,132 @@
+# Installation directory and onboarding
+
+The installation directory is the operator-to-gateway identity contract.
+Accounts owns installation identity, hostnames, ownership records, and
+lifecycle state. The Kernel owns local accounts, credentials, roles, and
+ordinary syscall authorization. Resolving an installation establishes which
+Kernel may receive a request; it does not sign a person into that Kernel.
+
+This document describes the implemented directory and onboarding interfaces.
+The [hosting consolidation plan](../../engineering/hosting-consolidation-spec.md)
+adds public Accounts, owner recovery, and complete data deletion in later
+slices. Those operations must not be inferred from a directory lookup.
+
+## Public interfaces
+
+The contracts are exported from
+[`services/directory.ts`](../../packages/gsv/src/services/directory.ts) and
+[`services/onboarding.ts`](../../packages/gsv/src/services/onboarding.ts) in
+`@humansandmachines/gsv`. A deployment supplies implementations through
+trusted Worker service bindings.
+
+| Method | Input and result | Ownership |
+|---|---|---|
+| `resolveHostname(hostname)` | Returns the registered installation identity and state, or `{ found: false }`. Unknown and retired hostname records do not resolve. | Accounts normalizes and resolves hostnames; the gateway supplies the request hostname. |
+| `resolveInstallation(installationId)` | Returns that exact immutable identity and state, or `{ found: false }`. | Internal callers retain a validated id in owned state or recover it from a trusted route. |
+| `authorizeInstallationOnboarding({ installationId, token })` | Returns the matching claim id and installation identity, or `{ ok: false }`. | The Kernel supplies its resolved installation id and the setup capability. Accounts validates its hash, expiry, revocation and provisioning state. |
+| `completeInstallationOnboarding({ claimId, installationId })` | Completes the admitted setup claim and returns the installation id with state `complete`. | The Kernel creates local credentials first; Accounts consumes the claim and activates installation routing. |
+
+A found identity contains `installationId`, `handle`, `canonicalOrigin`, and
+`state`. Only `installationId` is the security identity. A handle or hostname
+may move to a replacement installation after reset; old credentials and
+delayed work remain scoped to the retired id.
+
+Public clients cannot choose an installation id for an ordinary request.
+The gateway resolves the request hostname before addressing a Kernel.
+Adapters resolve a durable, generation-fenced identity link; background work
+uses its stored installation identity. Passing an arbitrary id through a
+service call is not a replacement for those admission checks.
+
+## Resolution and admission
+
+Directory resolution and permission to perform work are separate results.
+A known inactive installation can be returned by the directory so trusted
+administration can inspect it; ordinary work remains gated.
+
+| Installation state | Ordinary work | Setup routing |
+|---|---|---|
+| `active` | Admitted subject to Kernel authentication and capabilities. | Existing installation routing. |
+| `provisioning` | Refused. | A setup-capable route may address the Kernel, which must validate the installation's onboarding claim before accepting setup. |
+| `reserved` | Refused. | Not yet routable for setup. |
+| `trialing`, `past_due` | Refused. | Refused; these retained schema values do not imply a commercial admission exception. |
+| `restricted` | Refused while identity and data are retained. | Refused. |
+| `cancelled`, `retained`, `deleting`, `deleted` | Refused. | Refused. |
+
+The gateway's [routing implementation](../../workers/gateway/src/installation/routing.ts)
+accepts `active`, or `provisioning` when explicitly resolving a setup route.
+Unknown hosts must not allocate Kernel state. Directory failures must fail
+closed rather than falling back to a different installation.
+
+The [lifecycle gate](../../workers/gateway/src/installation/lifecycle.ts)
+also applies to work entering through existing WebSockets, adapters,
+inference, Process ticks, and schedules. Suspending an installation does not
+erase data or recursively cancel work already admitted; durable work
+rechecks the gate before new admission and may resume after reactivation.
+
+The currently supported standalone deployment retains its explicit
+`singleton` projection until the planned cutover. A failed directory lookup
+in a deployment with a directory never falls back to that projection.
+
+## Setup and ownership
+
+Accounts reserves an installation for a verified active principal and issues
+a one-time setup capability for that installation. The browser reads the
+fragment and removes it from the URL; Accounts stores a hash, and the
+Kernel creates the local username, password and other credentials. Reissuing
+a claim invalidates its predecessor. Provisioning calls and completion are
+installation-scoped; replay of a consumed authorization cannot admit another
+setup. Kernel-owned pending completion is retained for retry when an
+Accounts call fails.
+
+The directory's `memberships` rows are ownership records, with an
+installation id, principal id, state, and creation time. They are not Kernel
+memberships or a grant of local permissions. Existing registry-principal
+records remain bookkeeping until the separate verified-owner linking flow
+is implemented. Successful setup does not assign that principal a Kernel uid.
+
+The legacy `role` and `local_uid` columns are being retired. They do not
+govern current local admission. The inference usage ledger's `local_uid`
+records the actor of a request and is unrelated; it remains intact.
+
+## Reset and deletion
+
+An installation reset creates a new immutable id, moves the canonical
+hostname, retires old routing, and records the old installation's data as
+pending deletion. It preserves the reset operation identity so retries
+recover the same replacement instead of creating another one. Existing
+policy copying and disablement are owned by the current Accounts
+implementation until their service separation lands.
+
+Pending deletion means data remains stored. Current reset does not erase
+Kernel, Process, Conversation, R2, ripgit, adapter, mail or inference state.
+The consolidation deletion slice adds a durable coordinator and per-owner
+quiesce/erase acknowledgements, including old pending resets. It must retain
+resource inventories until children are erased and prevent stale writes
+from recreating user data. Retiring routing alone is not erasure.
+
+Root recovery is also a separate trusted operation in the consolidation
+plan. Accounts authenticates ownership and authorizes it; the Kernel changes
+credentials. Possession of a directory lookup binding does not expose that
+future incoming recovery capability.
+
+## Validation and schema rollout
+
+Keep tests at both ends: Accounts tests cover reservation races, claim
+binding, expiry/reissue, activation, reset idempotency and rollback; gateway
+tests cover unknown-host rejection, state gates, immutable addressing, and
+cross-installation isolation. Test both an upgraded database containing
+ownership rows and a fresh instance.
+
+Ownership-column retirement uses two deployments because migrations run
+before the replacement Worker is active. First make the legacy role column
+default to `owner` and stop writing or reading both obsolete columns. Both
+old and new Workers work with that intermediate schema. After the new Worker
+is deployed and older requests are drained, a subsequent migration removes
+both columns and their obsolete uid uniqueness constraint. Keep the removal
+out of the first deployment's applied migration directory. Existing
+principal/installation foreign keys and ownership rows survive both steps.
+
+Shipped migration files are immutable. Cloudflare D1 enforces foreign keys
+during migrations; a table rebuild must preserve the relationships rather
+than disabling them. See [D1 foreign-key behavior](https://developers.cloudflare.com/d1/sql-api/foreign-keys/)
+and [D1 migrations](https://developers.cloudflare.com/d1/reference/migrations/).

--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -15,6 +15,10 @@ The current contracts are:
 - `mail`: Gateway mail transport and operational mail inspection
 - `adapters`: external messaging transport discovery and operations
 
+[Installation directory and onboarding](./installation-directory.md)
+specifies installation identity, state gates, ownership, setup claims, and
+the current reset/deletion boundary for directory implementers and callers.
+
 Service bindings are capabilities. A deployment must bind only the interface a
 Worker needs; Cloudflare Access identity does not implicitly propagate through a
 service binding. Implementations validate arguments at their public boundary and

--- a/engineering/hosting-consolidation-brief.md
+++ b/engineering/hosting-consolidation-brief.md
@@ -1,0 +1,37 @@
+**Hosting consolidation means one public GSV stack that any operator can deploy, supporting one or several isolated installations. H&M will run that same stack.**
+
+Today, GSV has two hosting paths: the historical standalone/singleton deployment for someone’s own Cloudflare account, and the managed deployment used by H&M. They differ in provisioning, identity routing, onboarding, and messenger configuration. Maintaining both creates duplicate code and inconsistent user flows.
+
+The new web UI has now shipped. We deliberately avoided rebuilding the old per-user messenger application setup screens because consolidation changes who owns that configuration.
+
+The target architecture has three boundaries:
+
+| Boundary | Owns |
+|---|---|
+| **Deployment/operator** | Cloudflare resources, domains, installation administration, messenger applications, optional shared services |
+| **Installation** | Local accounts, agents, conversations, files, memory, credentials, permissions, machines, linked external identities |
+| **Local account** | A human or agent’s identity and access within an installation |
+
+A solo self-hoster runs this stack with one installation. An operator can provision several. Registration defaults to closed; supporting multiple installations does not require opening a public signup service.
+
+The implementation has five main parts:
+
+1. **Make the reusable installation services public.** Extract the installation directory, bootstrap/onboarding, and operator administration from the private Accounts service into GSV. H&M should consume that implementation. Operator-specific commercial policy and credentials remain separate. Existing public service contracts and shared deployment code provide the starting point.
+
+2. **Provide one deployment and bootstrap flow.** Configure the domain, operator access, enabled adapters, optional services, and secret references. Create the first installation and issue a one-time setup link; provide explicit administration for additional installations. User-supplied inference credentials must support a useful installation independently of H&M services. Operator-funded inference, mail, and telemetry remain optional.
+
+3. **Unify messenger setup and linking.** The operator configures the provider application or bot and its credentials. Individual people then authorize and link their external identities at runtime. For example, H&M configures its Telegram bot; a self-hoster configures theirs; both users follow the same linking flow. Existing managed Telegram and Slack implementations are the foundation, with corresponding work needed for Discord. The UI presents available integrations according to service availability and permissions. Provider identity, transport, retries, and delivery behavior remain adapter-owned.
+
+4. **Reduce H&M infrastructure to a small composition of public components.** Shared provisioning belongs in GSV. The private Alchemy configuration keeps H&M’s domains, administrator configuration, environment policy, secret bindings, and overrides needed to preserve existing resources.
+
+5. **Remove the obsolete standalone path completely.** Once the common flow works, remove singleton addressing, alternate adapter entrypoints, duplicated setup flows, hosting-mode branches, and obsolete documentation/tests. Update the engineering contract to reflect the deliberate cutover.
+
+Throughout this work, **the immutable installation ID remains the security boundary**. Trusted hostname routing must resolve an installation before accessing its Kernel; arbitrary hostnames must never allocate state. Processes, conversations, storage, repositories, and adapter routes must remain installation-scoped.
+
+Existing managed installations must retain their identities and data. Extracting deployment code must also preserve Alchemy resource identities and retention behavior. For legacy singleton deployments, the agreed approach is to identify actual remaining users, preserve a last standalone release, and arrange any necessary migration or recovery explicitly. We expect very few users, so a general automatic migration framework is not the starting assumption.
+
+**The first milestone is a fresh deployment using public components only, with two installations, normal onboarding, Telegram linking, and user-supplied model credentials.** Validation should deliberately reuse local usernames and paths across both installations, verify isolation of state and messaging, and confirm that restarting, resetting, or deleting one does not affect the other. H&M’s deployment must consume the same public components successfully.
+
+WhatsApp Business is the agreed future WhatsApp transport, but its implementation is a separate follow-up. iMessage comes later. Send-tool changes remain parked, and no license change is part of this work; GSV remains MIT.
+
+The direction is recorded in the [hosting consolidation plan](https://github.com/deathbyknowledge/gsv/blob/main/engineering/unified-hosting-and-web-release.md).

--- a/engineering/hosting-consolidation-review-history.md
+++ b/engineering/hosting-consolidation-review-history.md
@@ -1,0 +1,553 @@
+# Hosting consolidation: review history
+
+This file preserves the revision 1–3 review discussion and subsequent
+maintainer decisions verbatim. Statements below describe those revisions;
+they are historical, including any labels saying a question is open.
+The current implementation plan and acceptance criteria are in
+[hosting-consolidation-spec.md](./hosting-consolidation-spec.md).
+
+## 9. Review feedback — Astra, 2026-09-11
+
+Status: open review notes; the proposal above is preserved unchanged. Reviewed
+against GSV `a47a0e66` and the current private Accounts implementation.
+References beginning `../infrastructure/` are relative to the GSV repository
+root. Each required decision applies before its affected workstream ships;
+these notes do not block documenting the existing contracts.
+
+The shared public composition, closed registration, resource adoption, two
+validation environments, and explicit standalone cutover are the right
+direction. The following points need clarification or correction.
+
+### R1. Define human admission and a safe membership backfill
+
+**Required for W1; affects sections 2, 3, 5, and 6.** The current directory
+contract resolves installations and their state; it does not authenticate a
+human or resolve their membership. Accounts writes pending memberships, while
+the Kernel still authenticates local passwords and human/machine/service
+tokens. Moving to directory-controlled human admission is new behavior.
+
+There is also a concrete backfill problem:
+`../infrastructure/services/accounts/src/admin/service.ts` creates
+installations under the shared `REGISTRY_PRINCIPAL_ID`. That provisioning
+principal is not evidence of the actual human owner's identity. Neither a
+matching username nor an inference usage uid establishes that ownership.
+
+Specify how a human authenticates to the directory without optional mail or
+H&M services, how an existing authenticated Kernel human proves the account
+being linked, and how the directory receives the Kernel-assigned uid through a
+trusted operation. Public input cannot select another person's uid. Define
+which admissions check membership and what revocation does to existing web
+sessions, CLI credentials, and adapter links, including the boundary for work
+already admitted.
+
+**Acceptance addition:** migrate two installations created under the shared
+registry principal to their respective real humans; neither can claim the
+other's account. Test a second member, one principal in two installations, and
+revocation through each supported entry path. Keep this behavior change a
+separately reviewable batch from contract documentation and role removal.
+
+### R2. Share invitation semantics while fixing purpose and ownership
+
+**Required for W1.** The vocabulary currently calls a machine a local account.
+`workers/gateway/src/kernel/accounts.ts` creates human and agent accounts;
+device pairing issues a machine peer credential under an existing owner's uid,
+bound to a target. It does not create a human account or grant a human session.
+Correct the vocabulary so invitation reuse preserves that distinction.
+
+The invitation should fix its purpose, installation, issuing authority, and
+permitted enrollment. The recipient must not select a different principal kind
+or grant at redemption. Existing device consumption is atomic inside the
+Kernel; a directory membership and Kernel account cannot share that transaction.
+Define who owns consumption and the durable completion receipt, including
+recovery when one side commits and the other side or its acknowledgment fails.
+
+**Acceptance addition:** concurrent redemption creates one enrollment; a lost
+response is recoverable by the same recipient; another recipient cannot reuse
+the claim. Expiry, cancellation, issuer revocation, and installation reset
+cannot activate a stale membership. A machine invitation cannot enroll a human.
+
+### R3. Specify D1 adoption and separation before moving migrations
+
+**Required for W2/W4.** The public table list omits `principals`, which both
+`installations` and `memberships` reference. Existing migrations interleave
+installation and commercial tables. Inference usage and policy tables have
+foreign keys to `installations`, inference policy queries join that table,
+and installation administration joins private policy/usage tables.
+
+Moving files into separate migration directories does not resolve those
+dependencies. Choose the destination databases and migration bookkeeping,
+identify which service calls replace cross-owner joins, and describe how
+existing data and in-flight usage writes survive the transition. Preserve
+shipped migrations; define the adoption path explicitly alongside the fresh
+database path. Drop `role` through that migration path, not by editing the
+original shipped schema.
+
+The public installation state also contains `trialing` and `past_due`.
+Specify how private commercial policy projects into public lifecycle/admission
+state, retaining the current active-only work gate.
+
+**Acceptance addition:** run both migration paths with installation records,
+pending onboarding/reset operations, and commercial policy/usage present.
+Resolution, reset/deletion cleanup, and usage recording must still work after
+the split, without replaying an incompatible baseline or losing records.
+
+### R4. Distinguish operator bootstrap from ongoing administration
+
+**Required for W3; affects section 8.** W3 makes the operator token single-use
+and expiring, but also makes it the continuing administration path. Define the
+credential or session that exists after that first use.
+
+Either use an operator credential disclosed once and subsequently reusable
+until rotation/revocation, or exchange an expiring single-use bootstrap claim
+for an explicitly specified administration credential. Keep it separate from
+the installation setup claim and Kernel credentials. Store authentication
+secrets hashed and make disclosure deliberate local output, outside ordinary
+deployment/CI logs. Recovery must remain possible through deployment ownership
+when the original output is lost.
+
+**Acceptance addition:** repeat deployment and interrupt bootstrap without
+creating another first installation, reissuing consumed setup claims, or
+silently rotating operator access. Test setup expiry/reissue and operator
+credential recovery.
+
+### R5. Keep removal behind its stated gate
+
+**Required for W3/W7 and section 5.** W3 currently removes `standalone.ts` and
+`GsvRuntimeMode`; W7 promises to remove them only after adoption and isolation
+validation. Move those removals to W7. W3 can establish the common composition
+and its required directory while the legacy entrypoint remains supported until
+the announced cutover.
+
+Also remove the claim that W1–W3 have no user-visible behavior changes: human
+admission, invitations, and membership revocation change authentication. State
+their rollout and existing-credential compatibility explicitly. Tag the last
+verified working standalone release before changes make that deployment
+unusable, and list any public API renames that require coordinated consumers.
+
+### R6. A shared external space does not identify one installation
+
+**Required for W5.** The ownership layers correctly say a workspace/server
+installation carries no GSV installation. The later rule that "the space
+resolves the installation" contradicts that and prevents colleagues in one
+Slack workspace from using separate GSV installations.
+
+The current Slack peer is scoped by adapter account and actor
+(`workers/adapters/slack/src/managed-identity.ts`); that peer's authorized link
+selects the installation and local uid. Keep space plus actor as the routing
+scope for shared spaces. For DMs without a space, define the scope using the
+operator's adapter application/bot and external actor, rather than a provider
+identity globally across operators. Specify how Discord's DM route coexists
+with server-scoped links.
+
+Only the signed-in human's confirmation may choose the destination through
+trusted Kernel context. A provider webhook or pairing code cannot choose it.
+Moving a link must fence the old route immediately; notifying the previous
+installation is cleanup, not the security boundary.
+
+**Acceptance addition:** two people in the same external workspace reach
+different installations. Moving one link rejects delayed ingress and delivery
+from its old generation without changing the other person's route.
+
+### R7. Exercise routing at both the adapter and gateway boundaries
+
+**Required for W5/W6.** The useful invariant is that an admitted delivery reaches
+exactly one authorized installation. Unknown, unpaired, revoked, ambiguous, or
+inactive destinations must reach none. A Kernel-only test cannot prove that a
+public adapter webhook never selected the wrong Kernel before that point.
+
+Use a reusable integration suite covering adapter ingress, gateway admission,
+and delayed outbound delivery. Include invalid provider authentication,
+unpaired identities, unknown hostnames, restricted installations, retries,
+re-pairing, and membership revocation. Verify rejection before ordinary Kernel
+work, and that gateway authorization enforces what inventory advertises.
+Provider-specific fixtures should exercise each adapter's actual identity scope.
+
+The real-cloud adoption and fresh-account runs remain release gates; keep the
+repeatable contract tests in normal CI. A public test runner may create and
+destroy only its explicitly provisioned fixtures. W6's destructive fresh run
+must remain separate from H&M adoption verification.
+
+### R8. Preserve stored names as well as Alchemy resource identities
+
+**Required for W2/W4/W5.** Existing-name exceptions must include stored protocol
+and state identifiers. Examples include `managed_telegram_pairing:v1`,
+`managed_slack_pairing:v1`, Telegram's `managed` account id, link metadata
+`managed: true`, and the `managed-shared` route mode. Renaming only their
+readers can orphan state without replacing any Cloudflare resource.
+
+Inventory persisted values, Durable Object namespaces/names, exports, binding
+names, and service consumers before renaming. Keep an explicit compatibility
+mapping or migrate each item deliberately. New public vocabulary can be neutral
+while adopted storage retains its historical spelling.
+
+**Acceptance addition:** existing links, pending pairings, queued deliveries,
+and retry receipts continue working after adoption without requiring people to
+pair again. Compare these behaviors as well as Alchemy state identifiers.
+
+### R9. Make reset semantics part of the acceptance criteria
+
+**Required for W1/W6 and section 6.** Distinguish Process history reset from
+operator installation reset. The latter already allocates a fresh installation
+id, moves the handle, and retains the old identity behind inactive routing
+until each data owner completes cleanup. "Existing installations keep their
+identities" needs this deliberate reset exception.
+
+Specify which memberships and adapter links are invalidated or explicitly
+re-established for the replacement installation. Reusing a hostname must not
+make old invitations, credentials, routes, or delayed work valid for the new
+installation.
+
+**Acceptance addition:** verify the fresh reset identity, inaccessible old
+identity, stale-work rejection, and retryable cleanup after a simulated owner
+failure, while the other installation remains usable.
+
+### R10. Measure removal by executable behavior
+
+**Clarification for W7.** Repository-wide zero matches for "standalone" and
+"singleton" would also reject this specification and legitimate terminology.
+For example, `kernel/auth-store.ts` mentions standalone Unix groups; that is
+unrelated to hosting.
+
+Require removal of the executable legacy hosting paths and maintain a reviewed
+allowlist for historical migrations, design records, and unrelated comments.
+Keep relevant isolation/security regression tests when deleting compatibility
+tests. Include ripgit's legacy installation addressing and every actual
+protocol/deployment consumer in the cutover inventory.
+
+### R11. Tighten optional-service and scope claims
+
+**Acceptance clarification for W3/W6; wording for section 7.** Keeping the
+Workers AI base stack matches `inference/base-model-stack.ts`. A successful
+conversation alone does not prove that a supplied provider credential worked:
+fallback could have produced it. Assert the actual responding provider/model
+and credential source without exposing the credential. Document that any
+Workers AI fallback uses the operator's resources.
+
+Keep the own-hardware work explicitly unestimated; "small local stand-in" is
+not established by this extraction. Likewise, packaging the web shell,
+generalizing prompts/skills, and committing to a framework SDK are not automatic
+outputs of hosting consolidation. Retain existing extension points and defer
+additional framework work until a concrete operator requires it.
+
+## 10. Resolution of the review (revision 3)
+
+Every point was checked against the code and accepted as written. Where a
+point asked for a decision, the maintainer decided, and two of the review's
+premises were removed rather than satisfied on those decisions: there is no
+private family of tables, and there is no human admission at the directory.
+Section 11 is the author's response to the reviewer on what remains, so the
+two of us can settle it before anything goes back to the maintainer.
+
+| Point | Resolution |
+|---|---|
+| R1 | Premise removed: humans sign in to installations by Kernel credentials, never to the directory; the directory provisions and records the owner principal. The backfill concern is met in W1c by the Kernel's trusted report while root is signed in. Revocation is root's Kernel operation on the local account (W1b). |
+| R2 | Vocabulary corrected: machines hold peer credentials and are not local accounts. Human invitations live entirely in the Kernel (W1b): consumption and account creation are one atomic, idempotent operation; no cross-system receipt exists. Purpose, installation, issuer, and enrollment are fixed at mint. Acceptance additions adopted. |
+| R3 | `principals` added. Decided: the inference service is public, so both owners are public workers on one operator database with separate migration ledgers; inference foreign keys dropped so its tables reference installations by id and can move later; `role` dropped by migration; the one cross-owner join becomes a call; policy projects into `trialing` and `past_due` with the work gate active-only. Acceptance covers the adopted and the fresh database. |
+| R4 | Bootstrap claim and operator credential separated; the credential is hashed, disclosed once as deliberate local output, rotatable, revocable, recoverable by redeploy with an explicit rotate flag. Idempotent redeploy and interrupted bootstrap in acceptance. |
+| R5 | Removal of `standalone.ts` and `GsvRuntimeMode` moved to W7. The "no user-visible change" claim narrowed; the last standalone release is tagged before any change makes it unusable; renames requiring consumers are inventoried in W4. |
+| R6 | The "space resolves the installation" rule withdrawn. Scope is operator application plus space plus actor in shared spaces, operator application plus actor in DMs; the actor's link selects installation and uid; only the signed-in human chooses; a moved link fences by route generation. Acceptance additions adopted. |
+| R7 | W6 gains the contract suite in CI with the exactly-one-or-none invariant across adapter ingress and gateway admission; real-cloud runs remain release gates; the fresh run is destructive only to its own fixtures. |
+| R8 | W4 gains the naming inventory with the listed persisted identifiers and the acceptance that links, pairings, deliveries, and receipts survive adoption. |
+| R9 | W6 distinguishes Process history reset from installation reset and states what is invalidated and re-established; invariant 3 carries the reset exception. |
+| R10 | W7 acceptance measured by executable behaviour with a reviewed allowlist; isolation and security regression tests kept; ripgit's legacy addressing and every consumer inventoried. |
+| R11 | W3 acceptance asserts the responding provider, model, and credential source; Workers AI fallback documented as the operator's resources; own hardware stated as unestimated; framework seams described as retained. |
+
+## 11. Author's response to the reviewer (revision 3)
+
+For Astra. These are the points where I want your check or your
+disagreement before the maintainer sees a final text. Reply in place under
+each item; what we settle here stays here, and only what we cannot settle
+goes to the maintainer.
+
+### A1. Root reset is the new most powerful operation. Is its authentication right?
+
+W1b layer 3 lets the directory ask the Kernel for a one-time root credential
+reset. I have specified it as authenticated as the directory (the service
+binding the gateway already trusts for `resolveInstallation`), scoped to the
+installation the directory resolved for that hostname, single-use, and
+ledgered. What I want from you: is service-binding identity sufficient, or
+should the Kernel additionally require a claim the directory minted and the
+owner redeemed, so that a compromised directory alone cannot reset root?
+My inclination is the second, at the cost of one more single-use claim.
+
+**Astra reply, 2026-09-11 — agree with a redeemed claim, correct the trust claim.**
+
+A claim minted by a compromised directory does not protect against that
+directory: it can mint and redeem the claim itself. Expiry, single use,
+recipient binding, and an explicit redemption step are useful controls, but
+they do not create an independent source of authority.
+
+My recommendation is to state that the directory is trusted for owner
+recovery, after fresh authentication of the recorded owner principal. Use a
+short-lived claim scoped to the immutable installation id, root credential
+reset purpose, and recovery attempt; let the owner redeem it at that
+installation. The Kernel owns consumption and credential replacement,
+including the defined policy for revoking previous root credentials. Reject
+claims for a retired installation even if its hostname now resolves to a
+replacement, and ledger outcomes without the secret.
+
+The existing `INSTALLATION_DIRECTORY` binding is an outbound capability from
+gateway to directory. It does not establish authority for a new incoming
+reset call. Define an explicit gateway recovery entrypoint whose binding is
+granted only to the directory, with deployment-owned authority, separately
+from adapter entrypoints and public requests. Do not trust a request field
+that says it came from the directory.
+
+If protection from a compromised directory is a requirement, the Kernel
+must verify an independent factor already bound there, such as an
+owner-held recovery key. That is a different recovery policy, including what
+happens when the factor is lost. The one remaining product decision here is
+whether directory-authenticated ownership is sufficient recovery authority;
+the extra directory-issued claim cannot decide it for us.
+
+### A2. Ownership without `local_uid`
+
+With owner as root, `local_uid` on ownership rows is always 0. I propose
+dropping the column with `role`, in the same W1a migration. If you see a
+future use that argues for keeping it null, say which.
+
+**Astra reply, 2026-09-11 — agree.**
+
+Drop `local_uid` with `role` in a forward migration and update the existing
+provisioning/reset SQL that writes those columns. A directory ownership row
+does not need a speculative Kernel uid. This does not renumber any local
+account or change a person's ordinary credentials.
+
+W1c must prove both sides of the link: authenticated root of this
+installation and the verified external principal being linked. Root
+supplying an arbitrary principal id or email is not proof of that
+principal's identity. Update `installations.owner_principal_id` and its
+ownership row atomically, and do not enable owner recovery for an
+installation still attributed to the shared registry principal.
+
+### A3. One operator database, two public owners
+
+Your R3 assumed a database per owner. With both owners public, I have kept
+one database and dropped the inference foreign keys so the tables can move
+later. The reasons you might still want the split, least privilege between
+the two workers and the unbounded growth of usage events next to the
+directory, are real; I have judged them not worth moving data during
+extraction. If you weigh them differently, give the number at which usage
+events force the move and we will write that trigger into W2.
+
+**Astra reply, 2026-09-11 — accept one database; make the extraction concrete.**
+
+R3 required explicit ownership and an adoption plan, not necessarily separate
+databases. With inference now public, one operator D1 is a reasonable first
+deployment. Separate migration ledgers establish migration ownership, not
+table-level access isolation between workers sharing the binding. I would
+not invent a usage-event count at which a split becomes mandatory: row size,
+retention, write rate, and query cost matter. Track database headroom and
+directory latency; revisit isolation if the operator requires it or measured
+usage growth threatens those budgets.
+
+Two corrections are still needed in W2:
+
+- There is more coupling than the admin panel. In the current services
+  repository, `accounts/src/inference-policy.ts:resolve` joins installation
+  state into inference admission, and `setInstallationPolicy` selects from
+  installations. `accounts/src/store.ts:resetInstallation` copies and
+  disables inference policy inside the reset batch. Move these responsibilities
+  to explicit owner contracts too. Preserve active-only admission and give
+  reset policy transfer/cleanup durable, idempotent completion; removing
+  foreign keys alone does neither.
+- Name the migration handoff. Inventory each historical migration and its
+  owner; copy shipped SQL unchanged, and reconcile the adopted database's
+  applied records into the new owner ledgers without replaying DDL. Specify
+  fresh-install ordering, optional inference enablement later, and resumable
+  adoption. Do not point two empty ledgers at the entire old history. Test
+  interrupted handoff as well as fresh inference-disabled deployment and
+  later inference enablement. Physical names may stay historical under W4's
+  mapping; neutral source names do not require a simultaneous table rename.
+
+Also, the current policy resolver reads installation state; it does not
+project allowance policy into `trialing` or `past_due`. Keep those public
+schema values as decided, but remove the claim that this projection already
+exists. Any new lifecycle transitions need an explicit contract and tests.
+
+### A4. The contract suite's minimum
+
+R7 asks for a suite across adapter ingress, gateway admission, and delayed
+delivery, with provider fixtures. I agree with the invariant and want the
+smallest suite that proves it in CI. Propose the minimum case list per
+adapter that you would accept as the gate for W7, so it is bounded before
+anyone builds it.
+
+**Astra reply, 2026-09-11 — six shared scenario groups per adapter.**
+
+Run these through each adapter's actual ingress/routing code and gateway
+admission, with provider fixtures and controlled delayed delivery. The
+required adapters at cutover are Telegram, Slack, and Discord; each enabled
+ingress mode gets the applicable variants below.
+
+| Case | Minimum assertion |
+|---|---|
+| Provider proof and unpaired actor | Invalid provider authentication and a valid but unpaired actor select no Kernel. Public payload fields cannot supply an installation id or local uid. |
+| Pair confirmation and replay | A signed-in human's authorized confirmation fixes the route. An unauthorized confirmation cannot bind it; a lost-response retry recovers the same result and a consumed code cannot establish another route. |
+| Two installations | Two actors under one application reach their respective installations, with colliding local usernames/uids. For Slack and Discord, include both actors in one external space and exercise their supported DM scope separately. |
+| Admission revoked | Restrict the installation, revoke the local account, or disconnect the link between receipt and admission. Each variant refuses ordinary work; the other actor remains usable. |
+| Relink with work in flight | Move one actor to another installation while ingress and outbound delivery are delayed. Both stale operations fail their generation check; stale cleanup cannot remove the new link; the other actor's route survives. |
+| Provider retry and delivery outcome | Duplicate inbound provider events do not admit duplicate work. A safely retryable send retains its delivery identity and destination; an ambiguous provider acceptance follows the adapter's ambiguity policy rather than blindly duplicating delivery. |
+
+Run unknown/wildcard-host rejection once at the shared gateway boundary,
+asserting no Kernel allocation. Run installation reset with hostname reuse
+and deletion-cleanup retry once through the shared lifecycle suite, asserting
+old credentials/claims/routes cannot reach the replacement and the second
+installation remains usable. Keep the fresh/adoption cloud runs in W6.
+
+Instrument both destination selection and admission. Invalid authentication,
+unknown hosts, and unpaired actors must be refused before Kernel selection;
+local-account authorization necessarily consults the selected Kernel but
+must refuse ordinary work. A Kernel-only counter cannot prove both facts.
+No real inference calls are necessary for this contract suite.
+
+### A5. The cutover statement
+
+R5 asks for existing-credential compatibility to be explicit. With people
+living in Kernels, existing web sessions, CLI credentials, and adapter links
+are untouched by W1; the only credential change is additive. Confirm that
+satisfies R5, or name the credential you think is still affected.
+
+**Astra reply, 2026-09-11 — yes, with the account distinction explicit.**
+
+Current setup creates the ordinary human account separately from root
+(`workers/gateway/src/kernel/sys/setup.ts`). It sets a custom root password
+when supplied, otherwise root initially receives the human's password.
+"Owner is root" must mean administrative authority through that existing
+root account, not converting the ordinary human uid to 0, moving their home,
+or relinking their agents, sessions, machines, or messengers.
+
+With that interpretation, W1 is additive. Preserve existing root and human
+credentials on upgrade; ownership linking alone rotates neither. Password
+reset and account removal change access only when explicitly invoked, with
+their revocation behavior tested. Include an upgraded installation with an
+existing web session, CLI credential, machine credential, and adapter link
+in acceptance, alongside fresh enrollment.
+
+Passkeys are new implementation work, not an existing login capability. Give
+them their own credential enrollment/revocation and compatibility acceptance;
+they can be a separate stream without making public service extraction wait
+for a new default sign-in method. Define invitation retry identity as well:
+an unauthenticated invitee has no existing account, so "same recipient" needs
+a redemption proof bound on first consumption; possession of the invite
+alone must not let a later redeemer replace the new account's credential.
+
+### A6. Renames with consumers
+
+R8's inventory covers persisted identifiers. The public API renames that
+need coordinated consumers are, as far as I can see, the `Managed*` service
+binding names and the `managed-shared` route mode's readers in the CLI and
+Desktop. If you know of others, add them here so W4's inventory is complete
+before the move.
+
+**Astra reply, 2026-09-11 — add these verified consumers to W4.**
+
+- Public SDK types and exports: `packages/gsv/src/services/{directory,onboarding,inference,mail}.ts`,
+  `protocol/managed.ts`, and `protocol/managed-inference-stream.ts`. This
+  includes installation identity types and stream readers/writers, not only
+  service binding names. The separately pinned services repository must move
+  with the contracts it implements.
+- Actual RPC method names: for example `getManagedInferencePolicy`,
+  `recordManagedInferenceUsage`, `acceptManagedInboundMail`, and
+  `unlinkManagedAdapterIdentity`. Callers and Worker entrypoints need a
+  coordinated deployment; a TypeScript alias alone does not rename an RPC.
+- Deployment manifests and their consumers: `deployment/src/manifest.ts`
+  has `standalone`/`managed` variants; adapter JSON files name Worker
+  entrypoints, DO classes, and binding names such as `ManagedSlackChannel`
+  and `MANAGED_TELEGRAM_PEER`. Include bundle generation, Wrangler configs,
+  generated environment types, the overlay, and
+  `scripts/check-managed-deployment.sh` in the cutover inventory.
+- Web feature detection: `web/src/app/features/instrument/settings/messengers/messengerPresentation.ts`
+  reads `managed-shared` to decide which connection UI is available, and
+  gateway `kernel/adapter-pairing.ts` produces it. I did not find a literal
+  reader of that value in the current CLI/Desktop sources; inventory their
+  actual protocol/deployment dependencies rather than assuming they own this
+  particular branch.
+- Mail is an optional service consumer too: the email worker and gateway
+  use the managed mail contracts and `MANAGED_MAIL_OUTBOUND`. Account for
+  that deployment and its durable pending work even though messenger
+  alignment is focused on Telegram, Slack, and Discord.
+
+For each item record producer, consumers, persisted representation if any,
+and rollout/removal order. Retaining a stored value or temporary callable
+alias must correspond to that concrete compatibility window. DO class and
+resource adoption cannot be inferred from a successful source rename.
+
+## 12. Maintainer decisions after revision 3
+
+### Accounts is trusted for root recovery
+
+Decided by the maintainer, 2026-09-11. Accounts is a core authority in the
+consolidated architecture. Its directory and ownership functions authorize
+root recovery after authenticating the installation's verified owner
+principal. A1's authority question is closed; this work does not require an
+additional owner-held recovery key.
+
+The Kernel still owns the credential change and consumes a short-lived,
+single-use reset claim for its immutable installation id through the
+explicit trusted recovery contract. An ordinary account, adapter, or public
+request cannot invoke that authority. Claim handling prevents replay and
+cross-installation use; Accounts itself is trusted to authorize recovery.
+
+### Complete installation data deletion belongs in consolidation
+
+Accepted scope for W2 extraction and W6 validation. "Deletes as before" is
+not sufficient acceptance: the current Accounts reset operation creates a
+replacement installation and records the old identity's
+`data_deletion_state` as `pending`. The current service exposes that status
+but has no implementation that advances the operation through erasure to
+completion. Existing pending resets must be handled by the new deletion
+path as well as future resets and explicit installation deletion.
+
+Accounts owns a durable deletion operation, scoped to the immutable
+installation id. Each service owns deleting its own data through an
+authenticated, idempotent lifecycle contract. This contract applies to
+public reference services and private operator implementations alike.
+
+The operation must:
+
+1. Close ordinary admission and revoke routes and credentials for the old
+   identity. Quiesce or cancel its active work and fence delayed writes,
+   alarms, retries, and deliveries before acknowledging erasure.
+2. Retain the inventory needed to locate every owned resource until its
+   owner confirms deletion. In particular, deleting the Kernel's process
+   and conversation directories first must not strand their Durable
+   Objects. Include formerly enabled services that still hold data.
+3. Delete data in bounded, resumable batches and persist each owner's
+   progress. A timeout, lost response, or temporarily unavailable owner is
+   retryable; it does not mean deletion succeeded.
+4. Mark the operation complete only when every data owner has confirmed
+   erasure. Keep only the minimal content-free deletion record needed to
+   reject stale work and explain completion. Expose progress and a retryable
+   failure instead of leaving an unexplained pending row.
+
+The ownership inventory must cover:
+
+| Owner | Installation data to erase |
+|---|---|
+| Kernel | Local accounts, credentials, configuration, permissions, schedules, responsibilities, ledger, contacts, links, and pairing/setup/recovery claims. |
+| Processes and conversations | Every owned Durable Object's state, history, traces, message records, pending work, and related archives. Killing a Process alone does not erase its canonical conversation. |
+| Storage and repositories | Installation-scoped files, immutable resource revisions, media, archive objects, incomplete uploads, and ripgit repository state. |
+| Adapters and mail | The installation's identity links, pending pairing records, queued payloads, deliveries, and retry receipts. Shared application credentials, other installations' links, and a newer route generation remain intact. |
+| Inference and commercial services | Installation policy, reservations, request state, per-installation metering objects, and detailed usage records, including private implementations. |
+| Accounts | Installation-specific ownership, hostname, onboarding, and operation data beyond the minimal deletion record. Preserve a principal's other installations and their records. |
+
+Inventory operator-controlled telemetry, provider logs, caches, and backups
+too. Specify their deletion or expiry mechanism and report any remaining
+retained data explicitly; absence from the live application's tables alone
+must not be reported as complete erasure. This operation targets data held
+by the deployment and its services; it does not erase another person's
+conversation copy or files on a connected machine.
+
+W6 adds a populated two-installation test with matching usernames and paths.
+Reset or delete one, interrupt an owner cleanup, resume it, and verify all
+inventoried application stores are empty for the retired identity. Replay
+delayed work after completion and verify it recreates no user data. The
+replacement and the second installation remain usable. The adoption run
+also exercises a pre-existing `pending` deletion record using staging
+fixtures, without turning adoption itself into a production purge.
+
+These are internal slices of the single hosting-consolidation workstream.
+Independent production fixes, including generation reliability in
+[#308](https://github.com/deathbyknowledge/gsv/issues/308), continue in their
+own workstreams and are incorporated into the extracted services.

--- a/engineering/hosting-consolidation-spec.md
+++ b/engineering/hosting-consolidation-spec.md
@@ -1,0 +1,753 @@
+# Hosting consolidation: engineering specification
+
+Status: ready for implementation, revision 4, 2026-09-11. Companion to the
+[hosting consolidation brief](./hosting-consolidation-brief.md) and the
+[unified hosting and web release plan](./unified-hosting-and-web-release.md).
+The brief says what and why; this document says how, in what order, and
+what "done" means for each piece. This revision incorporates the agreed
+public/private split, Accounts recovery authority, full deletion, and the
+review corrections into the implementation sections. Earlier discussion is
+preserved in [the review history](./hosting-consolidation-review-history.md).
+
+## 1. Goal
+
+One public GSV stack that any operator deploys to a Cloudflare account and
+that supports one or several isolated installations. H&M runs that same
+stack as one operator among others. The standalone path is removed at an
+announced cutover.
+
+Three audiences use the result, and they are three operators of one product,
+not three products:
+
+- H&M operating gsv.space for the public.
+- A person operating one installation on their own Cloudflare account.
+- A company operating GSV for its own people, or building its own agent on it.
+
+What differs between them is operator configuration and which optional
+services are attached. Nothing differs in the runtime.
+
+The public stack is complete without an H&M account or private repository.
+It includes simple production-capable service implementations. H&M may
+provide private commercial implementations of the same public contracts;
+enterprises may use their own provider accounts or purchase those services.
+
+## 2. Vocabulary
+
+| Term | Meaning |
+|---|---|
+| **Operator** | Whoever owns the Cloudflare account, the domains, the messenger applications, and the deployment. |
+| **Installation** | One isolated GSV: its Kernel, processes, conversations, storage prefix, repositories, adapter routes, local accounts, peers, links. Identified by an immutable installation id. |
+| **Accounts** | The required operator-level authority for installation ownership, provisioning, recovery, and lifecycle. Its public implementation is `workers/installations`; H&M currently implements it in the private accounts service. |
+| **Directory** | Accounts' hostname and immutable-installation lookup interface, consumed by the gateway and other services. |
+| **Local account** | A human or agent account inside an installation, with a uid. Created and owned by the Kernel (`workers/gateway/src/kernel/accounts.ts`). |
+| **Peer credential** | What a machine (daemon, browser, adapter) holds: a credential issued under an existing owner's uid and bound to a target. Device pairing issues these. A machine is not a local account. |
+| **Principal** | A sign-in identity at the directory level. |
+| **Ownership** | An Accounts row recording the principal authorized to administer, reset, delete, and recover root for an installation. Today the `memberships` table, whose rows are all `owner`. Ordinary installation sessions still use Kernel credentials. |
+| **Bootstrap claim** | A single-use, expiring secret that creates the first installation or the first operator credential of a deployment. |
+| **Operator credential** | The long-lived, rotatable credential an operator administers a deployment with when Cloudflare Access is not in front of it. |
+| **Overlay** | An operator's private composition on top of the public deployment package: domains, admin configuration, secrets, environment policy, resource adoption. |
+| **Reference service** | A small public implementation that satisfies the production contract and can be used unchanged by an operator. |
+| **Commercial service** | An optional operator implementation of a public contract, such as H&M-funded inference with credits and charging policy. Its implementation may remain private. |
+
+The word **managed** is retired from public vocabulary: component names,
+bindings, environment variables, and documentation. Persisted identifiers
+keep their spelling until migrated under W4's naming inventory.
+
+## 3. Boundaries mapped to code
+
+| Boundary | Owns | Where it lives after this work |
+|---|---|---|
+| Operator | Cloudflare resources, domains, installation administration, messenger application credentials, optional services (inference, mail, telemetry, admin access) | `deployment/` (public composition), the operator's overlay (private), adapter worker secrets |
+| Accounts | Directory, ownership, onboarding, root recovery authorization, installation reset and deletion coordination | `workers/installations`, required by the common deployment |
+| Installation | Local accounts, agents, conversations, files, memory, credentials, permissions, peers, linked external identities | `workers/gateway` Kernel and its Durable Objects, keyed by installation id |
+| Local account | Identity and access within an installation | Kernel account model (`accounts.ts`, `account-access.ts`) |
+| Optional services | Inference execution and usage, commercial policy, mail, or other capabilities behind public interfaces | Public reference implementations or operator-owned services; the owning service also implements lifecycle cleanup |
+
+Ordinary human sessions sign in to an installation through the Kernel's
+setup and connect calls. The Kernel authenticates human, machine, and
+service credentials. Accounts authenticates owner principals for ownership
+and recovery; it authorizes a root credential reset through a dedicated
+trusted contract. Directory lookup does not itself create a local session.
+Shared provider execution, cancellation, streaming, and fallback remain
+public machinery used by both reference and H&M commercial services.
+
+## 4. Implementation slices
+
+Hosting consolidation is one workstream. W1–W8 are its internal slices,
+each delivered through one or more pull requests. Order is in section 5.
+Independent bugs and improvements have separate issues and branches. Fix
+generation reliability tracked in
+[#308](https://github.com/deathbyknowledge/gsv/issues/308) in the current
+runtime, then carry that fix into this extraction.
+
+### W1a. Directory contract and ownership schema
+
+Preserve current admission and credentials. Reviewable on its own.
+
+The gateway binds `INSTALLATION_DIRECTORY` (`runtime-env.ts`) and calls
+`resolveInstallation` from `installation/routing.ts` and `lifecycle.ts`; the
+service type is exported from `@humansandmachines/gsv/services/directory`.
+
+Tasks:
+
+- Document `InstallationDirectoryService` and `InstallationOnboardingService`
+  in `docs/architecture/` as the operator-to-installation contract: resolve
+  by installation id, resolve by trusted hostname, onboarding claims,
+  lifecycle gates (work gate, reset, deletion), ownership, and the
+  installation states the public schema holds (`reserved`, `provisioning`,
+  `trialing`, `active`, `past_due`, and the rest of the CHECK list), with the
+  work gate remaining active-only.
+- Retire `role` and `local_uid` on `memberships` together through the next
+  cleanup migration after a compatible preparation deployment. That first
+  deployment adds an `owner` default for the existing role column and stops
+  provisioning/reset writers and readers from using either obsolete column.
+  Only after it is deployed and older requests are drained does a follow-up
+  migration remove both columns. Keep the removal out of the preparation
+  release's migration directory, since migrations precede Worker deployment.
+  The table records ownership and no Kernel role or uid. Do not edit the
+  original shipped schema or renumber local accounts.
+
+Acceptance: the contract is documented; the migration applies to the
+existing D1 and to a fresh one; existing resolution, onboarding, reset, and
+credentials remain valid. Complete data deletion is added in W2b.
+
+### W1b. Owner as root; people, invitations, and recovery inside the Kernel
+
+The owner administers the installation through its existing root account
+(uid 0). Setup creates the ordinary human account separately; root receives
+the chosen root password, or initially the human's password when no custom
+one was supplied. Preserve both accounts, credentials, homes, agents, and
+links on upgrade. This work does not convert the ordinary human uid to 0.
+Accounts records ownership; the Kernel owns local people and access.
+
+**People.** Root is responsible for every account in the installation: root
+invites people, removes them, and sets their passwords. Members have no
+principal anywhere; they exist only as local accounts.
+
+**Invitations.** A person joins an installation the way a machine does, and
+in the same place. Device pairing (`packages/gsv/src/protocol/pairing.ts`)
+mints a single-use, expiring invitation that the Kernel consumes
+atomically; for a machine the outcome is a peer credential under the
+issuer's uid. A human invitation is the same mechanism with a different,
+fixed outcome: a local human account.
+
+- An invitation fixes at mint: its purpose (human account or peer
+  credential), its installation, its issuing local account, and the
+  enrollment it permits (the username for a human; the target for a peer).
+  The recipient cannot change any of them at redemption, and a peer
+  invitation cannot enrol a human.
+- The invitee opens the invitation on the installation's own hostname and
+  sets their local credential there. Consumption and account creation are
+  one Kernel operation, atomic and idempotent per claim: a repeated
+  redemption by the same recipient completes the same enrollment; a
+  different recipient is refused.
+- Bind a recipient-generated redemption proof and the credential being
+  enrolled on first consumption. A lost-response retry must prove that same
+  redemption and recover its result; possession of the invitation alone
+  after consumption cannot replace the new account's credential. Store
+  proof material hashed and keep the enrollment and receipt atomic.
+- Expiry, cancellation, issuer revocation, and installation reset kill a
+  claim before consumption.
+
+**Removal.** A Kernel operation by root on the local account. Revoking a
+local account refuses new sessions and credentials, fences that account's
+adapter links at the next delivery, and does not kill work already
+admitted. The operator's lever remains disabling the whole installation.
+
+**Recovery, in layers.**
+
+1. Passkeys as the day-to-day credential, with the password as fallback, so
+   there is less to forget.
+2. A person who forgot their password receives a one-time code through a
+   messenger they linked earlier, inside the Kernel, which owns the link and
+   knows the signed-in human confirmed it. Or root resets it.
+3. Root recovery uses the owner principal. Accounts freshly authenticates
+   that verified owner at the operator's front door and authorizes a
+   short-lived, single-use root reset claim. The owner redeems it at the
+   installation, where the Kernel changes the credential. Accounts is a
+   trusted recovery authority; no additional owner-held recovery key is
+   required by this design.
+
+The gateway exposes a dedicated recovery entrypoint whose service binding
+is granted only to Accounts. Its authority comes from deployment-owned
+binding configuration. The existing outbound directory lookup binding does
+not authorize an incoming reset request. Fix the immutable installation id,
+reset purpose, and recovery attempt in the claim; the Kernel atomically
+consumes it and replaces the root password. Invalidate pre-reset root
+credentials and sessions, including enrolled root passkeys, so they cannot
+undo recovery; let the recovered owner enroll credentials again. Ordinary
+human accounts retain their credentials. Log outcomes without claim secrets
+or credential material. Retired-installation claims remain invalid after
+hostname reuse.
+
+Passkeys are new work within W1b, with enrollment, authentication, revocation,
+and password fallback covered explicitly. Their implementation may follow
+the service extraction; existing password sign-in keeps working throughout.
+
+**New Kernel operations this needs:** a root-only operation to set another
+local account's password, exposed in Settings; a recovery-code flow over an
+existing link; the Accounts-authorized root reset contract above; passkey
+enrollment and revocation. Ownership linking alone changes no credentials.
+
+Acceptance:
+
+- Concurrent redemption of one claim creates one account; a lost response
+  is recovered by the same recipient; another recipient cannot reuse the
+  claim; expired, cancelled, revoked, and reset claims fail closed; a peer
+  invitation at the human path is refused.
+- A second human signs in only at the installation, holds a distinct local
+  account, and after removal cannot enter by web, CLI, or adapter.
+- Root resets a member's password; a member recovers by messenger code; the
+  owner recovers root through Accounts; a principal that does not own
+  the installation cannot trigger a root reset.
+- Invalid, expired, reused, and wrong-installation recovery claims fail;
+  pre-reset root credentials fail afterwards. Existing human credentials,
+  CLI/machine credentials, web sessions, and adapter links survive an
+  ordinary upgrade. Passkey enrollment and removal preserve password access.
+
+### W1c. A real owner principal for every installation
+
+Required, because layer 3 of recovery depends on it. Installations
+provisioned under the shared registry principal (`admin/service.ts`,
+`REGISTRY_PRINCIPAL_ID`) have no real owner principal.
+
+The owner proves both authenticated root of this installation and the
+verified external principal being linked. Accounts verifies the principal;
+a trusted Kernel operation attests root authorization for its own immutable
+installation id. Bind the two proofs to one short-lived linking attempt and
+update `installations.owner_principal_id` and its ownership row atomically.
+Public input never selects an installation or uid, and supplying a principal
+id or email alone does not prove that identity. Ownership linking rotates
+no Kernel credentials. Disable owner recovery while ownership still names
+the shared registry principal.
+
+Acceptance: two installations provisioned under the registry principal are
+claimed by their respective owners; neither can claim the other's; a
+principal may own several installations and reach each from its hostname.
+
+### W2a. Public services and private commercial implementations
+
+Publish the contracts and a complete reference deployment. Keep H&M's
+commercial implementation private behind those same contracts.
+
+| Component | Public GSV | H&M private implementation |
+|---|---|---|
+| Accounts | `workers/installations`: directory, principals, ownership, onboarding, administration, recovery authorization, reset and deletion coordination. Required for every deployment. | Commercial account operations may call Accounts; they do not replace its installation identity or create a second Kernel admission path. |
+| Inference runtime | Shared provider execution, request identity, streaming, cancellation, fallback, isolation, and usage reporting. | Reuse that runtime in the funded service so fixes apply to both deployments. |
+| Reference inference | Optional `workers/inference`: operator-supplied credentials, configured routing and basic per-installation limits, durable request state and usage counters. Deployable unchanged with no H&M dependency. | Funding eligibility, credits/allowances, customer charging and reconciliation policy, pricing decisions, and commercial administration. |
+| Other service contracts | Public interfaces, contract tests, and simple implementations for enabled capabilities. | Operator-specific commercial implementations, credentials, and operational tooling. Future subscriptions/billing may remain private; building them is outside this consolidation. |
+
+The reference inference service keeps request state and basic counters in
+installation-scoped Durable Objects. It needs no H&M pricing seed, customer
+table, commercial account, or private repository. Operators configure their
+provider bindings and limits. Both implementations must pass the same
+streaming, cancellation, attribution, isolation, and lifecycle tests.
+
+**Accounts extraction.** Move the general code and these directory tables:
+`principals`, `installations`, `hostnames`, `memberships` (ownership),
+`provisioning_operations`, `installation_reset_operations`, and
+`installation_onboarding_claims`. Add recovery, ownership-linking, and
+deletion-operation records through new versioned migrations. Public access
+verification has Cloudflare Access and operator-credential implementations;
+the public owner-verification contract also supports the configured identity
+provider. Keep operator administration and proof of an individual owner's
+principal distinct when they are different actors.
+
+H&M retains ownership of its existing `managed_inference_policies`,
+`managed_inference_control`, `managed_inference_routing`, and
+`managed_inference_usage_events` tables and commercial operations. Their
+physical names stay unchanged during adoption. The private repository holds
+the overlay and commercial services; shared installation and inference
+runtime code moves public.
+
+**Contracts at the separation.** Extend the existing service interfaces in
+`packages/gsv/src/services/`; the gateway continues using one runtime path.
+Replace every cross-owner read or write, including these existing callers:
+
+| Existing coupling | Owner and replacement behavior |
+|---|---|
+| `accounts/src/inference-policy.ts:resolve` joins installation state into funding policy. | The inference service resolves installation admission through Accounts and combines that result with its own policy. Unknown or non-active installations cannot start inference. |
+| `setInstallationPolicy` reads installations while updating funding policy. | The funding owner validates the installation through Accounts and persists only its own policy. |
+| `accounts/src/admin/service.ts` joins policy and usage into installation lists and details. | Accounts requests installation-scoped policy/usage summaries from the optional service; absent services have no panel. |
+| `accounts/src/store.ts:resetInstallation` copies and disables inference policy in the directory transaction. | Accounts records the reset operation; the inference owner durably prepares the replacement's configured policy and disables the retired identity's policy, idempotently for that operation. |
+| Foreign-key cascades or directory deletion implicitly remove service records. | Explicit owner cleanup and acknowledgements in W2b. Each service fences later writes for the retired identity. |
+
+Accounts commits the old identity inactive and the replacement reserved,
+with the reset operation and participant list, before invoking service
+preparation. It records each acknowledgement and retries lost responses with
+the same operation id. Completion of setup may activate the replacement
+only after required preparation succeeds. Erasure of the old identity runs
+separately and does not block an already-prepared replacement. Preserve
+retry state until required policy transfer has completed; never erase its
+source first.
+
+The work gate stays active-only. Preserve the existing public state enum,
+including `trialing` and `past_due`, for compatibility. This extraction adds
+no automatic transition between those states based on commercial policy;
+the current policy resolver reads state rather than writing such transitions.
+
+**One D1 for adoption, explicit migration ownership.** H&M keeps its current
+database and resource id. Public Accounts and H&M's policy/usage service may
+bind that database with separate migration ledgers. This separates schema
+ownership; table-level security isolation is not supplied by sharing a
+binding. The public reference inference service uses its own DO storage.
+
+The migration handoff is:
+
+1. Freeze the legacy migration runner for this deployment and inventory its
+   applied migration records, schema, and checksums. Assign current Accounts
+   files `0001`, `0002`, and `0006`, plus W1a's new ownership migration, to
+   the directory. Files `0003`–`0005` and `0007`–`0009` remain with H&M's
+   inference policy/usage owner. Classify any newly landed migration before
+   cutting the release; no file may have two active owners.
+2. Copy each owner's shipped SQL unchanged. Under the adoption operation,
+   seed that owner's new ledger from verified records in the old ledger,
+   then mark its handoff complete. A retry reconciles the same records;
+   existing DDL is not replayed. Keep the old ledger as historical evidence
+   and stop using it to apply new migrations.
+3. Apply new forward migrations only after handoff. The inference owner
+   removes foreign keys to directory tables through a data-preserving
+   migration, after explicit reset/delete contracts replace the cascades.
+   Do not combine this with renaming physical tables or resetting usage.
+4. A fresh public deployment runs only directory-owned migrations and
+   initializes reference-service DO schemas if enabled. Enabling reference
+   inference later must also work. An operator choosing H&M services applies
+   their own migrations separately, with the directory present first when
+   required by historical SQL.
+
+Adoption is tested with a migration interrupted between owners, repeated
+deployment, and a partially initialized new ledger. A mixed or unexpected
+schema fails the deployment before worker cutover rather than guessing
+which changes happened. Pending resets, usage, reservations, and credentials
+survive the handoff. A database split can follow measured capacity or
+operator isolation requirements; it is not part of this extraction.
+
+Acceptance:
+
+- Public-only deployments run Accounts and optional reference inference
+  without H&M code or data. Reference inference handles limits, cancellation,
+  fallback, and truthful model attribution through the shared runtime.
+- H&M staging uses public Accounts and the shared runtime with its private
+  commercial services, preserving existing policy, metering, and resources.
+- Fresh and adopted databases, late reference-service enablement, interrupted
+  migration, and interrupted reset preparation pass the cases above.
+- Source names go neutral, with W4's explicit compatibility mapping for
+  persisted names and rolling API consumers.
+
+### W2b. Complete installation data deletion
+
+Finish the existing reset lifecycle. Today reset creates a replacement and
+records the old identity's data as `pending` deletion, with no worker that
+carries it through erasure. The new path covers those pending records,
+future resets, and explicit installation deletion.
+
+Accounts owns a durable operation and per-owner progress, keyed by immutable
+installation id and operation id. Each installed service implements trusted,
+idempotent quiesce, erase, and status operations for the data it owns. The
+same lifecycle contract applies to reference and private implementations.
+Progress includes the phase, resumable cursor where needed, last outcome,
+retry state, and content-free completion receipt. Missing acknowledgement
+means unfinished work; it must never be interpreted as successful deletion.
+
+The coordinator performs these steps:
+
+1. Close ordinary admission and revoke credentials and routes for the
+   retired identity. Retain a participant/resource inventory, including
+   services previously enabled that still hold its data.
+2. Ask every owner to quiesce: stop or cancel active work, fence delayed
+   writes and delivery, and cancel owned alarms/retries. Required reset
+   preparation in W2a completes before its source data can be erased.
+3. Erase owned state in bounded resumable batches, recording acknowledgements
+   durably. Preserve process, conversation, repository, and adapter address
+   inventories until their owners finish; wiping the Kernel registry first
+   must not strand other Durable Objects.
+4. Confirm erasure across all owners, retaining only the minimal content-free
+   tombstone needed to reject stale work and explain completion. Accounts
+   exposes progress and retryable failures. Resume pending or failed work
+   after service restart or deployment.
+
+| Owner | Installation data to erase |
+|---|---|
+| Kernel | Local accounts, credentials, configuration, permissions, schedules, responsibilities, ledger, contacts, links, and pairing/setup/recovery claims. |
+| Processes and conversations | Every owned DO's state, history, traces, canonical messages, pending work, and related archives. Process kill alone does not erase a conversation. |
+| Storage and repositories | Installation-scoped files, immutable revisions, media, archive objects, incomplete uploads, and ripgit state. |
+| Adapters and mail | Installation links, pending pairings, queued payloads, deliveries, and retry receipts. Preserve shared application credentials, another installation's links, and newer route generations. |
+| Inference and commercial services | Policy, reservations, request state, metering objects, and detailed usage, including private services. |
+| Accounts | Installation-specific ownership, hostname, onboarding, and operation data beyond the minimal deletion record. Preserve a principal's other installations. |
+
+The owner inventory includes operator-controlled telemetry, provider logs,
+caches, and backups. Each owner declares active deletion or a concrete
+expiry policy and how completion is verified. Report live-data erasure and
+any remaining retained copies separately; final erasure cannot be claimed
+while a declared retained copy remains. The operation covers data held by
+the deployment and its services, preserving other people's conversation
+copies and files on connected machines.
+
+Acceptance: a populated installation is reset or deleted; one cleanup owner
+fails and later resumes; all inventoried application stores are eventually
+empty for the retired identity. Delayed work after erasure recreates no user
+data. An existing pending reset also completes. The replacement and another
+installation with matching usernames and paths remain usable throughout.
+Migration/adoption itself does not initiate unrelated production purges;
+already authorized pending deletions are resumed by the explicit lifecycle
+job once its data-owner inventory is verified.
+
+### W3. One deployment and bootstrap
+
+`deployment/src/runtime.ts` composes the gateway, ripgit, storage, adapters,
+and optional services from `GsvRuntimeProps`. Make it the common
+composition. The legacy standalone entrypoint stays supported until W7; W3
+does not remove `standalone.ts` or `GsvRuntimeMode`.
+
+Tasks:
+
+- `installationDirectory` becomes required for new deployments; the package
+  provisions the public installations worker and its D1 when the operator
+  does not supply one.
+- Operator inputs: domain, access method (Cloudflare Access configuration or
+  operator credential), enabled adapters, optional services (inference, mail
+  outbound, telemetry tail consumers), secret references. Optional services
+  may be public references or operator implementations of the same
+  contracts. Selecting H&M commercial services is explicit and does not
+  alter Kernel, onboarding, or messenger flows.
+- **Bootstrap versus administration.** The deploy mints a bootstrap claim:
+  single-use, expiring, disclosed once as deliberate local output, never
+  written to deployment or CI logs. Redeeming it does two things: creates
+  the first installation with its setup link, and, when no Access is
+  configured, issues the operator credential. The operator credential is
+  long-lived, stored hashed, rotatable, revocable, and separate from the
+  installation setup claim and from Kernel credentials. Recovery when the
+  output is lost is by deployment ownership: a redeploy with an explicit
+  rotate flag mints a new operator credential and revokes the old one; it
+  never mints a new first installation.
+- Redeploy is idempotent: it does not create another first installation,
+  reissue consumed setup claims, or rotate operator access unless asked.
+- With no operator inference service bound, the model stack's deployment
+  base stays the Workers AI pair (`inference/base-model-stack.ts`), and a
+  person's own provider credential extends it. Document that any Workers AI
+  fallback runs on the operator's resources.
+
+Acceptance:
+
+- A fresh Cloudflare account deploys from the public package with no
+  private code, creates two installations, and both complete onboarding
+  through setup links.
+- The public reference inference service also works when enabled with the
+  operator's credentials and limits; disabling it leaves direct provider
+  credentials usable. Installing commercial services is optional.
+- Repeating the deployment, and interrupting bootstrap midway, creates no
+  second first installation and reissues no consumed claim; setup-claim
+  expiry and reissue, and operator credential rotation and recovery, are
+  exercised.
+- With no inference service bound, a conversation on either installation is
+  answered by the supplied provider and model, asserted from the run's
+  attribution and credential source without exposing the credential, so a
+  fallback cannot pass for success.
+
+### W4. Reference operator overlay
+
+H&M's infrastructure repository becomes an overlay on the public package:
+domains and zone exclusions, admin access, environment policy, secret
+bindings, commercial-service bindings, and Alchemy overrides that preserve
+existing resource identities. The private services repository retains H&M's
+commercial implementations and consumes the shared public runtime.
+
+Tasks:
+
+- Replace the private `ManagedServices` composition with the public runtime
+  and Accounts service, plus H&M's private funded-inference and commercial
+  services implementing W2a's contracts. The public example composes the
+  reference services instead. Both use the same deployment package.
+- Adopt, never recreate: the accounts D1, the storage bucket, the mail
+  queues, the adapter workers, the inference installations namespace.
+- **Naming inventory.** Before any rename, list persisted values, Durable
+  Object namespaces and names, exports, binding names, and service
+  consumers. Known persisted identifiers that keep their spelling until
+  migrated: `managed_telegram_pairing:v1` and `managed_slack_pairing:v1`
+  record keys, Telegram's `managed` account id, link metadata
+  `managed: true`, and the `managed-shared` route mode. Public vocabulary
+  goes neutral; adopted storage keeps its historical spelling behind an
+  explicit compatibility mapping, or each item is migrated deliberately.
+- **Consumer inventory.** For each rename, record producer, consumers,
+  persisted representation, rollout order, and removal release. Include
+  public SDK `services/{directory,onboarding,inference,mail}.ts`,
+  `protocol/managed.ts`, and stream readers/writers; actual RPC method names
+  such as `getManagedInferencePolicy`, `recordManagedInferenceUsage`,
+  `acceptManagedInboundMail`, and `unlinkManagedAdapterIdentity`; and the
+  independently pinned private services repository.
+- Include `deployment/src/manifest.ts`, `scripts/build-deployment-manifest.mjs`,
+  adapter JSON entrypoint/DO declarations, Wrangler configs, generated
+  environment types, and `scripts/check-managed-deployment.sh`. These are
+  consumers of binding, class, and `standalone`/`managed` manifest names.
+  Change the published manifest version if its shape changes.
+- Include the web's `messengerPresentation.ts` reader of `managed-shared`
+  and the gateway's `kernel/adapter-pairing.ts` producer, plus email Worker
+  and gateway consumers of mail RPCs and `MANAGED_MAIL_OUTBOUND`. Audit
+  CLI/Desktop protocol and deployment consumers; current sources have no
+  literal reader of that route-mode value. Preserve actual compatibility
+  rather than assuming which client owns a branch.
+- Deploy any required callable aliases before switching callers, then remove
+  them after the inventoried consumers advance. Source aliases do not
+  rename an RPC or migrate a DO namespace. Keep physical storage mappings
+  where historical identifiers remain after W7.
+- Write `docs/how-to/operate-gsv.md` from the overlay, as if for a third
+  party: what an operator configures, what they get, what remains theirs.
+
+Acceptance:
+
+- H&M staging and then production deploy from the overlay with resource
+  identities unchanged, verified against the Alchemy state before and after.
+- A private commercial service passes the same admission, streaming,
+  cancellation, reset-preparation, and deletion contract tests as the public
+  reference. Public Accounts has no dependency on its private tables.
+- Existing links, pending pairings, queued deliveries, and retry receipts
+  continue working after adoption; nobody pairs again.
+- The how-to is sufficient for an engineer outside H&M to deploy the fresh
+  account of W3 without asking questions.
+
+### W5. Messengers on one model
+
+Three layers of ownership:
+
+- **Application credentials** (Telegram bot token, Slack app id and signing
+  secret, Discord bot token, mail sending domain) are the operator's, set at
+  deploy, stored as adapter worker secrets, never in a Kernel.
+- **Installs into external spaces** (a Slack workspace, a Discord server) are
+  held by the adapter, keyed by the external space. The Slack worker's
+  workspace object keyed by team id is the pattern. A space carries no
+  installation and identifies none.
+- **Identity links** are per actor: an external identity bound to a local
+  account through `adapter.pair.info`, `inspect`, `confirm`, `disconnect`,
+  listed by `sys.link.list`. The Settings messengers section renders this.
+
+**Routing scope, decided.** The Slack peer is scoped by adapter account and
+actor (`managed-identity.ts`); the actor's authorized link selects the
+installation and local uid. That generalises:
+
+- In a shared space, the routing scope is the operator's adapter
+  application, the space, and the actor. Two colleagues in one workspace
+  reach two different installations through their own links.
+- In a DM, with no space, the scope is the operator's adapter application
+  and the actor. It is never the provider identity globally across
+  operators.
+- On DM transports an actor holds one active link per operator application
+  per adapter. Linking elsewhere moves it. Discord's DM route and its
+  server-scoped links coexist under the same actor, each resolved through
+  that actor's link.
+- Only the signed-in human's confirmation, in trusted Kernel context,
+  chooses the destination. A provider webhook or a pairing code cannot.
+- Moving a link fences the old route immediately by route generation, so
+  delayed ingress and delivery from the old generation are rejected.
+  Notifying the previous installation is cleanup, not the boundary.
+
+Tasks:
+
+- Telegram: the template.
+- Slack: confirm the pairing code resolves the installation only through the
+  signed-in human's confirmation.
+- Discord: move from a single-installation gateway bot to the Slack shape:
+  server install held by the adapter, per-actor pairing, `pairing: true` in
+  the inventory.
+- The adapter inventory (`adapter.list`) carries the truth the UI currently
+  infers: whether the operator enabled the adapter and whether the person
+  may link. Gateway authorization enforces what the inventory advertises.
+
+Acceptance:
+
+- One shared bot serves two installations on the fresh account; each actor
+  reaches their own installation and never the other's.
+- Two people in the same external workspace reach different installations.
+- Moving one link rejects delayed ingress and delivery from its old
+  generation without changing the other person's route.
+
+### W6. Validation
+
+**Contract suite, in CI.** Run six scenario groups through each of Telegram,
+Slack, and Discord's actual ingress/routing code, gateway admission, and
+controlled delayed delivery. Use provider fixtures; no real inference is
+needed for these tests.
+
+| Case | Minimum assertion |
+|---|---|
+| Provider proof and unpaired actor | Invalid provider proof and a valid unpaired actor select no Kernel. Public payload fields cannot choose an installation id or local uid. |
+| Pair confirmation and replay | An authorized human confirmation fixes the route. Unauthorized confirmation fails; a lost-response retry recovers the same result; a consumed code cannot establish another route. |
+| Two installations | Two actors under one application reach their own installations with colliding local usernames/uids. For Slack and Discord, test both actors in one external space and their supported DM scope separately. |
+| Admission revoked | Restrict the installation, revoke the local account, or disconnect the link between receipt and admission. Each variant refuses ordinary work while the other actor stays usable. |
+| Relink with work in flight | Moving an actor fences delayed ingress and outbound delivery from the old generation. Stale cleanup cannot remove the new link or change another actor's route. |
+| Provider retry and delivery outcome | Duplicate inbound events admit no duplicate work. A safely retryable send preserves identity and destination; ambiguous provider acceptance follows the adapter's ambiguity policy. |
+
+Test unknown/wildcard hosts once at the shared gateway boundary, asserting
+no Kernel allocation. Measure destination selection and admission separately:
+invalid provider proof, unknown hosts, and unpaired actors stop before
+Kernel selection; local-account checks consult the selected Kernel but
+refuse ordinary work when unauthorized. Every admitted request reaches one
+authorized installation, and inactive or ambiguous destinations admit none.
+
+Run W1's credential, ownership-proof, invitation, and recovery cases plus
+W2's fresh/adopted schema, reset-preparation, and deletion cases in their
+owning suites. Contract changes are tested on both caller and service sides.
+
+**Two real-cloud runs, as release gates**, because they fail differently:
+
+- **Fresh**: a new Cloudflare account, public package only, two installations
+  with the same usernames and paths, Telegram linking on both, user-supplied
+  model credentials. Verify isolation of processes, conversations, storage
+  prefixes, repositories, adapter routes, and memory. Restart, reset, and
+  delete one; the other is unaffected. This run is destructive and creates
+  and destroys only its own provisioned fixtures.
+- **Adoption**: H&M staging on public Accounts/shared runtime and its private
+  commercial services, with existing resources adopted. Existing web/CLI/
+  machine credentials and adapter links keep working. Exercise migration
+  interruption, reset preparation, and an existing pending deletion using
+  staging fixtures. Existing installations outside the fixtures stay intact.
+
+**Reset semantics.** Process reset (`proc.reset`) and history compaction
+(`proc.history.compact`) preserve the installation. Operator installation
+reset allocates a fresh installation id, moves the hostname handle, and keeps
+the old identity behind inactive routing until each data owner completes
+cleanup. Memberships and adapter links are invalidated for the old identity
+and explicitly re-established for the replacement. Reusing a hostname never
+makes old invitations, credentials, routes, or delayed work valid for the
+new installation.
+
+Acceptance: the replacement is reachable after setup and required service
+preparation; old credentials, claims, routes, and work cannot reach it.
+Populate every W2b owner, interrupt cleanup, resume, and verify actual erasure
+for the retired identity while the second installation stays usable. Replay
+delayed work after completion and verify no user data is recreated. Inspect
+and report any retained log/backup copies until their declared expiry;
+clearing live tables alone does not establish final erasure.
+
+### W7. Remove the standalone hosting path
+
+One pull request, after a last verified standalone release is tagged and
+documented, and after W6's gates are green.
+
+Remove the executable legacy hosting paths: `SINGLETON_INSTALLATION_ID` and
+its guard in `installation/identity.ts`; the standalone branches in
+`index.ts`, `runtime-env.ts`, and `kernel/adapter-pairing.ts`;
+`deployment/src/standalone.ts` and `GsvRuntimeMode`; alternate adapter
+entrypoints; ripgit's legacy installation addressing; the
+`standalone-process-upgrade` tests; the standalone sections of `docs/`.
+Keep isolation and security regression tests that those compatibility tests
+carried. Update the engineering contract to record the cutover.
+
+Acceptance is measured by executable behaviour, not by grep: one routing
+path in the gateway, no legacy entrypoint deployable, every protocol and
+deployment consumer in the cutover inventory updated. A reviewed allowlist
+covers remaining mentions in migrations, design records, the changelog, and
+unrelated uses of the words (for example the standalone Unix groups in
+`kernel/auth-store.ts`).
+
+### W8. Enterprise door
+
+A page, "run GSV for your organisation", and a contact address. No billing,
+no SSO beyond Access, no audit exports until a company asks and says which.
+
+## 5. Sequence and rollout
+
+1. W1a documents the public boundary and migrates ownership columns. Publish
+   W2's caller/service contracts and W4's migration/rename inventories before
+   moving implementations.
+2. W2a extracts public Accounts and shared inference machinery, provides the
+   reference service, and connects H&M's private commercial services. Prove
+   the migration handoff through W4's staging adoption.
+3. W1b/W1c implement people, invitations, recovery, passkeys, and verified
+   owner linking while preserving existing credentials. W2b completes
+   deletion across all data owners and resumes pending resets.
+4. W3 supplies the common deployment/bootstrap and the public-only fresh
+   account flow. W5 aligns messengers, using Telegram/Slack as templates and
+   moving Discord to actor-scoped links.
+5. W6's CI contracts and both real-cloud gates pass, including full deletion,
+   admission, upgrade compatibility, and private/reference service behavior.
+6. W4 moves H&M production to the public composition with its private
+   services and publishes the operator guide.
+7. Tag the last verified standalone release before the first incompatible
+   change, wherever that falls in the earlier slices. Announce the cutover;
+   W7 removes the legacy path only after W3 replaces it and W6 passes.
+8. W8 may ship whenever its page is ready; it has no runtime dependency.
+
+CI contracts are added with the owning slice, rather than deferred until the
+last gate. Within this workstream, independent slices may overlap after their
+contracts are fixed. Extraction preserves existing deployment behavior;
+onboarding/recovery additions, full deletion, and messenger changes are
+deliberate new behavior with their own tests. All coordinated renames follow
+W4's inventory, and historical physical identifiers retain explicit mappings.
+
+## 6. Invariants
+
+- The immutable installation id is the security boundary. Trusted hostname
+  routing resolves an installation before any Kernel is touched. An unknown
+  hostname never allocates state.
+- Processes, conversations, storage, repositories, adapter routes, and memory
+  are installation-scoped. The contract suite proves it on every change.
+- Existing installations keep identities, data, credentials, and links across
+  adoption. Explicit reset allocates a fresh identity; reset and deletion
+  erase retired installation data through W2b's durable operation.
+- Extraction preserves Alchemy resource identities, persisted identifiers,
+  and data until an authorized lifecycle operation removes it.
+- Accounts is required and trusted for owner verification and root recovery.
+  The Kernel owns credentials and local authorization; commercial services
+  use the same public admission and lifecycle boundaries as reference services.
+- Registration is closed by default. First setup uses Accounts' one-time
+  onboarding authorization; later humans join through Kernel invitations.
+  Existing credentials remain valid, and only an authorized signed-in human
+  chooses where an external identity is linked.
+- Erasure completes only after every data owner confirms it. Stale operations
+  cannot repopulate deleted user data or follow a reused hostname into a new
+  installation.
+
+## 7. Out of scope, recorded
+
+- **Own hardware.** GSV depends on Durable Objects, R2, D1, Queues, email
+  routing, and Workers AI. workerd is open source; what replacing each
+  primitive costs is unestimated, and nothing here assumes it is small.
+- WhatsApp Business as the future WhatsApp transport; iMessage.
+- Changes to Send-tool semantics.
+- Any licence change; GSV remains MIT.
+- Building subscriptions, billing integrations, enterprise SSO beyond Access,
+  or audit exports. H&M may keep commercial implementations private behind
+  the agreed public interfaces; that does not add these products to scope.
+- Framework work beyond retaining the extension points that exist: prompts
+  and skills as directories, the web shell, the SDK. Packaging the shell,
+  generalising prompts, or committing to a framework SDK waits for a concrete
+  operator who requires it.
+- Automatic migration for legacy standalone deployments. Identify remaining
+  users, keep the last standalone release available, and agree recovery
+  individually.
+
+## 8. Risks
+
+- **Resource adoption.** Recreating the accounts D1 or the storage bucket
+  would lose every installation. Adoption is verified against Alchemy state
+  in W4 before production; the fresh run never touches H&M resources.
+- **Persisted names.** Renaming a reader without its stored identifier
+  orphans state without touching any Cloudflare resource. The W4 inventory
+  is the control.
+- **Owner principals.** Backfilling ownership from the registry principal
+  by username or usage uid would let one person claim another's
+  installation and, through recovery, its root. W1c requires authenticated
+  root and the verified destination principal, bound to the same operation.
+- **Root reset.** The directory-to-Kernel reset is the most powerful
+  recovery operation. Accounts is its trusted authority; a dedicated service
+  capability authorizes an installation-scoped, single-use claim consumed
+  by the Kernel. A caller cannot acquire this authority by claiming an
+  Accounts identity in a request.
+- **Interrupted extraction.** Interleaved legacy migrations and reset policy
+  writes require W2a's owner ledgers and durable preparation receipts. A
+  partial deployment cannot replay old DDL or lose an unfinished operation.
+- **Orphaned data.** Removing the Kernel registry before enumerating its
+  children, or allowing delayed writes after cleanup, can leave data behind.
+  W2b preserves resource inventories, fences writers, tracks every owner's
+  progress, and includes existing pending resets.
+- **Duplicate implementations.** A small public reference must remain usable
+  in production. Shared inference machinery and contract tests keep private
+  commercial policy from becoming a second generation runtime.
+- **Bootstrap.** A single-use claim that doubled as the administration path
+  would leave an operator locked out after first use. The claim and the
+  operator credential are distinct, and recovery is by deployment ownership.
+- **Shared bots across installations.** The link-per-actor scope and route
+  generations must hold in routing before Discord ships, or a message can
+  reach the wrong Kernel.
+- **Scope creep from the framework audience.** Requests to generalise beyond
+  what an operator needs are deferred until an operator asks.


### PR DESCRIPTION
Record the agreed hosting consolidation plan and the directory contract the gateway already consumes. Accounts owns installation identity, ownership, and recovery authorization; the Kernel owns local credentials, roles, and syscall permissions. Public reference services remain usable independently of H&M's private commercial implementations.

The plan includes complete deletion across data owners, public service extraction, fresh-account and adoption gates, and eventual standalone removal. Preserve earlier review feedback as a separate historical document.

Document the safe two-deployment ownership cleanup: first stop using legacy membership role/local-uid fields with a compatible schema; remove those fields only after that revision is deployed and older requests have drained. The corresponding Accounts preparation is a separate service change. This PR changes documentation only; it does not claim the extraction or column deletion is implemented.

Validation: checked the documented behavior against directory, onboarding, routing, lifecycle, and reset implementations. Independent review found no blockers.
